### PR TITLE
fix(crawler): make forked child agents work end-to-end

### DIFF
--- a/crates/acrawl-cli/src/app.rs
+++ b/crates/acrawl-cli/src/app.rs
@@ -14,7 +14,7 @@ use api::{
     ToolResultContentBlock,
 };
 use commands::{slash_command_specs, SlashCommand};
-use crawler::{mvp_tool_specs, CrawlerAgent, ToolRegistry};
+use crawler::{mvp_tool_specs, CrawlerAgent, SharedApiClient, ToolRegistry};
 use runtime::{
     load_settings, load_system_prompt, settings_get_max_steps, ApiClient, ApiRequest,
     AssistantEvent, CompactionConfig, ConfigLoader, ConversationMessage, ConversationRuntime,
@@ -985,6 +985,13 @@ fn build_runtime(
 ) -> Result<ConversationRuntime<LlmRuntimeClient, CliToolExecutor>, Box<dyn std::error::Error>> {
     session.model = Some(model.clone());
     let max_steps = settings_get_max_steps(&load_settings()) as usize;
+    let fork_client = SharedApiClient::new(LlmRuntimeClient::new(
+        model.clone(),
+        enable_tools,
+        false,
+        allowed_tools.clone(),
+        None,
+    ));
     Ok(ConversationRuntime::new_with_features(
         session,
         LlmRuntimeClient::new(
@@ -994,7 +1001,7 @@ fn build_runtime(
             allowed_tools.clone(),
             ui_tx.clone(),
         ),
-        CliToolExecutor::new(allowed_tools, emit_output, ui_tx),
+        CliToolExecutor::new(allowed_tools, emit_output, ui_tx, fork_client),
         system_prompt,
         &build_runtime_feature_config()?,
     )
@@ -1330,12 +1337,14 @@ impl CliToolExecutor {
         allowed_tools: Option<AllowedToolSet>,
         emit_output: bool,
         ui_tx: Option<mpsc::Sender<ReplTuiEvent>>,
+        fork_client: SharedApiClient,
     ) -> Self {
         Self {
             renderer: TerminalRenderer::new(),
             emit_output,
             allowed_tools,
-            agent: CrawlerAgent::new_lazy(ToolRegistry::new_with_core_tools()),
+            agent: CrawlerAgent::new_lazy(ToolRegistry::new_with_core_tools())
+                .with_api_client(fork_client),
             ui_tx,
         }
     }

--- a/crates/crawler/src/agent.rs
+++ b/crates/crawler/src/agent.rs
@@ -321,7 +321,7 @@ impl CrawlerAgent {
         let child_sub_goal = sub_goal.clone();
         let join_handle: tokio::task::JoinHandle<Option<Vec<Value>>> =
             tokio::task::spawn_blocking(move || {
-                let runtime = tokio::runtime::Builder::new_current_thread()
+                let runtime = tokio::runtime::Builder::new_multi_thread()
                     .enable_all()
                     .build()
                     .expect("child runtime should initialize");

--- a/crates/crawler/src/agent.rs
+++ b/crates/crawler/src/agent.rs
@@ -166,6 +166,12 @@ impl CrawlerAgent {
         self
     }
 
+    #[must_use]
+    pub fn with_api_client(mut self, client: SharedApiClient) -> Self {
+        self.api_client_arc = Some(client);
+        self
+    }
+
     /// Drop the current browser context so the next tool call will spawn a
     /// fresh Playwright bridge.  This is used by `/headed` and `/headless` to
     /// make the mode switch take effect immediately.
@@ -248,6 +254,18 @@ impl CrawlerAgent {
             .get("url")
             .and_then(Value::as_str)
             .map(ToOwned::to_owned);
+
+        {
+            let mut mgr = self.agent_manager.lock().await;
+            if !mgr.contains(&self.agent_id) {
+                let settings = runtime::load_settings();
+                mgr.max_concurrent_per_parent =
+                    runtime::settings_get_max_concurrent_per_parent(&settings) as usize;
+                mgr.max_depth = runtime::settings_get_max_fork_depth(&settings) as usize;
+                mgr.max_total = runtime::settings_get_max_total_agents(&settings) as usize;
+                mgr.register_root(self.agent_id.clone());
+            }
+        }
 
         let can_fork = {
             let manager = self.agent_manager.lock().await;

--- a/crates/crawler/src/browser.rs
+++ b/crates/crawler/src/browser.rs
@@ -25,7 +25,10 @@ impl BrowserContext {
     }
 
     pub async fn acquire_bridge(&self) -> MutexGuard<'_, PlaywrightBridge> {
-        self.bridge.lock().await
+        let page_idx = i64::try_from(self.page_index).unwrap_or(0);
+        let mut guard = self.bridge.lock().await;
+        let _ = guard.switch_tab(page_idx).await;
+        guard
     }
 
     #[must_use]

--- a/crates/crawler/src/playwright.rs
+++ b/crates/crawler/src/playwright.rs
@@ -42,9 +42,9 @@ function parseHeadless() {
 
 async function bootstrap() {
   const browser = await playwright.chromium.launch({ headless: parseHeadless() });
-  let page = await browser.newPage();
+  const context = await browser.newContext();
+  let page = await context.newPage();
   const pages = [page];
-  const context = browser.contexts()[0];
   context.on('page', (p) => {
     if (!pages.includes(p)) {
       pages.push(p);


### PR DESCRIPTION
﻿## Summary

- Register agent root in `AgentManager` and inject `SharedApiClient` lazily so the CLI fork path has a working LLM client and respects fork limits
- Use explicit `browser.newContext()` in the Playwright bridge bootstrap instead of relying on the implicit default context, fixing `context.newPage()` failures
- Switch to the correct `page_index` on every `acquire_bridge` call so forked agents operate on their own browser tab instead of stomping the parent's
- Use `new_multi_thread` runtime for child agent tasks — `block_in_place` in `LlmRuntimeClient::stream` requires it; `new_current_thread` panicked and corrupted the TUI

## Changed files

- **`crates/acrawl-cli/src/app.rs`** — build a `SharedApiClient` in `build_runtime` and pass it through `CliToolExecutor` into `CrawlerAgent`
- **`crates/crawler/src/agent.rs`** — add `with_api_client` builder, register root agent on first tool execution, switch child runtime to multi-thread
- **`crates/crawler/src/browser.rs`** — call `switch_tab(page_index)` inside `acquire_bridge`
- **`crates/crawler/src/playwright.rs`** — replace implicit default context with explicit `browser.newContext()`
