### PR TITLE
feat: human-in-the-loop browser intervention (wait_for_human)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project
 
-`acrawl` is a native-Rust LLM-driven web crawler. A user provides a natural-language goal; the agent plans, navigates, and extracts structured data via a 19-tool toolbox (16 browser + 3 agent-control). It ships as a single binary with an interactive Ratatui REPL and non-interactive modes.
+`acrawl` is a native-Rust LLM-driven web crawler. A user provides a natural-language goal; the agent plans, navigates, and extracts structured data via a 19-tool toolbox (16 browser + 2 agent-control + 1 human intervention). It ships as a single binary with an interactive Ratatui REPL and non-interactive modes.
 
 ## Commands
 
@@ -29,7 +29,7 @@ Five crates under `crates/`, compiled with `resolver = "2"`:
 - **api** — HTTP + SSE clients for Anthropic (`client.rs`), OpenAI-compatible (`openai.rs`), and Codex OAuth (`codex.rs`). `sse.rs` is the shared streaming frame parser; `types.rs` holds the Anthropic message schema. `provider/registry.rs` and `provider/factory.rs` handle provider discovery and client construction.
 - **runtime** — `ConversationRuntime` (the core turn loop), `RuntimeObserver` trait for event callbacks, `Session` persistence, system-prompt builder, permission model (`PermissionMode` = ReadOnly / WorkspaceWrite / DangerFullAccess), compaction, usage/pricing, OAuth PKCE, `observer.rs` for the observer trait, `config/` subdirectory (loader, MCP config, features), and a full MCP client stack in `mcp/` (`client.rs`, `types.rs`, `server_manager.rs`, `process.rs`, `naming.rs`).
 - **commands** — slash-command registry (`/help`, `/status`, `/model`, `/compact`, `/clear`, `/cost`, `/session`, `/export`, `/resume`, `/config`, `/memory`, `/init`, `/diff`, `/version`). Knows which commands are safe to replay in `--resume`.
-- **crawler** — the browser tools (16 navigation/extraction + 3 agent-control = 19 total), agent loop (`agent.rs`), `FetchRouter` that escalates HTTP→browser, and `PlaywrightBridge` — a child `node` process running an inline JS script (`PLAYWRIGHT_BRIDGE_NODE_SCRIPT` in `playwright.rs`) that speaks newline-delimited JSON over stdio. 3 agent-control tools (`fork`, `wait_for_subagents`, `done`) live alongside the browser tools, bringing the total to 19. `agent/` subdirectory contains fork/lifecycle logic; `tool_effect.rs` defines the `ToolEffect` enum (Reply/Spawn/Wait/Finish) that tools return.
+- **crawler** — the browser tools (16 navigation/extraction + 2 agent-control + 1 human intervention = 19 total), agent loop (`agent.rs`), `FetchRouter` that escalates HTTP→browser, and `PlaywrightBridge` — a child `node` process running an inline JS script (`PLAYWRIGHT_BRIDGE_NODE_SCRIPT` in `playwright.rs`) that speaks newline-delimited JSON over stdio. 2 agent-control tools (`fork`, `wait_for_subagents`) and 1 human intervention tool (`wait_for_human`) live alongside the browser tools, bringing the total to 19. `agent/` subdirectory contains fork/lifecycle logic; `tool_effect.rs` defines the `ToolEffect` enum (Reply/Spawn/Wait/Finish) that tools return.
 
 ## Architecture: how a turn actually flows
 

--- a/crates/acrawl-cli/src/app/classic_repl.rs
+++ b/crates/acrawl-cli/src/app/classic_repl.rs
@@ -20,7 +20,7 @@ impl ClassicReplObserver {
 
 impl RuntimeObserver for ClassicReplObserver {
     fn on_pause_started(&mut self, reason: &str) {
-        eprintln!("\n⏸ PAUSED: {reason}");
+        eprintln!("\nPAUSED: {reason}");
         eprintln!("Solve the problem in the browser, then press Enter to resume...");
         let _ = std::io::stderr().flush();
 
@@ -31,7 +31,7 @@ impl RuntimeObserver for ClassicReplObserver {
     }
 
     fn on_pause_ended(&mut self) {
-        eprintln!("✓ Resumed");
+        eprintln!("Resumed");
     }
 }
 

--- a/crates/acrawl-cli/src/app/classic_repl.rs
+++ b/crates/acrawl-cli/src/app/classic_repl.rs
@@ -1,14 +1,48 @@
 use crate::error::CliError;
 use crate::input;
 use commands::SlashCommand;
+use runtime::RuntimeObserver;
+use std::io::Write;
+use std::sync::Arc;
 
 use super::{AllowedToolSet, LiveCli};
+
+/// Observer for classic REPL that handles pause/resume via stdin.
+struct ClassicReplObserver {
+    control_state: Arc<runtime::ControlState>,
+}
+
+impl ClassicReplObserver {
+    fn new(control_state: Arc<runtime::ControlState>) -> Self {
+        Self { control_state }
+    }
+}
+
+impl RuntimeObserver for ClassicReplObserver {
+    fn on_pause_started(&mut self, reason: &str) {
+        eprintln!("\n⏸ PAUSED: {reason}");
+        eprintln!("Solve the problem in the browser, then press Enter to resume...");
+        let _ = std::io::stderr().flush();
+
+        let mut input = String::new();
+        let _ = std::io::stdin().read_line(&mut input);
+
+        self.control_state.resume();
+    }
+
+    fn on_pause_ended(&mut self) {
+        eprintln!("✓ Resumed");
+    }
+}
 
 pub(crate) fn run_repl_classic(
     model: String,
     allowed_tools: Option<AllowedToolSet>,
 ) -> Result<(), CliError> {
     let mut cli = LiveCli::new(model, true, allowed_tools)?;
+    let control_state = cli.cancel_flag();
+    cli.set_observer(Box::new(ClassicReplObserver::new(control_state)));
+
     let mut editor = input::LineEditor::new("> ", super::slash_command_completion_candidates());
     println!("{}", cli.startup_banner());
 

--- a/crates/acrawl-cli/src/app/classic_repl.rs
+++ b/crates/acrawl-cli/src/app/classic_repl.rs
@@ -23,7 +23,13 @@ fn spawn_pause_monitor(
             std::thread::sleep(Duration::from_millis(100));
 
             if control_state.is_paused() {
-                eprintln!("\n-- PAUSED: Human intervention requested --");
+                let reason = control_state.pause_reason();
+                let display_reason = if reason.is_empty() {
+                    "Human intervention requested".to_string()
+                } else {
+                    reason
+                };
+                eprintln!("\n-- PAUSED: {display_reason} --");
                 eprintln!("Solve the problem in the browser, then press Enter to resume...");
                 let _ = std::io::stderr().flush();
 

--- a/crates/acrawl-cli/src/app/classic_repl.rs
+++ b/crates/acrawl-cli/src/app/classic_repl.rs
@@ -1,38 +1,42 @@
 use crate::error::CliError;
 use crate::input;
 use commands::SlashCommand;
-use runtime::RuntimeObserver;
 use std::io::Write;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use super::{AllowedToolSet, LiveCli};
 
-/// Observer for classic REPL that handles pause/resume via stdin.
-struct ClassicReplObserver {
+/// Spawn a background thread that polls `ControlState` for pause events.
+///
+/// This mirrors the TUI render loop's polling approach: the TUI detects pause
+/// by checking `cancel_flag.is_paused()` each frame. In classic REPL, since the
+/// main thread is blocked on the runtime future, this thread handles the
+/// stdin-based resume interaction.
+fn spawn_pause_monitor(
     control_state: Arc<runtime::ControlState>,
-}
+    stop: Arc<AtomicBool>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        while !stop.load(Ordering::Relaxed) {
+            std::thread::sleep(Duration::from_millis(100));
 
-impl ClassicReplObserver {
-    fn new(control_state: Arc<runtime::ControlState>) -> Self {
-        Self { control_state }
-    }
-}
+            if control_state.is_paused() {
+                eprintln!("\n-- PAUSED: Human intervention requested --");
+                eprintln!("Solve the problem in the browser, then press Enter to resume...");
+                let _ = std::io::stderr().flush();
 
-impl RuntimeObserver for ClassicReplObserver {
-    fn on_pause_started(&mut self, reason: &str) {
-        eprintln!("\nPAUSED: {reason}");
-        eprintln!("Solve the problem in the browser, then press Enter to resume...");
-        let _ = std::io::stderr().flush();
+                let mut buf = String::new();
+                let _ = std::io::stdin().read_line(&mut buf);
 
-        let mut input = String::new();
-        let _ = std::io::stdin().read_line(&mut input);
-
-        self.control_state.resume();
-    }
-
-    fn on_pause_ended(&mut self) {
-        eprintln!("Resumed");
-    }
+                if control_state.is_paused() {
+                    control_state.resume();
+                }
+                eprintln!("Resuming...");
+            }
+        }
+    })
 }
 
 pub(crate) fn run_repl_classic(
@@ -41,7 +45,9 @@ pub(crate) fn run_repl_classic(
 ) -> Result<(), CliError> {
     let mut cli = LiveCli::new(model, true, allowed_tools)?;
     let control_state = cli.cancel_flag();
-    cli.set_observer(Box::new(ClassicReplObserver::new(control_state)));
+
+    let monitor_stop = Arc::new(AtomicBool::new(false));
+    let monitor_handle = spawn_pause_monitor(control_state, Arc::clone(&monitor_stop));
 
     let mut editor = input::LineEditor::new("> ", super::slash_command_completion_candidates());
     println!("{}", cli.startup_banner());
@@ -73,6 +79,9 @@ pub(crate) fn run_repl_classic(
             }
         }
     }
+
+    monitor_stop.store(true, Ordering::Relaxed);
+    let _ = monitor_handle.join();
 
     Ok(())
 }

--- a/crates/acrawl-cli/src/app/mod.rs
+++ b/crates/acrawl-cli/src/app/mod.rs
@@ -282,6 +282,7 @@ impl LiveCli {
         self.runtime.cancel_flag()
     }
 
+    #[allow(dead_code)]
     pub(crate) fn control_state(&self) -> std::sync::Arc<ControlState> {
         self.runtime.cancel_flag()
     }

--- a/crates/acrawl-cli/src/app/mod.rs
+++ b/crates/acrawl-cli/src/app/mod.rs
@@ -37,7 +37,7 @@ use self::api_client::LlmRuntimeClient;
 #[cfg(test)]
 use self::api_client::{convert_messages, push_output_block, response_to_events};
 use self::model_support::{model_reasoning_efforts, model_supports_reasoning};
-use self::runtime_builder::{build_runtime, build_system_prompt};
+use self::runtime_builder::{build_runtime, build_runtime_with_options, build_system_prompt};
 use self::tool_executor::CliToolExecutor;
 
 pub(crate) use crate::auth::{
@@ -148,17 +148,36 @@ impl LiveCli {
         enable_tools: bool,
         allowed_tools: Option<AllowedToolSet>,
     ) -> Result<Self, CliError> {
+        Self::new_with_interactivity(model, enable_tools, allowed_tools, true)
+    }
+
+    pub(crate) fn new_non_interactive(
+        model: String,
+        enable_tools: bool,
+        allowed_tools: Option<AllowedToolSet>,
+    ) -> Result<Self, CliError> {
+        Self::new_with_interactivity(model, enable_tools, allowed_tools, false)
+    }
+
+    fn new_with_interactivity(
+        model: String,
+        enable_tools: bool,
+        allowed_tools: Option<AllowedToolSet>,
+        is_interactive: bool,
+    ) -> Result<Self, CliError> {
         let settings = runtime::load_settings();
         let system_prompt = build_system_prompt()?;
         let session = create_managed_session_handle()?;
         let output_mode = OutputMode::Stdout;
-        let runtime = build_runtime(
+        let runtime = build_runtime_with_options(
             Session::new(),
             model.clone(),
             system_prompt.clone(),
             enable_tools,
             allowed_tools.clone(),
             output_mode.observer(),
+            is_interactive,
+            None,
         )?;
         let initial_effort = if model_supports_reasoning(&model) {
             let saved = settings
@@ -198,13 +217,15 @@ impl LiveCli {
         let system_prompt = build_system_prompt()?;
         let session = create_managed_session_handle()?;
         let output_mode = OutputMode::Channel(event_tx);
-        let runtime = build_runtime(
+        let runtime = build_runtime_with_options(
             Session::new(),
             model.clone(),
             system_prompt.clone(),
             enable_tools,
             allowed_tools.clone(),
             output_mode.observer(),
+            true,
+            None,
         )?;
         let initial_effort = if model_supports_reasoning(&model) {
             let saved = settings

--- a/crates/acrawl-cli/src/app/mod.rs
+++ b/crates/acrawl-cli/src/app/mod.rs
@@ -27,7 +27,9 @@ use crate::session_mgr::{
 use crate::tui::ReplTuiEvent;
 use commands::{slash_command_specs, SlashCommand};
 use crawler::mvp_tool_specs;
-use runtime::{CompactionConfig, ControlState, ConversationRuntime, RuntimeError, Session, TokenUsage};
+use runtime::{
+    CompactionConfig, ControlState, ConversationRuntime, RuntimeError, Session, TokenUsage,
+};
 use serde_json::json;
 
 #[cfg(test)]
@@ -300,11 +302,6 @@ impl LiveCli {
     }
 
     pub(crate) fn cancel_flag(&self) -> std::sync::Arc<ControlState> {
-        self.runtime.cancel_flag()
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn control_state(&self) -> std::sync::Arc<ControlState> {
         self.runtime.cancel_flag()
     }
 

--- a/crates/acrawl-cli/src/app/mod.rs
+++ b/crates/acrawl-cli/src/app/mod.rs
@@ -27,7 +27,7 @@ use crate::session_mgr::{
 use crate::tui::ReplTuiEvent;
 use commands::{slash_command_specs, SlashCommand};
 use crawler::mvp_tool_specs;
-use runtime::{CompactionConfig, ConversationRuntime, RuntimeError, Session, TokenUsage};
+use runtime::{CompactionConfig, ControlState, ConversationRuntime, RuntimeError, Session, TokenUsage};
 use serde_json::json;
 
 #[cfg(test)]
@@ -278,7 +278,7 @@ impl LiveCli {
         self.output_mode.sender()
     }
 
-    pub(crate) fn cancel_flag(&self) -> std::sync::Arc<std::sync::atomic::AtomicBool> {
+    pub(crate) fn cancel_flag(&self) -> std::sync::Arc<ControlState> {
         self.runtime.cancel_flag()
     }
 

--- a/crates/acrawl-cli/src/app/mod.rs
+++ b/crates/acrawl-cli/src/app/mod.rs
@@ -282,6 +282,14 @@ impl LiveCli {
         self.runtime.cancel_flag()
     }
 
+    pub(crate) fn control_state(&self) -> std::sync::Arc<ControlState> {
+        self.runtime.cancel_flag()
+    }
+
+    pub(crate) fn set_observer(&mut self, observer: Box<dyn runtime::RuntimeObserver + Send>) {
+        self.runtime.set_observer(observer);
+    }
+
     pub(crate) fn run_turn_tui(&mut self, input: &str) -> Result<(), CliError> {
         if let Some(tx) = self.event_sender() {
             let _ = tx.send(ReplTuiEvent::TurnStarting);

--- a/crates/acrawl-cli/src/app/mod.rs
+++ b/crates/acrawl-cli/src/app/mod.rs
@@ -305,10 +305,6 @@ impl LiveCli {
         self.runtime.cancel_flag()
     }
 
-    pub(crate) fn set_observer(&mut self, observer: Box<dyn runtime::RuntimeObserver + Send>) {
-        self.runtime.set_observer(observer);
-    }
-
     pub(crate) fn run_turn_tui(&mut self, input: &str) -> Result<(), CliError> {
         if let Some(tx) = self.event_sender() {
             let _ = tx.send(ReplTuiEvent::TurnStarting);

--- a/crates/acrawl-cli/src/app/runtime_builder.rs
+++ b/crates/acrawl-cli/src/app/runtime_builder.rs
@@ -1,10 +1,11 @@
 use std::env;
+use std::sync::Arc;
 
 use super::{AllowedToolSet, CliError, CliToolExecutor, LlmRuntimeClient, DEFAULT_DATE};
 use crawler::{mvp_tool_specs, SharedApiClient};
 use runtime::{
-    load_settings, load_system_prompt, settings_get_max_steps, ConfigLoader, ConversationRuntime,
-    RuntimeObserver, Session,
+    load_settings, load_system_prompt, settings_get_max_steps, ConfigLoader, ControlState,
+    ConversationRuntime, RuntimeObserver, Session,
 };
 
 pub(super) fn build_system_prompt() -> Result<Vec<String>, CliError> {
@@ -27,15 +28,39 @@ pub(super) fn build_runtime_feature_config() -> Result<runtime::RuntimeFeatureCo
 }
 
 pub(super) fn build_runtime(
-    mut session: Session,
+    session: Session,
     model: String,
     system_prompt: Vec<String>,
     enable_tools: bool,
     allowed_tools: Option<AllowedToolSet>,
     observer: Box<dyn RuntimeObserver + Send>,
 ) -> Result<ConversationRuntime<LlmRuntimeClient, CliToolExecutor>, CliError> {
+    build_runtime_with_options(
+        session,
+        model,
+        system_prompt,
+        enable_tools,
+        allowed_tools,
+        observer,
+        true,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn build_runtime_with_options(
+    mut session: Session,
+    model: String,
+    system_prompt: Vec<String>,
+    enable_tools: bool,
+    allowed_tools: Option<AllowedToolSet>,
+    observer: Box<dyn RuntimeObserver + Send>,
+    is_interactive: bool,
+    control_state: Option<Arc<ControlState>>,
+) -> Result<ConversationRuntime<LlmRuntimeClient, CliToolExecutor>, CliError> {
     session.model = Some(model.clone());
     let max_steps = settings_get_max_steps(&load_settings()) as usize;
+    let shared_control = control_state.unwrap_or_default();
     let fork_client = SharedApiClient::new(LlmRuntimeClient::new(
         model.clone(),
         enable_tools,
@@ -44,10 +69,16 @@ pub(super) fn build_runtime(
     Ok(ConversationRuntime::new_with_features(
         session,
         LlmRuntimeClient::new(model, enable_tools, allowed_tools.clone()),
-        CliToolExecutor::new(allowed_tools, fork_client),
+        CliToolExecutor::new(
+            allowed_tools,
+            fork_client,
+            is_interactive,
+            Some(Arc::clone(&shared_control)),
+        ),
         system_prompt,
         &build_runtime_feature_config()?,
     )
+    .with_control_state(shared_control)
     .with_max_iterations(max_steps)
     .with_observer(observer))
 }

--- a/crates/acrawl-cli/src/app/tool_executor.rs
+++ b/crates/acrawl-cli/src/app/tool_executor.rs
@@ -1,5 +1,7 @@
+use std::sync::Arc;
+
 use crawler::{CrawlerAgent, SharedApiClient, ToolRegistry};
-use runtime::{ToolError, ToolExecutor};
+use runtime::{ControlState, ToolError, ToolExecutor};
 
 use super::AllowedToolSet;
 
@@ -9,11 +11,20 @@ pub(crate) struct CliToolExecutor {
 }
 
 impl CliToolExecutor {
-    pub(crate) fn new(allowed_tools: Option<AllowedToolSet>, fork_client: SharedApiClient) -> Self {
+    pub(crate) fn new(
+        allowed_tools: Option<AllowedToolSet>,
+        fork_client: SharedApiClient,
+        is_interactive: bool,
+        control_state: Option<Arc<ControlState>>,
+    ) -> Self {
+        let registry = ToolRegistry::new_with_options(is_interactive);
+        let mut agent = CrawlerAgent::new_lazy(registry).with_api_client(fork_client);
+        if let Some(state) = control_state {
+            agent = agent.with_control_state(state);
+        }
         Self {
             allowed_tools,
-            agent: CrawlerAgent::new_lazy(ToolRegistry::new_with_core_tools())
-                .with_api_client(fork_client),
+            agent,
         }
     }
 

--- a/crates/acrawl-cli/src/main.rs
+++ b/crates/acrawl-cli/src/main.rs
@@ -89,7 +89,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             output_format,
             allowed_tools,
         } => {
-            LiveCli::new(model, true, allowed_tools)?
+            LiveCli::new_non_interactive(model, true, allowed_tools)?
                 .run_turn_with_output(&prompt, output_format)?;
         }
         CliAction::Auth { provider } => run_auth_cli(provider.as_deref())?,

--- a/crates/acrawl-cli/src/output_sink.rs
+++ b/crates/acrawl-cli/src/output_sink.rs
@@ -27,6 +27,8 @@ pub trait OutputSink: Send {
     fn on_tool_result(&mut self, name: &str, output: &str, is_error: bool);
     fn on_system(&mut self, msg: &str);
     fn on_turn_finished(&mut self, result: &Result<(), String>);
+    fn on_pause_started(&mut self, _reason: &str) {}
+    fn on_pause_ended(&mut self) {}
 }
 
 pub struct StdoutSink {
@@ -457,6 +459,14 @@ impl OutputSink for ChannelSink {
     fn on_turn_finished(&mut self, result: &Result<(), String>) {
         let _ = self.tx.send(ReplTuiEvent::TurnFinished(result.clone()));
     }
+
+    fn on_pause_started(&mut self, reason: &str) {
+        let _ = self.tx.send(ReplTuiEvent::PauseStarted(reason.to_string()));
+    }
+
+    fn on_pause_ended(&mut self) {
+        let _ = self.tx.send(ReplTuiEvent::PauseEnded);
+    }
 }
 
 impl RuntimeObserver for Box<dyn OutputSink + Send + '_> {
@@ -481,6 +491,14 @@ impl RuntimeObserver for Box<dyn OutputSink + Send + '_> {
     }
 
     fn on_usage(&mut self, _usage: &TokenUsage) {}
+
+    fn on_pause_started(&mut self, reason: &str) {
+        (**self).on_pause_started(reason);
+    }
+
+    fn on_pause_ended(&mut self) {
+        (**self).on_pause_ended();
+    }
 }
 
 #[cfg(test)]

--- a/crates/acrawl-cli/src/tui/events.rs
+++ b/crates/acrawl-cli/src/tui/events.rs
@@ -35,6 +35,10 @@ pub enum ReplTuiEvent {
     /// Live model catalog fetched from models.dev on REPL startup.
     /// Empty Vec means fetch failed — caller falls back to builtin catalog.
     ModelCatalogReady(Vec<ModelInfo>),
+    /// The runtime has entered the paused state.
+    PauseStarted(String),
+    /// The runtime has exited the paused state.
+    PauseEnded,
 }
 
 #[cfg(test)]

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -972,7 +972,7 @@ impl ReplTuiState {
                     self.paused = true;
                     self.pause_reason = reason;
                     self.status_line = format!(
-                        "⏸ PAUSED: {} — Solve in browser, press Enter to resume",
+                        "PAUSED: {} -- Solve in browser, press Enter to resume",
                         self.pause_reason
                     );
                 }
@@ -1514,7 +1514,7 @@ fn run_loop(
                 .clone()
                 .unwrap_or_else(|| "Human intervention requested".to_string());
             state.status_line = format!(
-                "\u{23f8} PAUSED: {} \u{2014} Solve in browser, press Enter to resume",
+                "PAUSED: {} -- Solve in browser, press Enter to resume",
                 state.pause_reason
             );
         }

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -175,6 +175,8 @@ pub(super) struct ReplTuiState {
     pub(super) slash_overlay: Option<SlashOverlay>,
     pub(super) last_slash_overlay_rect: Option<Rect>,
     pub(super) cached_header: HeaderSnapshot,
+    pub(super) paused: bool,
+    pub(super) pause_reason: String,
     spinner_tick: u8,
     spinner_deadline: Instant,
     pub(super) typewriter: TypewriterState,
@@ -214,6 +216,8 @@ impl ReplTuiState {
             slash_overlay: None,
             last_slash_overlay_rect: None,
             cached_header: HeaderSnapshot::default(),
+            paused: false,
+            pause_reason: String::new(),
             spinner_tick: 0,
             spinner_deadline: Instant::now() + Duration::from_millis(120),
             typewriter: TypewriterState {
@@ -956,6 +960,17 @@ impl ReplTuiState {
                     } else {
                         ModelCatalogState::Ready(models)
                     };
+                }
+                ReplTuiEvent::PauseStarted(reason) => {
+                    self.paused = true;
+                    self.pause_reason = reason;
+                    self.status_line =
+                        format!("⏸ PAUSED: {} — Solve in browser, press Enter to resume", self.pause_reason);
+                }
+                ReplTuiEvent::PauseEnded => {
+                    self.paused = false;
+                    self.pause_reason = String::new();
+                    self.status_line = "Thinking...".to_string();
                 }
             }
         }
@@ -1810,6 +1825,16 @@ fn run_loop(
                     continue;
                 }
 
+                if key.code == KeyCode::Char('p')
+                    && !key.modifiers.contains(KeyModifiers::CONTROL)
+                    && state.busy
+                    && !state.paused
+                {
+                    cancel_flag.request_pause();
+                    state.push_system("Pausing after current operation...");
+                    continue;
+                }
+
                 if key.code == KeyCode::Char('d') && key.modifiers.contains(KeyModifiers::CONTROL) {
                     if state.busy {
                         continue;
@@ -1845,6 +1870,13 @@ fn run_loop(
                         state.refresh_slash_overlay();
                     }
                     KeyCode::Enter => {
+                        if state.paused {
+                            cancel_flag.resume();
+                            state.paused = false;
+                            state.pause_reason = String::new();
+                            state.push_system("Resuming...");
+                            continue;
+                        }
                         if state.busy {
                             state.push_system(
                                 "Please wait for the current task to finish before submitting.",

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -3,7 +3,6 @@
 use std::cmp::min;
 use std::collections::VecDeque;
 use std::io;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -33,6 +32,7 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::ListState;
 use ratatui::DefaultTerminal;
+use runtime::ControlState;
 
 const MAX_INPUT_LINES: usize = 5;
 pub(super) const WELCOME_BOX_SIDE_GUTTER: u16 = 16;
@@ -1460,7 +1460,7 @@ fn run_loop(
     ui_tx: &Sender<ReplTuiEvent>,
     work_tx: &Sender<WorkerMsg>,
     cli: &Arc<Mutex<LiveCli>>,
-    cancel_flag: &Arc<AtomicBool>,
+    cancel_flag: &Arc<ControlState>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let _ = execute!(io::stdout(), event::EnableMouseCapture);
     let _ = execute!(io::stdout(), SetCursorStyle::SteadyBar);
@@ -1801,7 +1801,7 @@ fn run_loop(
 
                 if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
                     if state.busy {
-                        cancel_flag.store(true, Ordering::Release);
+                        cancel_flag.request_cancel();
                         state.push_system("Interrupting…");
                         continue;
                     }
@@ -1974,7 +1974,7 @@ fn run_loop(
                                 .last_esc_at
                                 .is_some_and(|t| now.duration_since(t) < Duration::from_millis(500))
                             {
-                                cancel_flag.store(true, Ordering::Release);
+                                cancel_flag.request_cancel();
                                 state.push_system("Interrupting…");
                                 state.last_esc_at = None;
                             } else {

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -964,8 +964,10 @@ impl ReplTuiState {
                 ReplTuiEvent::PauseStarted(reason) => {
                     self.paused = true;
                     self.pause_reason = reason;
-                    self.status_line =
-                        format!("⏸ PAUSED: {} — Solve in browser, press Enter to resume", self.pause_reason);
+                    self.status_line = format!(
+                        "⏸ PAUSED: {} — Solve in browser, press Enter to resume",
+                        self.pause_reason
+                    );
                 }
                 ReplTuiEvent::PauseEnded => {
                     self.paused = false;

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -177,6 +177,7 @@ pub(super) struct ReplTuiState {
     pub(super) cached_header: HeaderSnapshot,
     pub(super) paused: bool,
     pub(super) pause_reason: String,
+    last_wait_for_human_reason: Option<String>,
     spinner_tick: u8,
     spinner_deadline: Instant,
     pub(super) typewriter: TypewriterState,
@@ -218,6 +219,7 @@ impl ReplTuiState {
             cached_header: HeaderSnapshot::default(),
             paused: false,
             pause_reason: String::new(),
+            last_wait_for_human_reason: None,
             spinner_tick: 0,
             spinner_deadline: Instant::now() + Duration::from_millis(120),
             typewriter: TypewriterState {
@@ -476,6 +478,11 @@ impl ReplTuiState {
                 self.entries.push(TranscriptEntry::Stream(styled_line));
             }
             self.typewriter.live.clear();
+        }
+        if name == "wait_for_human" {
+            self.last_wait_for_human_reason = serde_json::from_str::<serde_json::Value>(input)
+                .ok()
+                .and_then(|v| v.get("reason").and_then(|r| r.as_str()).map(String::from));
         }
         let input_summary = tool_input_summary(&name, input);
         self.ui_state = AppUiState::ChatMode;
@@ -1496,6 +1503,21 @@ fn run_loop(
 
     loop {
         state.drain_events(ui_rx);
+
+        // Detect pause state directly from ControlState — the observer event may not
+        // fire for LLM-triggered pauses (handle_pause blocks inline before the runtime
+        // can notify the observer).
+        if !state.paused && state.busy && cancel_flag.is_paused() {
+            state.paused = true;
+            state.pause_reason = state
+                .last_wait_for_human_reason
+                .clone()
+                .unwrap_or_else(|| "Human intervention requested".to_string());
+            state.status_line = format!(
+                "\u{23f8} PAUSED: {} \u{2014} Solve in browser, press Enter to resume",
+                state.pause_reason
+            );
+        }
 
         if state.exit {
             if state.persist_on_exit {

--- a/crates/acrawl-cli/src/tui/repl_render.rs
+++ b/crates/acrawl-cli/src/tui/repl_render.rs
@@ -903,7 +903,9 @@ pub(super) fn draw_chat(
     draw_header(frame, header_area, header);
 
     // --- Transcript block (rounded, matches welcome palette) ---
-    let transcript_border_color = if state.busy {
+    let transcript_border_color = if state.paused {
+        Color::Rgb(180, 140, 30)
+    } else if state.busy {
         Color::Rgb(40, 80, 110)
     } else {
         Color::Rgb(50, 65, 90)
@@ -1027,7 +1029,9 @@ pub(super) fn draw_chat(
     }
 
     // --- Footer / input block (rounded) ---
-    let footer_title = if let Some(ref tool) = state.current_tool {
+    let footer_title = if state.paused {
+        format!(" ⏸ PAUSED: {} — press Enter to resume ", state.pause_reason)
+    } else if let Some(ref tool) = state.current_tool {
         let s = state.spinner_char();
         format!(" {s} Executing {tool} ")
     } else if state.busy {
@@ -1039,13 +1043,19 @@ pub(super) fn draw_chat(
         format!(" Input · {} ", header.model)
     };
 
-    let footer_title_style = if state.busy {
+    let footer_title_style = if state.paused {
+        Style::default()
+            .fg(Color::Rgb(255, 200, 50))
+            .add_modifier(Modifier::BOLD)
+    } else if state.busy {
         Style::default().fg(Color::LightCyan)
     } else {
         Style::default().fg(Color::Rgb(100, 140, 180))
     };
 
-    let footer_border_color = if state.busy {
+    let footer_border_color = if state.paused {
+        Color::Rgb(180, 140, 30)
+    } else if state.busy {
         Color::Rgb(30, 70, 100)
     } else {
         Color::Rgb(50, 70, 100)

--- a/crates/acrawl-cli/src/tui/repl_render.rs
+++ b/crates/acrawl-cli/src/tui/repl_render.rs
@@ -1030,7 +1030,7 @@ pub(super) fn draw_chat(
 
     // --- Footer / input block (rounded) ---
     let footer_title = if state.paused {
-        format!(" ⏸ PAUSED: {} — press Enter to resume ", state.pause_reason)
+        format!(" PAUSED: {} -- press Enter to resume ", state.pause_reason)
     } else if let Some(ref tool) = state.current_tool {
         let s = state.spinner_char();
         format!(" {s} Executing {tool} ")

--- a/crates/crawler/src/agent/fork.rs
+++ b/crates/crawler/src/agent/fork.rs
@@ -94,7 +94,12 @@ impl CrawlerAgent {
         )
         .with_max_steps(child_max_steps)
         .with_agent_id(child_id.clone())
-        .with_agent_manager(self.agent_manager.clone());
+        .with_agent_manager(self.agent_manager.clone())
+        .with_control_state(
+            self.control_state
+                .clone()
+                .unwrap_or_else(|| std::sync::Arc::new(runtime::ControlState::default())),
+        );
         child_agent.shared_bridge = Some(shared_bridge);
         child_agent.crawl_state = child_state;
         child_agent.api_client_arc = Some(child_api_client.clone());

--- a/crates/crawler/src/agent/lifecycle.rs
+++ b/crates/crawler/src/agent/lifecycle.rs
@@ -64,9 +64,7 @@ impl CrawlerAgent {
             ));
         }
 
-        let is_headless = std::env::var("HEADLESS")
-            .map(|value| value != "false")
-            .unwrap_or(true);
+        let is_headless = std::env::var("HEADLESS").map_or(true, |value| value != "false");
         if !is_headless {
             return Ok(());
         }

--- a/crates/crawler/src/agent/lifecycle.rs
+++ b/crates/crawler/src/agent/lifecycle.rs
@@ -2,7 +2,7 @@ use runtime::ToolError;
 use tokio::sync::Mutex;
 
 use super::CrawlerAgent;
-use crate::{BrowserContext, SharedBridge};
+use crate::{BrowserContext, BrowserState, SharedBridge};
 
 #[derive(Clone)]
 pub(crate) struct BrowserSession {
@@ -46,6 +46,97 @@ impl CrawlerAgent {
         self.browser = Some(session.browser);
         self.shared_bridge = Some(session.shared_bridge);
         Ok(())
+    }
+
+    pub async fn pause_browser_switch(&mut self) -> Result<(), ToolError> {
+        let active_children = {
+            let manager = self.agent_manager.lock().await;
+            if manager.contains(&self.agent_id) {
+                manager.get_active_children(&self.agent_id).len()
+            } else {
+                0
+            }
+        };
+
+        if active_children > 0 {
+            return Err(ToolError::new(
+                "Cannot pause while sub-agents are running because they share the browser bridge.",
+            ));
+        }
+
+        let is_headless = std::env::var("HEADLESS")
+            .map(|value| value != "false")
+            .unwrap_or(true);
+        if !is_headless {
+            return Ok(());
+        }
+
+        let page_index = self.browser.as_ref().map_or(0, BrowserContext::page_index);
+        let browser_state = self.export_browser_state().await;
+        eprintln!(
+            "Switching to headed mode. Note: JS runtime state (timers, WebSocket connections) will be lost."
+        );
+
+        std::env::set_var("HEADLESS", "false");
+        self.reset_browser();
+        self.ensure_browser().await?;
+        if let Some(browser) = self.browser.as_mut() {
+            browser.set_page_index(page_index);
+        }
+
+        if let Some(state) = browser_state {
+            self.restore_browser_state(&state).await;
+        }
+
+        Ok(())
+    }
+
+    async fn export_browser_state(&self) -> Option<BrowserState> {
+        let state_result = if let Some(browser) = self.browser.as_ref() {
+            let mut browser = browser.clone();
+            let mut bridge = browser.acquire_bridge().await.ok()?;
+            bridge.export_cookies().await
+        } else {
+            let shared_bridge = self.shared_bridge.as_ref()?.clone();
+            let mut bridge = shared_bridge.lock().await;
+            bridge.export_cookies().await
+        };
+
+        match state_result {
+            Ok(state) => Some(state),
+            Err(error) => {
+                eprintln!("Warning: failed to export browser state: {error}");
+                None
+            }
+        }
+    }
+
+    async fn restore_browser_state(&mut self, state: &BrowserState) {
+        let Some(browser) = self.browser.as_mut() else {
+            return;
+        };
+
+        let mut bridge = match browser.acquire_bridge().await {
+            Ok(bridge) => bridge,
+            Err(error) => {
+                eprintln!("Warning: failed to acquire browser after headed switch: {error}");
+                return;
+            }
+        };
+        if let Err(error) = bridge.import_cookies(state).await {
+            eprintln!("Warning: failed to import cookies after headed switch: {error}");
+        }
+        if !state.url.is_empty() && state.url != "about:blank" {
+            let navigate_result = bridge.navigate(&state.url).await;
+            drop(bridge);
+            if let Err(error) = navigate_result {
+                eprintln!("Warning: failed to navigate to saved URL after headed switch: {error}");
+            } else {
+                browser.set_navigated_url(&state.url, true);
+            }
+        } else {
+            drop(bridge);
+        }
     }
 }
 

--- a/crates/crawler/src/agent/lifecycle.rs
+++ b/crates/crawler/src/agent/lifecycle.rs
@@ -156,12 +156,17 @@ impl CrawlerAgent {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::sync::{Arc, OnceLock};
 
     use tokio::sync::Mutex;
 
     use super::*;
     use crate::tool_registry::ToolRegistry;
+
+    fn env_lock() -> &'static tokio::sync::Mutex<()> {
+        static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+    }
 
     async fn test_bridge() -> SharedBridge {
         Arc::new(Mutex::new(
@@ -206,6 +211,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_lifecycle_state_transitions() {
+        let _env_guard = env_lock().lock().await;
+        std::env::set_var("HEADLESS", "true");
         let mut agent = CrawlerAgent::new_for_testing(ToolRegistry::new());
 
         agent

--- a/crates/crawler/src/agent/lifecycle.rs
+++ b/crates/crawler/src/agent/lifecycle.rs
@@ -123,19 +123,35 @@ impl CrawlerAgent {
                 return;
             }
         };
-        if let Err(error) = bridge.import_cookies(state).await {
+
+        if let Err(error) = bridge.import_cookies_only(state).await {
             eprintln!("Warning: failed to import cookies after headed switch: {error}");
         }
-        if !state.url.is_empty() && state.url != "about:blank" {
-            let navigate_result = bridge.navigate(&state.url).await;
-            drop(bridge);
-            if let Err(error) = navigate_result {
-                eprintln!("Warning: failed to navigate to saved URL after headed switch: {error}");
-            } else {
-                browser.set_navigated_url(&state.url, true);
+
+        let navigated = if !state.url.is_empty() && state.url != "about:blank" {
+            match bridge.navigate(&state.url).await {
+                Ok(_) => {
+                    if let Err(error) = bridge.import_local_storage(state).await {
+                        eprintln!(
+                            "Warning: failed to import localStorage after headed switch: {error}"
+                        );
+                    }
+                    true
+                }
+                Err(error) => {
+                    eprintln!(
+                        "Warning: failed to navigate to saved URL after headed switch: {error}"
+                    );
+                    false
+                }
             }
         } else {
-            drop(bridge);
+            false
+        };
+
+        drop(bridge);
+        if navigated {
+            browser.set_navigated_url(&state.url, true);
         }
     }
 }

--- a/crates/crawler/src/agent/mod.rs
+++ b/crates/crawler/src/agent/mod.rs
@@ -281,6 +281,11 @@ impl CrawlerAgent {
             ToolEffect::Reply(output) => Ok(output),
             ToolEffect::Spawn(spec) => self.handle_spawn(spec).await,
             ToolEffect::Wait(spec) => self.handle_wait_effect(spec).await,
+            ToolEffect::Pause { reason } => {
+                // Actual blocking logic will be wired in Task 9.
+                // For now, return a placeholder indicating pause was requested.
+                Ok(format!("Pause requested: {reason}"))
+            }
         }
     }
 }

--- a/crates/crawler/src/agent/mod.rs
+++ b/crates/crawler/src/agent/mod.rs
@@ -302,7 +302,7 @@ impl CrawlerAgent {
         }
     }
 
-    async fn handle_pause(&mut self, reason: String) -> Result<String, ToolError> {
+    async fn handle_pause(&mut self, _reason: String) -> Result<String, ToolError> {
         self.pause_browser_switch().await?;
 
         let control = self
@@ -312,9 +312,83 @@ impl CrawlerAgent {
             .clone();
         control.request_pause();
 
-        Ok(format!(
-            "Human intervention requested: {reason}. Browser is now in headed mode. Make your changes, then press Enter/p to resume."
-        ))
+        loop {
+            tokio::select! {
+                () = control.wait_for_resume() => { break; }
+                () = tokio::time::sleep(tokio::time::Duration::from_millis(100)) => {
+                    if control.is_cancelled() { break; }
+                }
+            }
+        }
+
+        control.reset();
+
+        if control.is_cancelled() {
+            return Err(ToolError::new("interrupted by user"));
+        }
+
+        Ok(self.auto_read_page_after_resume().await)
+    }
+
+    async fn auto_read_page_after_resume(&mut self) -> String {
+        let Some(browser) = self.browser.as_mut() else {
+            return serde_json::json!({
+                "resumed": true,
+                "page_url": "",
+                "page_title": "",
+                "page_content": "Browser not available after resume"
+            })
+            .to_string();
+        };
+
+        let bridge_result = browser.acquire_bridge().await;
+        match bridge_result {
+            Ok(mut bridge) => {
+                let url = bridge
+                    .evaluate("window.location.href")
+                    .await
+                    .ok()
+                    .and_then(|v| v.as_str().map(String::from))
+                    .unwrap_or_default();
+                let title = bridge
+                    .evaluate("document.title")
+                    .await
+                    .ok()
+                    .and_then(|v| v.as_str().map(String::from))
+                    .unwrap_or_default();
+                match bridge.read_content(None, None, 0, 4000).await {
+                    Ok(content) => {
+                        let text = content
+                            .get("text")
+                            .and_then(|t| t.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        serde_json::json!({
+                            "resumed": true,
+                            "page_url": url,
+                            "page_title": title,
+                            "page_content": text
+                        })
+                        .to_string()
+                    }
+                    Err(e) => serde_json::json!({
+                        "resumed": true,
+                        "page_url": url,
+                        "page_title": title,
+                        "page_content": "",
+                        "read_error": e.to_string()
+                    })
+                    .to_string(),
+                }
+            }
+            Err(_) => serde_json::json!({
+                "resumed": true,
+                "page_url": "",
+                "page_title": "",
+                "page_content": "Browser not available after resume"
+            })
+            .to_string(),
+        }
     }
 }
 
@@ -585,7 +659,7 @@ mod tests {
             .await
             .expect("pause should succeed when already headed");
 
-        assert!(result.contains("manual review"));
+        assert!(result.contains("\"resumed\":true") || result.contains("\"resumed\": true"));
     }
 
     #[tokio::test]
@@ -1024,19 +1098,23 @@ mod tests {
         std::env::set_var("HEADLESS", "false");
 
         let control_state = Arc::new(ControlState::default());
+        let control_clone = Arc::clone(&control_state);
 
         let mut registry = ToolRegistry::new();
         registry.register(
             "wait_for_human",
-            Box::new(|input| {
-                crate::tools::wait_for_human::execute(input, true)
-            }),
+            Box::new(|input| crate::tools::wait_for_human::execute(input, true)),
         );
 
-        let mut agent = CrawlerAgent::new_for_testing(registry)
-            .with_control_state(control_state.clone());
+        let mut agent =
+            CrawlerAgent::new_for_testing(registry).with_control_state(control_state.clone());
 
         assert!(!control_state.is_paused());
+
+        tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+            control_clone.resume();
+        });
 
         let result = agent
             .execute("wait_for_human", r#"{"reason":"captcha detected"}"#)
@@ -1044,12 +1122,8 @@ mod tests {
             .expect("wait_for_human should succeed in interactive mode");
 
         assert!(
-            result.contains("captcha detected"),
-            "result should contain the reason: {result}"
-        );
-        assert!(
-            control_state.is_paused(),
-            "control state should be paused after handle_pause sets it"
+            result.contains("resumed"),
+            "result should contain resumed status: {result}"
         );
     }
 

--- a/crates/crawler/src/agent/mod.rs
+++ b/crates/crawler/src/agent/mod.rs
@@ -316,7 +316,7 @@ impl CrawlerAgent {
             tokio::select! {
                 () = control.wait_for_resume() => { break; }
                 () = tokio::time::sleep(tokio::time::Duration::from_millis(100)) => {
-                    if control.is_cancelled() { break; }
+                    if !control.is_paused() { break; }
                 }
             }
         }

--- a/crates/crawler/src/agent/mod.rs
+++ b/crates/crawler/src/agent/mod.rs
@@ -321,9 +321,10 @@ impl CrawlerAgent {
             }
         }
 
+        let was_cancelled = control.is_cancelled();
         control.reset();
 
-        if control.is_cancelled() {
+        if was_cancelled {
             return Err(ToolError::new("interrupted by user"));
         }
 

--- a/crates/crawler/src/agent/mod.rs
+++ b/crates/crawler/src/agent/mod.rs
@@ -551,6 +551,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_spawn_effect_triggers_fork() {
+        let _env_guard = env_lock().lock().await;
+        std::env::set_var("HEADLESS", "true");
         let manager = default_agent_manager();
         manager.lock().await.register_root("root");
 
@@ -661,6 +663,7 @@ mod tests {
             .expect("pause should succeed when already headed");
 
         assert!(result.contains("\"resumed\":true") || result.contains("\"resumed\": true"));
+        std::env::set_var("HEADLESS", "true");
     }
 
     #[tokio::test]
@@ -754,6 +757,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_fork_dispatch_spawns_child() {
+        let _env_guard = env_lock().lock().await;
+        std::env::set_var("HEADLESS", "true");
         let manager = default_agent_manager();
         manager.lock().await.register_root("root");
 
@@ -797,6 +802,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_fork_returns_observation() {
+        let _env_guard = env_lock().lock().await;
+        std::env::set_var("HEADLESS", "true");
         let manager = default_agent_manager();
         manager.lock().await.register_root("root");
 
@@ -1126,6 +1133,7 @@ mod tests {
             result.contains("resumed"),
             "result should contain resumed status: {result}"
         );
+        std::env::set_var("HEADLESS", "true");
     }
 
     #[tokio::test]
@@ -1146,5 +1154,6 @@ mod tests {
             err.to_string().contains("no control state"),
             "unexpected error: {err}"
         );
+        std::env::set_var("HEADLESS", "true");
     }
 }

--- a/crates/crawler/src/agent/mod.rs
+++ b/crates/crawler/src/agent/mod.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use runtime::{
-    ApiClient, ContentBlock, ConversationRuntime, Session, ToolError, ToolExecutor, TurnSummary,
+    ApiClient, ContentBlock, ControlState, ConversationRuntime, Session, ToolError, ToolExecutor,
+    TurnSummary,
 };
 use serde_json::Value;
 use tokio::sync::Mutex;
@@ -86,6 +87,7 @@ pub struct CrawlerAgent {
     pub(super) crawl_state: CrawlState,
     pub(crate) child_tasks: ChildTaskMap,
     pub(super) api_client_arc: Option<SharedApiClient>,
+    control_state: Option<Arc<ControlState>>,
     #[cfg(test)]
     pub(super) fork_page_index_override: Option<usize>,
 }
@@ -106,6 +108,7 @@ impl CrawlerAgent {
             },
             child_tasks: HashMap::new(),
             api_client_arc: None,
+            control_state: None,
             #[cfg(test)]
             fork_page_index_override: None,
         }
@@ -126,6 +129,7 @@ impl CrawlerAgent {
             },
             child_tasks: HashMap::new(),
             api_client_arc: None,
+            control_state: None,
             #[cfg(test)]
             fork_page_index_override: None,
         }
@@ -146,6 +150,7 @@ impl CrawlerAgent {
             },
             child_tasks: HashMap::new(),
             api_client_arc: None,
+            control_state: None,
             #[cfg(test)]
             fork_page_index_override: None,
         }
@@ -176,6 +181,16 @@ impl CrawlerAgent {
         self
     }
 
+    #[must_use]
+    pub fn with_control_state(mut self, state: Arc<ControlState>) -> Self {
+        self.control_state = Some(state);
+        self
+    }
+
+    pub fn set_control_state(&mut self, state: Arc<ControlState>) {
+        self.control_state = Some(state);
+    }
+
     pub async fn run(
         mut self,
         goal: &str,
@@ -201,6 +216,8 @@ impl CrawlerAgent {
         let mut runtime =
             ConversationRuntime::new(Session::new(), shared_client.clone(), self, system_prompt)
                 .with_max_iterations(max_steps);
+        let control_state = runtime.control_state();
+        runtime.tool_executor_mut().set_control_state(control_state);
         let result = runtime.run_turn(goal).await;
         let agent_id = runtime.tool_executor_mut().agent_id.clone();
         let agent_manager = runtime.tool_executor_mut().agent_manager.clone();
@@ -281,12 +298,23 @@ impl CrawlerAgent {
             ToolEffect::Reply(output) => Ok(output),
             ToolEffect::Spawn(spec) => self.handle_spawn(spec).await,
             ToolEffect::Wait(spec) => self.handle_wait_effect(spec).await,
-            ToolEffect::Pause { reason } => {
-                // Actual blocking logic will be wired in Task 9.
-                // For now, return a placeholder indicating pause was requested.
-                Ok(format!("Pause requested: {reason}"))
-            }
+            ToolEffect::Pause { reason } => self.handle_pause(reason).await,
         }
+    }
+
+    async fn handle_pause(&mut self, reason: String) -> Result<String, ToolError> {
+        self.pause_browser_switch().await?;
+
+        let control = self
+            .control_state
+            .as_ref()
+            .ok_or_else(|| ToolError::new("no control state available for pause"))?
+            .clone();
+        control.request_pause();
+
+        Ok(format!(
+            "Human intervention requested: {reason}. Browser is now in headed mode. Make your changes, then press Enter/p to resume."
+        ))
     }
 }
 
@@ -328,7 +356,10 @@ fn build_crawl_result(summary: &TurnSummary, crawl_state: &CrawlState) -> CrawlR
 
 #[cfg(test)]
 mod tests {
+    use std::sync::OnceLock;
+
     use runtime::{ApiRequest, AssistantEvent, RuntimeError, TokenUsage};
+    use tokio::sync::Mutex as AsyncMutex;
 
     use super::*;
     use crate::tool_registry::ToolRegistry;
@@ -427,6 +458,11 @@ mod tests {
         registry
     }
 
+    fn env_lock() -> &'static AsyncMutex<()> {
+        static LOCK: OnceLock<AsyncMutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| AsyncMutex::new(()))
+    }
+
     #[tokio::test]
     async fn test_reply_effect_adds_to_conversation() {
         let mut agent = CrawlerAgent::new_for_testing(mock_registry());
@@ -492,6 +528,64 @@ mod tests {
 
         assert_eq!(result, "Waited for 1 subagent(s). Collected 1 item(s).");
         assert_eq!(agent.crawl_state.child_blocks.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn pause_with_children_errors() {
+        let manager = default_agent_manager();
+        {
+            let mut locked = manager.lock().await;
+            locked.register_root("test-agent");
+            locked
+                .register_child("test-agent-child-1", "test-agent", None)
+                .expect("child registration should succeed");
+        }
+
+        let _env_guard = env_lock().lock().await;
+        std::env::set_var("HEADLESS", "true");
+
+        let control_state = Arc::new(ControlState::default());
+        let mut agent = CrawlerAgent::new_for_testing(mock_registry())
+            .with_agent_manager(manager)
+            .with_control_state(control_state.clone());
+        let err = agent
+            .dispatch_tool_effect(ToolEffect::Pause {
+                reason: "need human".to_string(),
+            })
+            .await
+            .expect_err("pause should fail while child agents are active");
+
+        assert!(
+            err.to_string()
+                .contains("Cannot pause while sub-agents are running"),
+            "unexpected error: {err}"
+        );
+        assert!(!control_state.is_paused());
+    }
+
+    #[tokio::test]
+    async fn pause_when_already_headed_requests_runtime_pause() {
+        let _env_guard = env_lock().lock().await;
+        std::env::set_var("HEADLESS", "false");
+
+        let control_state = Arc::new(ControlState::default());
+        let control_clone = Arc::clone(&control_state);
+        let mut agent = CrawlerAgent::new_for_testing(mock_registry())
+            .with_control_state(control_state.clone());
+
+        tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+            control_clone.resume();
+        });
+
+        let result = agent
+            .dispatch_tool_effect(ToolEffect::Pause {
+                reason: "manual review".to_string(),
+            })
+            .await
+            .expect("pause should succeed when already headed");
+
+        assert!(result.contains("manual review"));
     }
 
     #[tokio::test]

--- a/crates/crawler/src/agent/mod.rs
+++ b/crates/crawler/src/agent/mod.rs
@@ -302,7 +302,7 @@ impl CrawlerAgent {
         }
     }
 
-    async fn handle_pause(&mut self, _reason: String) -> Result<String, ToolError> {
+    async fn handle_pause(&mut self, reason: String) -> Result<String, ToolError> {
         self.pause_browser_switch().await?;
 
         let control = self
@@ -310,7 +310,7 @@ impl CrawlerAgent {
             .as_ref()
             .ok_or_else(|| ToolError::new("no control state available for pause"))?
             .clone();
-        control.request_pause();
+        control.request_pause_with_reason(&reason);
 
         loop {
             tokio::select! {

--- a/crates/crawler/src/agent/mod.rs
+++ b/crates/crawler/src/agent/mod.rs
@@ -1017,4 +1017,59 @@ mod tests {
             vec![serde_json::json!({"from_state": true})]
         );
     }
+
+    #[tokio::test]
+    async fn wait_for_human_tool_triggers_agent_pause() {
+        let _env_guard = env_lock().lock().await;
+        std::env::set_var("HEADLESS", "false");
+
+        let control_state = Arc::new(ControlState::default());
+
+        let mut registry = ToolRegistry::new();
+        registry.register(
+            "wait_for_human",
+            Box::new(|input| {
+                crate::tools::wait_for_human::execute(input, true)
+            }),
+        );
+
+        let mut agent = CrawlerAgent::new_for_testing(registry)
+            .with_control_state(control_state.clone());
+
+        assert!(!control_state.is_paused());
+
+        let result = agent
+            .execute("wait_for_human", r#"{"reason":"captcha detected"}"#)
+            .await
+            .expect("wait_for_human should succeed in interactive mode");
+
+        assert!(
+            result.contains("captcha detected"),
+            "result should contain the reason: {result}"
+        );
+        assert!(
+            control_state.is_paused(),
+            "control state should be paused after handle_pause sets it"
+        );
+    }
+
+    #[tokio::test]
+    async fn pause_no_control_state_returns_error() {
+        let _env_guard = env_lock().lock().await;
+        std::env::set_var("HEADLESS", "false");
+
+        let mut agent = CrawlerAgent::new_for_testing(mock_registry());
+
+        let err = agent
+            .dispatch_tool_effect(ToolEffect::Pause {
+                reason: "test".to_string(),
+            })
+            .await
+            .expect_err("pause should fail without control state");
+
+        assert!(
+            err.to_string().contains("no control state"),
+            "unexpected error: {err}"
+        );
+    }
 }

--- a/crates/crawler/src/lib.rs
+++ b/crates/crawler/src/lib.rs
@@ -341,7 +341,7 @@ mod tests {
     use super::mvp_tool_specs;
 
     #[test]
-    fn mvp_tool_specs_contains_expected_18_tools() {
+    fn mvp_tool_specs_contains_expected_19_tools() {
         let specs = mvp_tool_specs();
         assert_eq!(specs.len(), 19);
 

--- a/crates/crawler/src/lib.rs
+++ b/crates/crawler/src/lib.rs
@@ -18,7 +18,7 @@ pub use browser::BrowserContext;
 pub use fetcher::{FetchError, FetchRouter, FetchedPage};
 pub use manager::{AgentInfo, AgentManager, AgentStatus, ForkLimitError, SharedAgentManager};
 pub use output::{write_output, OutputError, OutputFormat};
-pub use playwright::{PageInfo, PlaywrightBridge, PlaywrightBridgeError, SharedBridge};
+pub use playwright::{BrowserState, PageInfo, PlaywrightBridge, PlaywrightBridgeError, SharedBridge};
 pub use prompt::build_system_prompt;
 pub use shared_client::SharedApiClient;
 pub use state::CrawlState;
@@ -304,6 +304,22 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
 
             instructions: Some("Only call this when you need subagent results before deciding your next action."),
         },
+        ToolSpec {
+            name: "wait_for_human",
+            description: "Pause execution and request human intervention. Use when encountering captchas, login walls, paywalls, or other obstacles that require human action in the browser.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "reason": {
+                        "type": "string",
+                        "description": "Why human intervention is needed (e.g., 'Login wall detected', 'CAPTCHA challenge appeared')"
+                    }
+                },
+                "required": ["reason"],
+                "additionalProperties": false
+            }),
+            instructions: Some("Use only when you encounter an obstacle that genuinely requires a human to solve (captcha, login, paywall). Be specific about what the human needs to do in the browser."),
+        },
     ]
 }
 
@@ -327,10 +343,10 @@ mod tests {
     #[test]
     fn mvp_tool_specs_contains_expected_18_tools() {
         let specs = mvp_tool_specs();
-        assert_eq!(specs.len(), 18);
+        assert_eq!(specs.len(), 19);
 
         let names: BTreeSet<_> = specs.iter().map(|spec| spec.name).collect();
-        assert_eq!(names.len(), 18, "tool names should be unique");
+        assert_eq!(names.len(), 19, "tool names should be unique");
         assert!(names.contains("navigate"));
         assert!(names.contains("save_file"));
         assert!(names.contains("fork"));

--- a/crates/crawler/src/lib.rs
+++ b/crates/crawler/src/lib.rs
@@ -320,7 +320,7 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                 "required": ["reason"],
                 "additionalProperties": false
             }),
-            instructions: Some("Use only when you encounter an obstacle that genuinely requires a human to solve (captcha, login, paywall). Be specific about what the human needs to do in the browser."),
+            instructions: Some("Use only when you encounter an obstacle that genuinely requires a human to solve (captcha, login, paywall). Be specific in the reason about what the human needs to do. The browser becomes visible for the human. After they finish and press resume, you receive the updated page content (URL, title, text) — continue your task from there."),
         },
     ]
 }

--- a/crates/crawler/src/lib.rs
+++ b/crates/crawler/src/lib.rs
@@ -18,7 +18,9 @@ pub use browser::BrowserContext;
 pub use fetcher::{FetchError, FetchRouter, FetchedPage};
 pub use manager::{AgentInfo, AgentManager, AgentStatus, ForkLimitError, SharedAgentManager};
 pub use output::{write_output, OutputError, OutputFormat};
-pub use playwright::{BrowserState, PageInfo, PlaywrightBridge, PlaywrightBridgeError, SharedBridge};
+pub use playwright::{
+    BrowserState, PageInfo, PlaywrightBridge, PlaywrightBridgeError, SharedBridge,
+};
 pub use prompt::build_system_prompt;
 pub use shared_client::SharedApiClient;
 pub use state::CrawlState;

--- a/crates/crawler/src/playwright.rs
+++ b/crates/crawler/src/playwright.rs
@@ -458,6 +458,63 @@ async function bootstrap() {
       continue;
     }
 
+    if (command.action === 'export_cookies') {
+      try {
+        const cookies = await context.cookies();
+        let localStorage = {};
+        try {
+          localStorage = await page.evaluate(() => {
+            const result = {};
+            for (let i = 0; i < window.localStorage.length; i++) {
+              const key = window.localStorage.key(i);
+              if (key !== null) result[key] = window.localStorage.getItem(key) || '';
+            }
+            return result;
+          });
+        } catch (_) { /* localStorage may be unavailable on some pages */ }
+        const url = page.url();
+        process.stdout.write(JSON.stringify({
+          event: 'bridge_response',
+          ok: true,
+          result: { cookies, local_storage: localStorage, url }
+        }) + '\n');
+      } catch (error) {
+        process.stdout.write(JSON.stringify({
+          event: 'bridge_response',
+          ok: false,
+          error: { kind: 'export_cookies_failed', message: String(error) }
+        }) + '\n');
+      }
+      continue;
+    }
+
+    if (command.action === 'import_cookies') {
+      try {
+        if (command.cookies && command.cookies.length > 0) {
+          await context.addCookies(command.cookies);
+        }
+        if (command.local_storage && typeof command.local_storage === 'object') {
+          await page.evaluate((ls) => {
+            for (const [k, v] of Object.entries(ls)) {
+              try { window.localStorage.setItem(k, v); } catch (_) {}
+            }
+          }, command.local_storage);
+        }
+        process.stdout.write(JSON.stringify({
+          event: 'bridge_response',
+          ok: true,
+          result: { imported: true }
+        }) + '\n');
+      } catch (error) {
+        process.stdout.write(JSON.stringify({
+          event: 'bridge_response',
+          ok: false,
+          error: { kind: 'import_cookies_failed', message: String(error) }
+        }) + '\n');
+      }
+      continue;
+    }
+
     process.stdout.write(JSON.stringify({
       event: 'bridge_response',
       ok: false,
@@ -480,6 +537,14 @@ bootstrap().catch((error) => {
 pub struct PageInfo {
     pub title: String,
     pub html: String,
+}
+
+/// Captured browser state for preservation across bridge restarts.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BrowserState {
+    pub cookies: serde_json::Value,
+    pub local_storage: serde_json::Value,
+    pub url: String,
 }
 
 #[derive(Debug)]
@@ -840,6 +905,24 @@ impl PlaywrightBridge {
             "index": index,
         });
         self.send_raw_command(&cmd).await
+    }
+
+    pub async fn export_cookies(&mut self) -> Result<BrowserState, PlaywrightBridgeError> {
+        let cmd = serde_json::json!({ "action": "export_cookies" });
+        let result = self.send_raw_command(&cmd).await?;
+        let state = serde_json::from_value::<BrowserState>(result)
+            .map_err(|e| PlaywrightBridgeError::Protocol(format!("failed to parse BrowserState: {e}")))?;
+        Ok(state)
+    }
+
+    pub async fn import_cookies(&mut self, state: &BrowserState) -> Result<(), PlaywrightBridgeError> {
+        let cmd = serde_json::json!({
+            "action": "import_cookies",
+            "cookies": state.cookies,
+            "local_storage": state.local_storage,
+        });
+        self.send_raw_command(&cmd).await?;
+        Ok(())
     }
 
     pub async fn list_resources(&mut self) -> Result<serde_json::Value, PlaywrightBridgeError> {
@@ -1274,5 +1357,34 @@ for line in sys.stdin:
             .close()
             .await
             .expect("bridge should close without zombie process");
+    }
+
+    #[test]
+    fn browser_state_serializes_and_deserializes() {
+        use super::BrowserState;
+
+        let state = BrowserState {
+            cookies: serde_json::json!([{"name": "session", "value": "abc123", "domain": "example.com"}]),
+            local_storage: serde_json::json!({"theme": "dark", "lang": "en"}),
+            url: "https://example.com/page".to_string(),
+        };
+        let json = serde_json::to_string(&state).expect("should serialize");
+        let parsed: BrowserState = serde_json::from_str(&json).expect("should deserialize");
+        assert_eq!(parsed.url, state.url);
+        assert_eq!(parsed.local_storage["theme"], "dark");
+    }
+
+    #[test]
+    fn browser_state_empty_cookies_round_trips() {
+        use super::BrowserState;
+
+        let state = BrowserState {
+            cookies: serde_json::json!([]),
+            local_storage: serde_json::json!({}),
+            url: String::new(),
+        };
+        let json = serde_json::to_string(&state).unwrap();
+        let parsed: BrowserState = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.url, "");
     }
 }

--- a/crates/crawler/src/playwright.rs
+++ b/crates/crawler/src/playwright.rs
@@ -929,6 +929,30 @@ impl PlaywrightBridge {
         Ok(())
     }
 
+    pub async fn import_cookies_only(
+        &mut self,
+        state: &BrowserState,
+    ) -> Result<(), PlaywrightBridgeError> {
+        let cmd = serde_json::json!({
+            "action": "import_cookies",
+            "cookies": state.cookies,
+        });
+        self.send_raw_command(&cmd).await?;
+        Ok(())
+    }
+
+    pub async fn import_local_storage(
+        &mut self,
+        state: &BrowserState,
+    ) -> Result<(), PlaywrightBridgeError> {
+        let cmd = serde_json::json!({
+            "action": "import_cookies",
+            "local_storage": state.local_storage,
+        });
+        self.send_raw_command(&cmd).await?;
+        Ok(())
+    }
+
     pub async fn list_resources(&mut self) -> Result<serde_json::Value, PlaywrightBridgeError> {
         let cmd = serde_json::json!({ "action": "list_resources" });
         self.send_raw_command(&cmd).await

--- a/crates/crawler/src/playwright.rs
+++ b/crates/crawler/src/playwright.rs
@@ -910,12 +910,16 @@ impl PlaywrightBridge {
     pub async fn export_cookies(&mut self) -> Result<BrowserState, PlaywrightBridgeError> {
         let cmd = serde_json::json!({ "action": "export_cookies" });
         let result = self.send_raw_command(&cmd).await?;
-        let state = serde_json::from_value::<BrowserState>(result)
-            .map_err(|e| PlaywrightBridgeError::Protocol(format!("failed to parse BrowserState: {e}")))?;
+        let state = serde_json::from_value::<BrowserState>(result).map_err(|e| {
+            PlaywrightBridgeError::Protocol(format!("failed to parse BrowserState: {e}"))
+        })?;
         Ok(state)
     }
 
-    pub async fn import_cookies(&mut self, state: &BrowserState) -> Result<(), PlaywrightBridgeError> {
+    pub async fn import_cookies(
+        &mut self,
+        state: &BrowserState,
+    ) -> Result<(), PlaywrightBridgeError> {
         let cmd = serde_json::json!({
             "action": "import_cookies",
             "cookies": state.cookies,

--- a/crates/crawler/src/prompt.rs
+++ b/crates/crawler/src/prompt.rs
@@ -143,11 +143,11 @@ fn section_error_recovery() -> String {
       click or fill_form fail, but not as a first choice.\n\
      - Popup or overlay blocking interaction: Try pressing Escape or clicking \
      a dismiss button before retrying the intended action."
-         .to_string()
+        .to_string()
 }
 
 fn section_completion() -> String {
-     "Completion:\n\
+    "Completion:\n\
       - Before reporting success, re-read the original task and confirm each \
       requirement is met by data you actually extracted.\n\
       - If any requirement is unmet or uncertain, say so explicitly rather \
@@ -157,11 +157,11 @@ fn section_completion() -> String {
       and explain why if running in non-interactive mode.\n\
       - When providing extracted data, include the source URL and note any \
       gaps or limitations."
-         .to_string()
+        .to_string()
 }
 
 fn section_parallel_exploration() -> String {
-     "Parallel exploration:\n\
+    "Parallel exploration:\n\
        - Use the `fork` tool to spawn a subagent on a separate browser tab when you need \
        to explore multiple pages simultaneously.\n\
        - Each subagent gets a copy of your history and works independently.\n\

--- a/crates/crawler/src/prompt.rs
+++ b/crates/crawler/src/prompt.rs
@@ -34,123 +34,143 @@ fn list_tools(specs: &[ToolSpec]) -> String {
 /// Returns `Vec<String>` for [`runtime::ConversationRuntime`]'s `system_prompt` parameter.
 #[must_use]
 pub fn build_system_prompt(tool_specs: &[ToolSpec]) -> Vec<String> {
-    let tool_listing = list_tools(tool_specs);
-
     vec![
-        // Section 1 — identity + tool listing
-        format!(
-            "You are an autonomous web crawler agent. Your job is to complete the \
-             user's web task by navigating websites, interacting with pages, and \
-             extracting information from page content only.\n\n\
-             Your task arrives as a user message. Read it carefully before acting.\n\n\
-             Available browser tools:\n{tool_listing}"
-        ),
-        // Section 2 — operating procedure (replaces vague "think step by step")
-        "Operating procedure:\n\
-         1. Read the current task carefully. Identify every concrete requirement.\n\
-         2. Start from the most relevant direct URL when known, using a full URL \
-         including https://.\n\
-         3. At each step:\n\
-         \x20\x20 a. Observe the current page state from the last tool result.\n\
-         \x20\x20 b. Check for blockers: if the page content mentions CAPTCHAs, \
-         \"verify you are human\", \"unusual traffic\", login forms you cannot fill, \
-         paywalls, or access denied messages — immediately call `wait_for_human` \
-         with a description of what you see. Do not retry or work around it.\n\
-         \x20\x20 c. Decide the single best next action.\n\
-         \x20\x20 d. Execute one tool call.\n\
-         \x20\x20 e. Evaluate the result before continuing.\n\
-         4. Prefer the simplest reliable action:\n\
-          \x20\x20 - Direct navigate over clicking links when the URL is known.\n\
-          \x20\x20 - click, fill_form, and scroll before execute_js.\n\
-          \x20\x20 - page_map to discover page structure, then read_content to extract specific sections.\n\
-          5. When extracting information from a page:\n\
-          \x20\x20 a. Call page_map to see the heading structure and section sizes.\n\
-          \x20\x20 b. Call read_content with the heading name or CSS selector for the section you need.\n\
-          \x20\x20 c. For large sections, use offset and max_chars to paginate through content.\n\
-          \x20\x20 d. If page_map returns no sections (empty list), use read_content with a CSS selector.\n\
-           6. When you have accomplished the goal, provide a summary and the structured results \
-           in JSON format in your final message."
-            .to_string(),
-        // Section 3 — data integrity (anti-hallucination + grounding)
-        "Data integrity:\n\
-         - Only report facts that were actually observed through tool results or \
-         page content. Never use training knowledge to fill gaps in extracted data.\n\
-         - Every URL, price, name, date, and value you report must appear verbatim \
-         in a tool result from this session. If information was not found on the \
-         page, say so explicitly.\n\
-         - Never claim to have clicked, extracted, or observed something unless a \
-         tool result confirms it.\n\
-         - Distinguish clearly between what you observed on the page and any \
-         inferences or assumptions you are making."
-            .to_string(),
-        // Section 4 — constraints (concrete budgets, not vague advice)
-        "Constraints:\n\
-         - Do not loop indefinitely.\n\
-         - Maximum retries for any single failed action: 2. After that, try a \
-         different approach entirely.\n\
-         - If you are on the same page for 3 or more steps without meaningful \
-         progress, change strategy.\n\
-         - If no meaningful progress is made in 3 consecutive steps, stop and \
-         summarize partial results.\n\
-         - Keep extracted data clean, deduplicated, and well-structured.\n\
-         - Prefer navigate with a direct URL over clicking links when possible.\n\
-         - Use go_back to return to previous pages instead of re-navigating."
-            .to_string(),
-        // Section 5 — error recovery (tiered by situation, not generic)
-        "Error recovery by situation:\n\
-         - Selector not found: Try a more general selector, scroll to reveal \
-         content, or check for overlays or popups blocking the element.\n\
-         - Page not loading or navigation error: Verify the URL is correct and \
-         complete. Try an alternative URL or search for the page.\n\
-         - CAPTCHA or human verification (e.g. \"verify you are human\", \
-         \"unusual traffic\", reCAPTCHA, hCaptcha, checkbox challenges): \
-         Call `wait_for_human` IMMEDIATELY. Do NOT retry, do NOT try to solve it, \
-         do NOT navigate away. The human will solve it in the visible browser.\n\
-         - Login wall or paywall: Call `wait_for_human` with a clear \
-         description (e.g. \"Login form requires credentials\" or \
-         \"Paywall blocking article content\"). The browser will become visible so \
-         the human can interact with it directly. After the human finishes and \
-         resumes, you will receive the updated page content (URL, title, text) as \
-         the tool result — continue your task using that new page state. \
-         If `wait_for_human` is not available (non-interactive mode), stop and \
-         report the blocker in your final response.\n\
-         - Anti-bot detection (403/429 errors, empty page, \"access denied\"): \
-         Wait briefly (use the `wait` tool) and retry once. \
-         If the obstacle persists after retrying, call `wait_for_human`.\n\
-         - Empty results on a page expected to have data: Scroll down for \
-          lazy-loaded content, wait for dynamic rendering, or check whether the \
-          page uses iframes.\n\
-          - Empty results on page_map (sections list is empty): the page does not use \
-          semantic headings — fall back to read_content with a CSS selector.\n\
-          - JavaScript interaction failing: Use execute_js as a fallback when \
-          click or fill_form fail, but not as a first choice.\n\
-         - Popup or overlay blocking interaction: Try pressing Escape or clicking \
-         a dismiss button before retrying the intended action."
-             .to_string(),
-        // Section 6 — completion protocol
-         "Completion:\n\
-          - Before reporting success, re-read the original task and confirm each \
-          requirement is met by data you actually extracted.\n\
-          - If any requirement is unmet or uncertain, say so explicitly rather \
-          than guessing.\n\
-          - If the task is impossible to continue (requires login, payment, or \
-          access you do not have), call `wait_for_human` if available. Only stop \
-          and explain why if running in non-interactive mode.\n\
-          - When providing extracted data, include the source URL and note any \
-          gaps or limitations."
-             .to_string(),
-         // Section 7 — parallel exploration
-         "Parallel exploration:\n\
-           - Use the `fork` tool to spawn a subagent on a separate browser tab when you need \
-           to explore multiple pages simultaneously.\n\
-           - Each subagent gets a copy of your history and works independently.\n\
-           - You can fork multiple subagents at once (up to the configured limit).\n\
-           - After forking, continue your own work — subagents run in parallel.\n\
-           - Use `wait_for_subagents` to pause and collect results when you need them.\n\
-           - Prefer forking over sequential navigation when visiting multiple independent pages.\n\
-           - Example: Scraping 5 product pages? Fork 5 subagents, each visiting one page, then wait for their results."
-             .to_string(),
-     ]
+        section_identity(tool_specs),
+        section_operating_procedure(),
+        section_data_integrity(),
+        section_constraints(),
+        section_error_recovery(),
+        section_completion(),
+        section_parallel_exploration(),
+    ]
+}
+
+fn section_identity(tool_specs: &[ToolSpec]) -> String {
+    let tool_listing = list_tools(tool_specs);
+    format!(
+        "You are an autonomous web crawler agent. Your job is to complete the \
+         user's web task by navigating websites, interacting with pages, and \
+         extracting information from page content only.\n\n\
+         Your task arrives as a user message. Read it carefully before acting.\n\n\
+         Available browser tools:\n{tool_listing}"
+    )
+}
+
+fn section_operating_procedure() -> String {
+    "Operating procedure:\n\
+     1. Read the current task carefully. Identify every concrete requirement.\n\
+     2. Start from the most relevant direct URL when known, using a full URL \
+     including https://.\n\
+     3. At each step:\n\
+     \x20\x20 a. Observe the current page state from the last tool result.\n\
+     \x20\x20 b. Check for blockers: if the page content mentions CAPTCHAs, \
+     \"verify you are human\", \"unusual traffic\", login forms you cannot fill, \
+     paywalls, or access denied messages — immediately call `wait_for_human` \
+     with a description of what you see. Do not retry or work around it.\n\
+     \x20\x20 c. Decide the single best next action.\n\
+     \x20\x20 d. Execute one tool call.\n\
+     \x20\x20 e. Evaluate the result before continuing.\n\
+     4. Prefer the simplest reliable action:\n\
+      \x20\x20 - Direct navigate over clicking links when the URL is known.\n\
+      \x20\x20 - click, fill_form, and scroll before execute_js.\n\
+      \x20\x20 - page_map to discover page structure, then read_content to extract specific sections.\n\
+      5. When extracting information from a page:\n\
+      \x20\x20 a. Call page_map to see the heading structure and section sizes.\n\
+      \x20\x20 b. Call read_content with the heading name or CSS selector for the section you need.\n\
+      \x20\x20 c. For large sections, use offset and max_chars to paginate through content.\n\
+      \x20\x20 d. If page_map returns no sections (empty list), use read_content with a CSS selector.\n\
+       6. When you have accomplished the goal, provide a summary and the structured results \
+       in JSON format in your final message."
+        .to_string()
+}
+
+fn section_data_integrity() -> String {
+    "Data integrity:\n\
+     - Only report facts that were actually observed through tool results or \
+     page content. Never use training knowledge to fill gaps in extracted data.\n\
+     - Every URL, price, name, date, and value you report must appear verbatim \
+     in a tool result from this session. If information was not found on the \
+     page, say so explicitly.\n\
+     - Never claim to have clicked, extracted, or observed something unless a \
+     tool result confirms it.\n\
+     - Distinguish clearly between what you observed on the page and any \
+     inferences or assumptions you are making."
+        .to_string()
+}
+
+fn section_constraints() -> String {
+    "Constraints:\n\
+     - Do not loop indefinitely.\n\
+     - Maximum retries for any single failed action: 2. After that, try a \
+     different approach entirely.\n\
+     - If you are on the same page for 3 or more steps without meaningful \
+     progress, change strategy.\n\
+     - If no meaningful progress is made in 3 consecutive steps, stop and \
+     summarize partial results.\n\
+     - Keep extracted data clean, deduplicated, and well-structured.\n\
+     - Prefer navigate with a direct URL over clicking links when possible.\n\
+     - Use go_back to return to previous pages instead of re-navigating."
+        .to_string()
+}
+
+fn section_error_recovery() -> String {
+    "Error recovery by situation:\n\
+     - Selector not found: Try a more general selector, scroll to reveal \
+     content, or check for overlays or popups blocking the element.\n\
+     - Page not loading or navigation error: Verify the URL is correct and \
+     complete. Try an alternative URL or search for the page.\n\
+     - CAPTCHA or human verification (e.g. \"verify you are human\", \
+     \"unusual traffic\", reCAPTCHA, hCaptcha, checkbox challenges): \
+     Call `wait_for_human` IMMEDIATELY. Do NOT retry, do NOT try to solve it, \
+     do NOT navigate away. The human will solve it in the visible browser.\n\
+     - Login wall or paywall: Call `wait_for_human` with a clear \
+     description (e.g. \"Login form requires credentials\" or \
+     \"Paywall blocking article content\"). The browser will become visible so \
+     the human can interact with it directly. After the human finishes and \
+     resumes, you will receive the updated page content (URL, title, text) as \
+     the tool result — continue your task using that new page state. \
+     If `wait_for_human` is not available (non-interactive mode), stop and \
+     report the blocker in your final response.\n\
+     - Anti-bot detection (403/429 errors, empty page, \"access denied\"): \
+     Wait briefly (use the `wait` tool) and retry once. \
+     If the obstacle persists after retrying, call `wait_for_human`.\n\
+     - Empty results on a page expected to have data: Scroll down for \
+      lazy-loaded content, wait for dynamic rendering, or check whether the \
+      page uses iframes.\n\
+      - Empty results on page_map (sections list is empty): the page does not use \
+      semantic headings — fall back to read_content with a CSS selector.\n\
+      - JavaScript interaction failing: Use execute_js as a fallback when \
+      click or fill_form fail, but not as a first choice.\n\
+     - Popup or overlay blocking interaction: Try pressing Escape or clicking \
+     a dismiss button before retrying the intended action."
+         .to_string()
+}
+
+fn section_completion() -> String {
+     "Completion:\n\
+      - Before reporting success, re-read the original task and confirm each \
+      requirement is met by data you actually extracted.\n\
+      - If any requirement is unmet or uncertain, say so explicitly rather \
+      than guessing.\n\
+      - If the task is impossible to continue (requires login, payment, or \
+      access you do not have), call `wait_for_human` if available. Only stop \
+      and explain why if running in non-interactive mode.\n\
+      - When providing extracted data, include the source URL and note any \
+      gaps or limitations."
+         .to_string()
+}
+
+fn section_parallel_exploration() -> String {
+     "Parallel exploration:\n\
+       - Use the `fork` tool to spawn a subagent on a separate browser tab when you need \
+       to explore multiple pages simultaneously.\n\
+       - Each subagent gets a copy of your history and works independently.\n\
+       - You can fork multiple subagents at once (up to the configured limit).\n\
+       - After forking, continue your own work — subagents run in parallel.\n\
+       - Use `wait_for_subagents` to pause and collect results when you need them.\n\
+       - Prefer forking over sequential navigation when visiting multiple independent pages.\n\
+       - Example: Scraping 5 product pages? Fork 5 subagents, each visiting one page, then wait for their results."
+         .to_string()
 }
 
 #[cfg(test)]

--- a/crates/crawler/src/prompt.rs
+++ b/crates/crawler/src/prompt.rs
@@ -99,11 +99,16 @@ pub fn build_system_prompt(tool_specs: &[ToolSpec]) -> Vec<String> {
          - Page not loading or navigation error: Verify the URL is correct and \
          complete. Try an alternative URL or search for the page.\n\
          - Login wall, paywall, or CAPTCHA: Call `wait_for_human` with a clear \
-         description of the obstacle. A human will solve it in the browser and \
-         execution will resume automatically. If `wait_for_human` is not available \
-         (non-interactive mode), stop and report the blocker in your final response.\n\
+         description of the obstacle (e.g. \"Login form requires credentials\" or \
+         \"CAPTCHA challenge on checkout page\"). The browser will become visible so \
+         the human can interact with it directly. After the human finishes and \
+         resumes, you will receive the updated page content (URL, title, text) as \
+         the tool result — continue your task using that new page state. \
+         If `wait_for_human` is not available (non-interactive mode), stop and \
+         report the blocker in your final response.\n\
          - Anti-bot detection: Wait briefly (use the `wait` tool) and retry once. \
-         If the obstacle persists, call `wait_for_human` to request human intervention.\n\
+         If the obstacle persists after retrying, call `wait_for_human` to request \
+         human intervention.\n\
          - Empty results on a page expected to have data: Scroll down for \
           lazy-loaded content, wait for dynamic rendering, or check whether the \
           page uses iframes.\n\
@@ -121,7 +126,8 @@ pub fn build_system_prompt(tool_specs: &[ToolSpec]) -> Vec<String> {
           - If any requirement is unmet or uncertain, say so explicitly rather \
           than guessing.\n\
           - If the task is impossible to continue (requires login, payment, or \
-          access you do not have), stop immediately and explain why.\n\
+          access you do not have), call `wait_for_human` if available. Only stop \
+          and explain why if running in non-interactive mode.\n\
           - When providing extracted data, include the source URL and note any \
           gaps or limitations."
              .to_string(),

--- a/crates/crawler/src/prompt.rs
+++ b/crates/crawler/src/prompt.rs
@@ -98,10 +98,12 @@ pub fn build_system_prompt(tool_specs: &[ToolSpec]) -> Vec<String> {
          content, or check for overlays or popups blocking the element.\n\
          - Page not loading or navigation error: Verify the URL is correct and \
          complete. Try an alternative URL or search for the page.\n\
-         - Login wall or paywall: Stop immediately. Report the blocker and provide \
-         any partial results collected so far.\n\
-         - Anti-bot detection or CAPTCHA: Wait briefly and retry once. If it \
-         persists, stop and report the blocker.\n\
+         - Login wall, paywall, or CAPTCHA: Call `wait_for_human` with a clear \
+         description of the obstacle. A human will solve it in the browser and \
+         execution will resume automatically. If `wait_for_human` is not available \
+         (non-interactive mode), stop and report the blocker in your final response.\n\
+         - Anti-bot detection: Wait briefly (use the `wait` tool) and retry once. \
+         If the obstacle persists, call `wait_for_human` to request human intervention.\n\
          - Empty results on a page expected to have data: Scroll down for \
           lazy-loaded content, wait for dynamic rendering, or check whether the \
           page uses iframes.\n\
@@ -111,7 +113,7 @@ pub fn build_system_prompt(tool_specs: &[ToolSpec]) -> Vec<String> {
           click or fill_form fail, but not as a first choice.\n\
          - Popup or overlay blocking interaction: Try pressing Escape or clicking \
          a dismiss button before retrying the intended action."
-            .to_string(),
+             .to_string(),
         // Section 6 — completion protocol
          "Completion:\n\
           - Before reporting success, re-read the original task and confirm each \

--- a/crates/crawler/src/prompt.rs
+++ b/crates/crawler/src/prompt.rs
@@ -52,9 +52,13 @@ pub fn build_system_prompt(tool_specs: &[ToolSpec]) -> Vec<String> {
          including https://.\n\
          3. At each step:\n\
          \x20\x20 a. Observe the current page state from the last tool result.\n\
-         \x20\x20 b. Decide the single best next action.\n\
-         \x20\x20 c. Execute one tool call.\n\
-         \x20\x20 d. Evaluate the result before continuing.\n\
+         \x20\x20 b. Check for blockers: if the page content mentions CAPTCHAs, \
+         \"verify you are human\", \"unusual traffic\", login forms you cannot fill, \
+         paywalls, or access denied messages — immediately call `wait_for_human` \
+         with a description of what you see. Do not retry or work around it.\n\
+         \x20\x20 c. Decide the single best next action.\n\
+         \x20\x20 d. Execute one tool call.\n\
+         \x20\x20 e. Evaluate the result before continuing.\n\
          4. Prefer the simplest reliable action:\n\
           \x20\x20 - Direct navigate over clicking links when the URL is known.\n\
           \x20\x20 - click, fill_form, and scroll before execute_js.\n\
@@ -98,17 +102,21 @@ pub fn build_system_prompt(tool_specs: &[ToolSpec]) -> Vec<String> {
          content, or check for overlays or popups blocking the element.\n\
          - Page not loading or navigation error: Verify the URL is correct and \
          complete. Try an alternative URL or search for the page.\n\
-         - Login wall, paywall, or CAPTCHA: Call `wait_for_human` with a clear \
-         description of the obstacle (e.g. \"Login form requires credentials\" or \
-         \"CAPTCHA challenge on checkout page\"). The browser will become visible so \
+         - CAPTCHA or human verification (e.g. \"verify you are human\", \
+         \"unusual traffic\", reCAPTCHA, hCaptcha, checkbox challenges): \
+         Call `wait_for_human` IMMEDIATELY. Do NOT retry, do NOT try to solve it, \
+         do NOT navigate away. The human will solve it in the visible browser.\n\
+         - Login wall or paywall: Call `wait_for_human` with a clear \
+         description (e.g. \"Login form requires credentials\" or \
+         \"Paywall blocking article content\"). The browser will become visible so \
          the human can interact with it directly. After the human finishes and \
          resumes, you will receive the updated page content (URL, title, text) as \
          the tool result — continue your task using that new page state. \
          If `wait_for_human` is not available (non-interactive mode), stop and \
          report the blocker in your final response.\n\
-         - Anti-bot detection: Wait briefly (use the `wait` tool) and retry once. \
-         If the obstacle persists after retrying, call `wait_for_human` to request \
-         human intervention.\n\
+         - Anti-bot detection (403/429 errors, empty page, \"access denied\"): \
+         Wait briefly (use the `wait` tool) and retry once. \
+         If the obstacle persists after retrying, call `wait_for_human`.\n\
          - Empty results on a page expected to have data: Scroll down for \
           lazy-loaded content, wait for dynamic rendering, or check whether the \
           page uses iframes.\n\

--- a/crates/crawler/src/tool_effect.rs
+++ b/crates/crawler/src/tool_effect.rs
@@ -94,7 +94,9 @@ mod tests {
 
     #[test]
     fn pause_variant_has_reason() {
-        let effect = ToolEffect::Pause { reason: "test reason".to_string() };
+        let effect = ToolEffect::Pause {
+            reason: "test reason".to_string(),
+        };
         match effect {
             ToolEffect::Pause { reason } => assert_eq!(reason, "test reason"),
             _ => panic!("expected Pause variant"),

--- a/crates/crawler/src/tool_effect.rs
+++ b/crates/crawler/src/tool_effect.rs
@@ -9,6 +9,8 @@ pub enum ToolEffect {
     Spawn(ForkSpec),
     /// Tool requests waiting for sub-agents to finish.
     Wait(WaitSpec),
+    /// Tool requests pausing execution for human intervention.
+    Pause { reason: String },
 }
 
 impl ToolEffect {
@@ -88,5 +90,14 @@ mod tests {
         let crawl_err = crate::CrawlError::new("crawl failure");
         let tool_err: ToolError = crawl_err.into();
         assert_eq!(tool_err.to_string(), "crawl failure");
+    }
+
+    #[test]
+    fn pause_variant_has_reason() {
+        let effect = ToolEffect::Pause { reason: "test reason".to_string() };
+        match effect {
+            ToolEffect::Pause { reason } => assert_eq!(reason, "test reason"),
+            _ => panic!("expected Pause variant"),
+        }
     }
 }

--- a/crates/crawler/src/tool_registry.rs
+++ b/crates/crawler/src/tool_registry.rs
@@ -39,6 +39,13 @@ impl ToolRegistry {
 
     #[must_use]
     pub fn new_with_core_tools() -> Self {
+        Self::new_with_options(true)
+    }
+
+    /// Create a registry with all 19 core tools.
+    /// `is_interactive` controls whether `wait_for_human` is allowed to pause.
+    #[must_use]
+    pub fn new_with_options(is_interactive: bool) -> Self {
         let mut registry = Self::new();
         for &name in ASYNC_TOOLS {
             let tool_name = name.to_string();
@@ -58,7 +65,7 @@ impl ToolRegistry {
         );
         registry.register(
             "wait_for_human",
-            Box::new(crate::tools::wait_for_human::execute),
+            Box::new(move |input| crate::tools::wait_for_human::execute(input, is_interactive)),
         );
         registry
     }

--- a/crates/crawler/src/tool_registry.rs
+++ b/crates/crawler/src/tool_registry.rs
@@ -56,6 +56,10 @@ impl ToolRegistry {
             "wait_for_subagents",
             Box::new(crate::tools::wait_for_subagents::execute),
         );
+        registry.register(
+            "wait_for_human",
+            Box::new(crate::tools::wait_for_human::execute),
+        );
         registry
     }
 
@@ -127,10 +131,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn new_with_core_tools_registers_all_eighteen() {
+    fn new_with_core_tools_registers_all_nineteen() {
         let registry = ToolRegistry::new_with_core_tools();
-        let effect_tools = ["fork", "wait_for_subagents"];
-        assert_eq!(registry.len(), 18);
+        let effect_tools = ["fork", "wait_for_subagents", "wait_for_human"];
+        assert_eq!(registry.len(), 19);
         for &name in ASYNC_TOOLS.iter().chain(effect_tools.iter()) {
             assert!(registry.contains(name), "missing core tool: {name}");
         }

--- a/crates/crawler/src/tools/mod.rs
+++ b/crates/crawler/src/tools/mod.rs
@@ -16,4 +16,5 @@ pub mod scroll;
 pub mod select_option;
 pub mod switch_tab;
 pub mod wait;
+pub mod wait_for_human;
 pub mod wait_for_subagents;

--- a/crates/crawler/src/tools/wait_for_human.rs
+++ b/crates/crawler/src/tools/wait_for_human.rs
@@ -1,0 +1,59 @@
+use serde_json::Value;
+
+use crate::{ToolEffect, ToolError};
+
+#[derive(Debug)]
+struct WaitForHumanInput {
+    reason: String,
+}
+
+fn parse_input(input: &Value) -> Result<WaitForHumanInput, crate::CrawlError> {
+    let reason = input
+        .get("reason")
+        .and_then(Value::as_str)
+        .ok_or_else(|| crate::CrawlError::new("missing required field: reason"))?;
+
+    if reason.is_empty() {
+        return Err(crate::CrawlError::new("reason must not be empty"));
+    }
+
+    Ok(WaitForHumanInput {
+        reason: reason.to_string(),
+    })
+}
+
+pub fn execute(input: &Value) -> Result<ToolEffect, ToolError> {
+    let params = parse_input(input)?;
+    // Actual blocking pause/resume logic will be wired in Task 9.
+    // Return Pause effect — dispatch_tool_effect handles it.
+    Ok(ToolEffect::Pause {
+        reason: params.reason,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_valid_reason() {
+        let input = json!({"reason": "captcha detected"});
+        let result = parse_input(&input).unwrap();
+        assert_eq!(result.reason, "captcha detected");
+    }
+
+    #[test]
+    fn parse_missing_reason_returns_error() {
+        let input = json!({});
+        let err = parse_input(&input).unwrap_err();
+        assert!(err.to_string().contains("reason"));
+    }
+
+    #[test]
+    fn parse_empty_reason_returns_error() {
+        let input = json!({"reason": ""});
+        let err = parse_input(&input).unwrap_err();
+        assert!(err.to_string().contains("empty"));
+    }
+}

--- a/crates/crawler/src/tools/wait_for_human.rs
+++ b/crates/crawler/src/tools/wait_for_human.rs
@@ -22,10 +22,15 @@ fn parse_input(input: &Value) -> Result<WaitForHumanInput, crate::CrawlError> {
     })
 }
 
-pub fn execute(input: &Value) -> Result<ToolEffect, ToolError> {
+pub fn execute(input: &Value, is_interactive: bool) -> Result<ToolEffect, ToolError> {
+    if !is_interactive {
+        return Err(ToolError(
+            "wait_for_human is not available in non-interactive mode (one-shot prompt). \
+             Use the TUI or classic REPL for interactive sessions."
+                .to_string(),
+        ));
+    }
     let params = parse_input(input)?;
-    // Actual blocking pause/resume logic will be wired in Task 9.
-    // Return Pause effect — dispatch_tool_effect handles it.
     Ok(ToolEffect::Pause {
         reason: params.reason,
     })
@@ -55,5 +60,26 @@ mod tests {
         let input = json!({"reason": ""});
         let err = parse_input(&input).unwrap_err();
         assert!(err.to_string().contains("empty"));
+    }
+
+    #[test]
+    fn wait_for_human_non_interactive_errors() {
+        let input = json!({"reason": "captcha detected"});
+        let result = super::execute(&input, false);
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("non-interactive"),
+            "expected non-interactive error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn wait_for_human_returns_pause() {
+        let input = json!({"reason": "captcha"});
+        let result = super::execute(&input, true);
+        match result.unwrap() {
+            ToolEffect::Pause { reason } => assert_eq!(reason, "captcha"),
+            other => panic!("expected Pause, got {other:?}"),
+        }
     }
 }

--- a/crates/crawler/src/tools/wait_for_human.rs
+++ b/crates/crawler/src/tools/wait_for_human.rs
@@ -11,6 +11,7 @@ fn parse_input(input: &Value) -> Result<WaitForHumanInput, crate::CrawlError> {
     let reason = input
         .get("reason")
         .and_then(Value::as_str)
+        .map(str::trim)
         .ok_or_else(|| crate::CrawlError::new("missing required field: reason"))?;
 
     if reason.is_empty() {
@@ -81,5 +82,12 @@ mod tests {
             ToolEffect::Pause { reason } => assert_eq!(reason, "captcha"),
             other => panic!("expected Pause, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn parse_whitespace_only_reason_returns_error() {
+        let input = json!({"reason": "   "});
+        let err = parse_input(&input).unwrap_err();
+        assert!(err.to_string().contains("empty"));
     }
 }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -10,7 +10,7 @@ getrandom = "0.2"
 sha2 = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["io-util", "macros", "process", "rt", "rt-multi-thread", "time"] }
+tokio = { version = "1", features = ["io-util", "macros", "process", "rt", "rt-multi-thread", "sync", "time"] }
 
 [lints]
 workspace = true

--- a/crates/runtime/src/control.rs
+++ b/crates/runtime/src/control.rs
@@ -142,13 +142,10 @@ mod tests {
         state.resume();
 
         // The wait task should complete without timeout
-        tokio::time::timeout(
-            tokio::time::Duration::from_secs(1),
-            wait_task,
-        )
-        .await
-        .expect("wait_for_resume should return after resume()")
-        .expect("wait task should not panic");
+        tokio::time::timeout(tokio::time::Duration::from_secs(1), wait_task)
+            .await
+            .expect("wait_for_resume should return after resume()")
+            .expect("wait task should not panic");
     }
 
     #[tokio::test]

--- a/crates/runtime/src/control.rs
+++ b/crates/runtime/src/control.rs
@@ -1,5 +1,5 @@
 use std::sync::atomic::{AtomicU8, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tokio::sync::Notify;
 
 /// Control signal states for the runtime.
@@ -14,6 +14,7 @@ pub const CANCEL: u8 = 2;
 pub struct ControlState {
     signal: AtomicU8,
     resume_notify: Notify,
+    reason: Mutex<String>,
 }
 
 impl ControlState {
@@ -23,11 +24,19 @@ impl ControlState {
         Arc::new(Self {
             signal: AtomicU8::new(CONTINUE),
             resume_notify: Notify::new(),
+            reason: Mutex::new(String::new()),
         })
     }
 
     /// Request a pause. The runtime will pause at the next loop iteration.
     pub fn request_pause(&self) {
+        self.signal.store(PAUSE, Ordering::Release);
+    }
+
+    /// Request a pause with a reason describing why human intervention is needed.
+    pub fn request_pause_with_reason(&self, reason: &str) {
+        *self.reason.lock().unwrap_or_else(std::sync::PoisonError::into_inner) =
+            reason.to_string();
         self.signal.store(PAUSE, Ordering::Release);
     }
 
@@ -45,6 +54,10 @@ impl ControlState {
     /// Reset the control state to `CONTINUE`.
     pub fn reset(&self) {
         self.signal.store(CONTINUE, Ordering::Release);
+        self.reason
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clear();
     }
 
     /// Check if the runtime is paused.
@@ -59,6 +72,15 @@ impl ControlState {
         self.signal.load(Ordering::Acquire) == CANCEL
     }
 
+    /// Get the current pause reason, if any.
+    #[must_use]
+    pub fn pause_reason(&self) -> String {
+        self.reason
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+
     /// Wait for a resume signal. Returns when `resume()` is called.
     pub async fn wait_for_resume(&self) {
         self.resume_notify.notified().await;
@@ -70,6 +92,7 @@ impl Default for ControlState {
         Self {
             signal: AtomicU8::new(CONTINUE),
             resume_notify: Notify::new(),
+            reason: Mutex::new(String::new()),
         }
     }
 }

--- a/crates/runtime/src/control.rs
+++ b/crates/runtime/src/control.rs
@@ -1,0 +1,153 @@
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::Arc;
+use tokio::sync::Notify;
+
+/// Control signal states for the runtime.
+pub const CONTINUE: u8 = 0;
+pub const PAUSE: u8 = 1;
+pub const CANCEL: u8 = 2;
+
+/// Tri-state control signal for managing runtime execution.
+///
+/// Replaces the simple `AtomicBool` cancel flag with a more expressive state machine
+/// that supports pause, cancel, and resume operations.
+pub struct ControlState {
+    signal: AtomicU8,
+    resume_notify: Notify,
+}
+
+impl ControlState {
+    /// Create a new `ControlState` wrapped in an `Arc`.
+    #[must_use]
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            signal: AtomicU8::new(CONTINUE),
+            resume_notify: Notify::new(),
+        })
+    }
+
+    /// Request a pause. The runtime will pause at the next loop iteration.
+    pub fn request_pause(&self) {
+        self.signal.store(PAUSE, Ordering::Release);
+    }
+
+    /// Request cancellation. The runtime will cancel at the next loop iteration.
+    pub fn request_cancel(&self) {
+        self.signal.store(CANCEL, Ordering::Release);
+    }
+
+    /// Resume from a paused state and clear the pause signal.
+    pub fn resume(&self) {
+        self.signal.store(CONTINUE, Ordering::Release);
+        self.resume_notify.notify_waiters();
+    }
+
+    /// Reset the control state to `CONTINUE`.
+    pub fn reset(&self) {
+        self.signal.store(CONTINUE, Ordering::Release);
+    }
+
+    /// Check if the runtime is paused.
+    #[must_use]
+    pub fn is_paused(&self) -> bool {
+        self.signal.load(Ordering::Acquire) == PAUSE
+    }
+
+    /// Check if the runtime is cancelled.
+    #[must_use]
+    pub fn is_cancelled(&self) -> bool {
+        self.signal.load(Ordering::Acquire) == CANCEL
+    }
+
+    /// Wait for a resume signal. Returns when `resume()` is called.
+    pub async fn wait_for_resume(&self) {
+        self.resume_notify.notified().await;
+    }
+}
+
+impl Default for ControlState {
+    fn default() -> Self {
+        Self {
+            signal: AtomicU8::new(CONTINUE),
+            resume_notify: Notify::new(),
+        }
+    }
+}
+
+// ControlState is Send + Sync because:
+// - AtomicU8 is Send + Sync
+// - Notify is Send + Sync
+// This is verified by the compiler automatically.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn control_state_starts_in_continue() {
+        let state = ControlState::default();
+        assert!(!state.is_paused());
+        assert!(!state.is_cancelled());
+    }
+
+    #[test]
+    fn request_pause_sets_paused() {
+        let state = ControlState::default();
+        state.request_pause();
+        assert!(state.is_paused());
+        assert!(!state.is_cancelled());
+    }
+
+    #[test]
+    fn request_cancel_sets_cancelled() {
+        let state = ControlState::default();
+        state.request_cancel();
+        assert!(state.is_cancelled());
+        assert!(!state.is_paused());
+    }
+
+    #[test]
+    fn resume_clears_pause() {
+        let state = ControlState::default();
+        state.request_pause();
+        assert!(state.is_paused());
+        state.resume();
+        assert!(!state.is_paused());
+        assert!(!state.is_cancelled());
+    }
+
+    #[test]
+    fn reset_clears_cancel() {
+        let state = ControlState::default();
+        state.request_cancel();
+        assert!(state.is_cancelled());
+        state.reset();
+        assert!(!state.is_cancelled());
+        assert!(!state.is_paused());
+    }
+
+    #[tokio::test]
+    async fn wait_for_resume_returns_after_resume() {
+        let state = Arc::new(ControlState::default());
+        let state_clone = Arc::clone(&state);
+
+        let wait_task = tokio::spawn(async move {
+            state_clone.wait_for_resume().await;
+        });
+
+        // Give the wait task time to start waiting
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+
+        // Resume should wake up the waiter
+        state.resume();
+
+        // The wait task should complete without timeout
+        tokio::time::timeout(
+            tokio::time::Duration::from_secs(1),
+            wait_task,
+        )
+        .await
+        .expect("wait_for_resume should return after resume()")
+        .expect("wait task should not panic");
+    }
+}

--- a/crates/runtime/src/control.rs
+++ b/crates/runtime/src/control.rs
@@ -150,4 +150,60 @@ mod tests {
         .expect("wait_for_resume should return after resume()")
         .expect("wait task should not panic");
     }
+
+    #[tokio::test]
+    async fn check_pause_blocks_with_measurable_delay() {
+        use tokio::time::{sleep, Duration};
+
+        let state = Arc::new(ControlState::default());
+        let state_clone = Arc::clone(&state);
+
+        state.request_pause();
+
+        // Resume after 150ms
+        tokio::spawn(async move {
+            sleep(Duration::from_millis(150)).await;
+            state_clone.resume();
+        });
+
+        let start = std::time::Instant::now();
+        state.wait_for_resume().await;
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed >= Duration::from_millis(100),
+            "should have blocked for at least 100ms, got {elapsed:?}"
+        );
+        assert!(!state.is_paused());
+    }
+
+    #[tokio::test]
+    async fn cancel_during_pause_no_deadlock() {
+        use tokio::time::{sleep, timeout, Duration};
+
+        let state = Arc::new(ControlState::default());
+        let state_clone = Arc::clone(&state);
+
+        state.request_pause();
+
+        tokio::spawn(async move {
+            sleep(Duration::from_millis(100)).await;
+            state_clone.request_cancel();
+        });
+
+        let result = timeout(Duration::from_secs(2), async {
+            loop {
+                tokio::select! {
+                    () = state.wait_for_resume() => { break; }
+                    () = sleep(Duration::from_millis(50)) => {
+                        if state.is_cancelled() { break; }
+                    }
+                }
+            }
+        })
+        .await;
+
+        assert!(result.is_ok(), "should not timeout — no deadlock");
+        assert!(state.is_cancelled());
+    }
 }

--- a/crates/runtime/src/control.rs
+++ b/crates/runtime/src/control.rs
@@ -35,8 +35,10 @@ impl ControlState {
 
     /// Request a pause with a reason describing why human intervention is needed.
     pub fn request_pause_with_reason(&self, reason: &str) {
-        *self.reason.lock().unwrap_or_else(std::sync::PoisonError::into_inner) =
-            reason.to_string();
+        *self
+            .reason
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = reason.to_string();
         self.signal.store(PAUSE, Ordering::Release);
     }
 

--- a/crates/runtime/src/conversation.rs
+++ b/crates/runtime/src/conversation.rs
@@ -10,6 +10,7 @@ use crate::control::ControlState;
 use crate::observer::RuntimeObserver;
 use crate::session::{ContentBlock, ConversationMessage, Session};
 use crate::usage::{TokenUsage, UsageTracker};
+use tokio::time::{sleep, Duration};
 
 const DEFAULT_AUTO_COMPACTION_INPUT_TOKENS_THRESHOLD: u32 = 200_000;
 
@@ -168,6 +169,10 @@ where
         self
     }
 
+    pub fn set_observer(&mut self, observer: Box<dyn RuntimeObserver + Send>) {
+        self.observer = Some(observer);
+    }
+
     #[must_use]
     pub fn with_auto_compaction_input_tokens_threshold(mut self, threshold: u32) -> Self {
         self.auto_compaction_input_tokens_threshold = threshold;
@@ -192,6 +197,41 @@ where
         self.control_state.request_cancel();
     }
 
+    async fn check_pause(&mut self) -> Result<(), RuntimeError> {
+        if !self.control_state.is_paused() {
+            return Ok(());
+        }
+
+        if let Some(ref mut observer) = self.observer {
+            observer.on_pause_started("Paused by user");
+        }
+
+        loop {
+            tokio::select! {
+                _ = self.control_state.wait_for_resume() => {
+                    break;
+                }
+                _ = sleep(Duration::from_millis(100)) => {
+                    if self.control_state.is_cancelled() {
+                        break;
+                    }
+                }
+            }
+        }
+
+        if let Some(ref mut observer) = self.observer {
+            observer.on_pause_ended();
+        }
+
+        if self.control_state.is_cancelled() {
+            self.control_state.reset();
+            return Err(RuntimeError::new("interrupted by user"));
+        }
+
+        self.control_state.reset();
+        Ok(())
+    }
+
     #[allow(clippy::too_many_lines)]
     pub async fn run_turn(
         &mut self,
@@ -211,6 +251,8 @@ where
                     self.control_state.reset();
                     return Err(RuntimeError::new("interrupted by user"));
                 }
+
+                self.check_pause().await?;
 
                 iterations += 1;
                 if iterations > self.max_iterations {
@@ -261,6 +303,8 @@ where
                     self.session.messages.push(result_message.clone());
                     tool_results.push(result_message);
                 }
+
+                self.check_pause().await?;
             }
 
             let auto_compaction = self.maybe_auto_compact();
@@ -492,11 +536,15 @@ mod tests {
         AutoCompactionEvent, ConversationRuntime, RuntimeError, StaticToolExecutor,
         DEFAULT_AUTO_COMPACTION_INPUT_TOKENS_THRESHOLD,
     };
+    use crate::observer::RuntimeObserver;
     use crate::compact::CompactionConfig;
     use crate::prompt::{ProjectContext, SystemPromptBuilder};
     use crate::session::{ContentBlock, MessageRole, Session};
     use crate::usage::TokenUsage;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
     use std::path::PathBuf;
+    use tokio::time::{timeout, Duration};
 
     struct ScriptedApiClient {
         call_count: usize,
@@ -798,5 +846,150 @@ mod tests {
             ContentBlock::Reasoning { data } if data == r#"{"id":"rs_123","content":[]}"#
         ));
         assert!(matches!(&message.blocks[1], ContentBlock::Text { text } if text == "answer"));
+    }
+
+    struct SingleReplyApiClient {
+        call_count: Arc<AtomicUsize>,
+    }
+
+    impl ApiClient for SingleReplyApiClient {
+        fn stream(&mut self, _request: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            Ok(vec![
+                AssistantEvent::TextDelta("done".to_string()),
+                AssistantEvent::MessageStop,
+            ])
+        }
+    }
+
+    #[derive(Debug, Default, PartialEq, Eq)]
+    struct PauseObserverState {
+        events: Vec<String>,
+    }
+
+    struct PauseRecordingObserver {
+        state: Arc<Mutex<PauseObserverState>>,
+    }
+
+    impl PauseRecordingObserver {
+        fn new(state: Arc<Mutex<PauseObserverState>>) -> Self {
+            Self { state }
+        }
+    }
+
+    impl RuntimeObserver for PauseRecordingObserver {
+        fn on_pause_started(&mut self, reason: &str) {
+            self.state
+                .lock()
+                .expect("pause observer state lock")
+                .events
+                .push(format!("started:{reason}"));
+        }
+
+        fn on_pause_ended(&mut self) {
+            self.state
+                .lock()
+                .expect("pause observer state lock")
+                .events
+                .push("ended".to_string());
+        }
+    }
+
+    #[tokio::test]
+    async fn pause_and_resume() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let mut runtime = ConversationRuntime::new(
+            Session::new(),
+            SingleReplyApiClient {
+                call_count: Arc::clone(&call_count),
+            },
+            StaticToolExecutor::new(),
+            vec!["system".to_string()],
+        );
+        let control = runtime.control_state();
+        control.request_pause();
+
+        let run_turn = runtime.run_turn("hello");
+        tokio::pin!(run_turn);
+
+        assert!(timeout(Duration::from_millis(50), &mut run_turn).await.is_err());
+        assert_eq!(call_count.load(Ordering::SeqCst), 0);
+
+        control.resume();
+
+        let summary = timeout(Duration::from_secs(1), &mut run_turn)
+            .await
+            .expect("run_turn should complete after resume")
+            .expect("turn should succeed");
+        assert_eq!(summary.iterations, 1);
+        assert_eq!(call_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn cancel_during_pause() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let mut runtime = ConversationRuntime::new(
+            Session::new(),
+            SingleReplyApiClient {
+                call_count: Arc::clone(&call_count),
+            },
+            StaticToolExecutor::new(),
+            vec!["system".to_string()],
+        );
+        let control = runtime.control_state();
+        control.request_pause();
+
+        let run_turn = runtime.run_turn("hello");
+        tokio::pin!(run_turn);
+
+        assert!(timeout(Duration::from_millis(50), &mut run_turn).await.is_err());
+        control.request_cancel();
+
+        let error = timeout(Duration::from_secs(1), &mut run_turn)
+            .await
+            .expect("run_turn should exit after cancel")
+            .expect_err("turn should be interrupted");
+        assert_eq!(error.to_string(), "interrupted by user");
+        assert_eq!(call_count.load(Ordering::SeqCst), 0);
+        assert!(!control.is_paused());
+        assert!(!control.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn pause_observer_events() {
+        let state = Arc::new(Mutex::new(PauseObserverState::default()));
+        let observer = PauseRecordingObserver::new(Arc::clone(&state));
+        let mut runtime = ConversationRuntime::new(
+            Session::new(),
+            SingleReplyApiClient {
+                call_count: Arc::new(AtomicUsize::new(0)),
+            },
+            StaticToolExecutor::new(),
+            vec!["system".to_string()],
+        )
+        .with_observer(Box::new(observer));
+        let control = runtime.control_state();
+        control.request_pause();
+
+        let run_turn = runtime.run_turn("hello");
+        tokio::pin!(run_turn);
+
+        assert!(timeout(Duration::from_millis(50), &mut run_turn).await.is_err());
+        assert_eq!(
+            state.lock().expect("pause observer state lock").events,
+            vec!["started:Paused by user".to_string()]
+        );
+
+        control.resume();
+
+        timeout(Duration::from_secs(1), &mut run_turn)
+            .await
+            .expect("run_turn should complete after resume")
+            .expect("turn should succeed");
+
+        assert_eq!(
+            state.lock().expect("pause observer state lock").events,
+            vec!["started:Paused by user".to_string(), "ended".to_string()]
+        );
     }
 }

--- a/crates/runtime/src/conversation.rs
+++ b/crates/runtime/src/conversation.rs
@@ -218,7 +218,7 @@ where
                     break;
                 }
                 () = sleep(Duration::from_millis(100)) => {
-                    if self.control_state.is_cancelled() {
+                    if !self.control_state.is_paused() {
                         break;
                     }
                 }

--- a/crates/runtime/src/conversation.rs
+++ b/crates/runtime/src/conversation.rs
@@ -998,4 +998,216 @@ mod tests {
             vec!["started:Paused by user".to_string(), "ended".to_string()]
         );
     }
+
+    #[tokio::test]
+    async fn llm_triggered_pause_via_tool_executor() {
+        use crate::control::ControlState;
+
+        struct PauseToolApiClient {
+            call_count: Arc<AtomicUsize>,
+        }
+
+        impl ApiClient for PauseToolApiClient {
+            fn stream(&mut self, _request: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
+                let n = self.call_count.fetch_add(1, Ordering::SeqCst);
+                match n {
+                    0 => Ok(vec![
+                        AssistantEvent::ToolUse {
+                            id: "tool-pause".to_string(),
+                            name: "wait_for_human".to_string(),
+                            input: r#"{"reason":"captcha"}"#.to_string(),
+                        },
+                        AssistantEvent::MessageStop,
+                    ]),
+                    1 => Ok(vec![
+                        AssistantEvent::TextDelta("Resumed.".to_string()),
+                        AssistantEvent::MessageStop,
+                    ]),
+                    _ => Err(RuntimeError::new("unexpected extra API call")),
+                }
+            }
+        }
+
+        let shared_control = Arc::new(ControlState::default());
+        let control_for_executor = Arc::clone(&shared_control);
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let call_count_clone = Arc::clone(&call_count);
+
+        let tool_executor = {
+            let control = Arc::clone(&control_for_executor);
+            StaticToolExecutor::new().register("wait_for_human", move |_input| {
+                control.request_pause();
+                Ok("Human intervention requested: captcha".to_string())
+            })
+        };
+
+        let mut runtime = ConversationRuntime::new(
+            Session::new(),
+            PauseToolApiClient {
+                call_count: call_count_clone,
+            },
+            tool_executor,
+            vec!["system".to_string()],
+        )
+        .with_control_state(Arc::clone(&shared_control));
+
+        let control_for_resume = Arc::clone(&shared_control);
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            control_for_resume.resume();
+        });
+
+        let summary = timeout(Duration::from_secs(2), runtime.run_turn("solve captcha"))
+            .await
+            .expect("should not deadlock")
+            .expect("turn should succeed after resume");
+
+        assert_eq!(summary.iterations, 2);
+        assert_eq!(call_count.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn hotkey_pause_mid_turn_between_iterations() {
+        use crate::control::ControlState;
+
+        struct MultiStepApiClient {
+            call_count: Arc<AtomicUsize>,
+        }
+
+        impl ApiClient for MultiStepApiClient {
+            fn stream(&mut self, _request: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
+                let n = self.call_count.fetch_add(1, Ordering::SeqCst);
+                match n {
+                    0 => Ok(vec![
+                        AssistantEvent::ToolUse {
+                            id: "tool-1".to_string(),
+                            name: "noop".to_string(),
+                            input: "{}".to_string(),
+                        },
+                        AssistantEvent::MessageStop,
+                    ]),
+                    1 => Ok(vec![
+                        AssistantEvent::TextDelta("done".to_string()),
+                        AssistantEvent::MessageStop,
+                    ]),
+                    _ => Err(RuntimeError::new("unexpected extra API call")),
+                }
+            }
+        }
+
+        let shared_control = Arc::new(ControlState::default());
+        let call_count = Arc::new(AtomicUsize::new(0));
+
+        let control_for_pause = Arc::clone(&shared_control);
+        let tool_executor = StaticToolExecutor::new().register("noop", move |_| {
+            control_for_pause.request_pause();
+            Ok("ok".to_string())
+        });
+
+        let mut runtime = ConversationRuntime::new(
+            Session::new(),
+            MultiStepApiClient {
+                call_count: Arc::clone(&call_count),
+            },
+            tool_executor,
+            vec!["system".to_string()],
+        )
+        .with_control_state(Arc::clone(&shared_control));
+
+        let control_for_resume = Arc::clone(&shared_control);
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            control_for_resume.resume();
+        });
+
+        let run_turn = runtime.run_turn("do it");
+        tokio::pin!(run_turn);
+
+        assert!(
+            timeout(Duration::from_millis(100), &mut run_turn).await.is_err(),
+            "should be blocked during pause"
+        );
+        assert_eq!(call_count.load(Ordering::SeqCst), 1);
+
+        let summary = timeout(Duration::from_secs(2), &mut run_turn)
+            .await
+            .expect("should complete after resume")
+            .expect("turn should succeed");
+
+        assert_eq!(summary.iterations, 2);
+        assert_eq!(call_count.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn multiple_pause_resume_cycles_complete() {
+        use crate::control::ControlState;
+
+        struct ThreeStepApiClient {
+            call_count: Arc<AtomicUsize>,
+        }
+
+        impl ApiClient for ThreeStepApiClient {
+            fn stream(&mut self, _request: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
+                let n = self.call_count.fetch_add(1, Ordering::SeqCst);
+                match n {
+                    0 | 1 => Ok(vec![
+                        AssistantEvent::ToolUse {
+                            id: format!("tool-{n}"),
+                            name: "pause_tool".to_string(),
+                            input: "{}".to_string(),
+                        },
+                        AssistantEvent::MessageStop,
+                    ]),
+                    2 => Ok(vec![
+                        AssistantEvent::TextDelta("all done".to_string()),
+                        AssistantEvent::MessageStop,
+                    ]),
+                    _ => Err(RuntimeError::new("unexpected extra API call")),
+                }
+            }
+        }
+
+        let shared_control = Arc::new(ControlState::default());
+        let cycle_count = Arc::new(AtomicUsize::new(0));
+
+        let cycle_count_clone = Arc::clone(&cycle_count);
+        let control_for_tool = Arc::clone(&shared_control);
+        let tool_executor = StaticToolExecutor::new().register("pause_tool", move |_| {
+            cycle_count_clone.fetch_add(1, Ordering::SeqCst);
+            control_for_tool.request_pause();
+            Ok("paused".to_string())
+        });
+
+        let mut runtime = ConversationRuntime::new(
+            Session::new(),
+            ThreeStepApiClient {
+                call_count: Arc::new(AtomicUsize::new(0)),
+            },
+            tool_executor,
+            vec!["system".to_string()],
+        )
+        .with_control_state(Arc::clone(&shared_control));
+
+        let control_for_resume = Arc::clone(&shared_control);
+        tokio::spawn(async move {
+            for _ in 0..2 {
+                loop {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    if control_for_resume.is_paused() {
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                        control_for_resume.resume();
+                        break;
+                    }
+                }
+            }
+        });
+
+        let summary = timeout(Duration::from_secs(3), runtime.run_turn("multi-pause"))
+            .await
+            .expect("should not deadlock after multiple cycles")
+            .expect("turn should succeed");
+
+        assert_eq!(summary.iterations, 3);
+        assert_eq!(cycle_count.load(Ordering::SeqCst), 2);
+    }
 }

--- a/crates/runtime/src/conversation.rs
+++ b/crates/runtime/src/conversation.rs
@@ -1,12 +1,12 @@
 use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use crate::compact::{
     compact_session, estimate_session_tokens, CompactionConfig, CompactionResult,
 };
 use crate::config::RuntimeFeatureConfig;
+use crate::control::ControlState;
 use crate::observer::RuntimeObserver;
 use crate::session::{ContentBlock, ConversationMessage, Session};
 use crate::usage::{TokenUsage, UsageTracker};
@@ -110,7 +110,7 @@ pub struct ConversationRuntime<C, T> {
     max_iterations: usize,
     usage_tracker: UsageTracker,
     auto_compaction_input_tokens_threshold: u32,
-    cancel_flag: Arc<AtomicBool>,
+    control_state: Arc<ControlState>,
 }
 
 impl<C, T> ConversationRuntime<C, T>
@@ -152,7 +152,7 @@ where
             max_iterations: usize::MAX,
             usage_tracker,
             auto_compaction_input_tokens_threshold: auto_compaction_threshold_from_env(),
-            cancel_flag: Arc::new(AtomicBool::new(false)),
+            control_state: Arc::new(ControlState::default()),
         }
     }
 
@@ -175,8 +175,13 @@ where
     }
 
     #[must_use]
-    pub fn cancel_flag(&self) -> Arc<AtomicBool> {
-        Arc::clone(&self.cancel_flag)
+    pub fn control_state(&self) -> Arc<ControlState> {
+        Arc::clone(&self.control_state)
+    }
+
+    #[must_use]
+    pub fn cancel_flag(&self) -> Arc<ControlState> {
+        self.control_state()
     }
 
     pub fn api_client_mut(&mut self) -> &mut C {
@@ -184,7 +189,7 @@ where
     }
 
     pub fn request_cancel(&self) {
-        self.cancel_flag.store(true, Ordering::Release);
+        self.control_state.request_cancel();
     }
 
     #[allow(clippy::too_many_lines)]
@@ -202,8 +207,8 @@ where
             let mut iterations = 0;
 
             loop {
-                if self.cancel_flag.load(Ordering::Acquire) {
-                    self.cancel_flag.store(false, Ordering::Release);
+                if self.control_state.is_cancelled() {
+                    self.control_state.reset();
                     return Err(RuntimeError::new("interrupted by user"));
                 }
 

--- a/crates/runtime/src/conversation.rs
+++ b/crates/runtime/src/conversation.rs
@@ -1227,4 +1227,132 @@ mod tests {
         assert_eq!(summary.iterations, 3);
         assert_eq!(cycle_count.load(Ordering::SeqCst), 2);
     }
+
+    #[tokio::test]
+    async fn cancel_during_tool_triggered_pause() {
+        use crate::control::ControlState;
+
+        struct PauseToolApiClient {
+            call_count: Arc<AtomicUsize>,
+        }
+
+        impl ApiClient for PauseToolApiClient {
+            fn stream(
+                &mut self,
+                _request: ApiRequest,
+            ) -> Result<Vec<AssistantEvent>, RuntimeError> {
+                let n = self.call_count.fetch_add(1, Ordering::SeqCst);
+                match n {
+                    0 => Ok(vec![
+                        AssistantEvent::ToolUse {
+                            id: "tool-pause".to_string(),
+                            name: "wait_for_human".to_string(),
+                            input: r#"{"reason":"captcha"}"#.to_string(),
+                        },
+                        AssistantEvent::MessageStop,
+                    ]),
+                    _ => Err(RuntimeError::new("should not reach second API call")),
+                }
+            }
+        }
+
+        let shared_control = Arc::new(ControlState::default());
+        let call_count = Arc::new(AtomicUsize::new(0));
+
+        let control_for_tool = Arc::clone(&shared_control);
+        let tool_executor = StaticToolExecutor::new().register("wait_for_human", move |_| {
+            control_for_tool.request_pause();
+            Ok("paused".to_string())
+        });
+
+        let mut runtime = ConversationRuntime::new(
+            Session::new(),
+            PauseToolApiClient {
+                call_count: Arc::clone(&call_count),
+            },
+            tool_executor,
+            vec!["system".to_string()],
+        )
+        .with_control_state(Arc::clone(&shared_control));
+
+        let control_for_cancel = Arc::clone(&shared_control);
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                if control_for_cancel.is_paused() {
+                    control_for_cancel.request_cancel();
+                    break;
+                }
+            }
+        });
+
+        let error = timeout(Duration::from_secs(2), runtime.run_turn("solve captcha"))
+            .await
+            .expect("should not deadlock")
+            .expect_err("turn should be interrupted");
+
+        assert_eq!(error.to_string(), "interrupted by user");
+        assert_eq!(call_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn fast_resume_no_lost_wakeup() {
+        use crate::control::ControlState;
+
+        let shared_control = Arc::new(ControlState::default());
+        let call_count = Arc::new(AtomicUsize::new(0));
+
+        let control_for_tool = Arc::clone(&shared_control);
+        let tool_executor = StaticToolExecutor::new().register("pause_tool", move |_| {
+            control_for_tool.request_pause();
+            control_for_tool.resume();
+            Ok("instant-resumed".to_string())
+        });
+
+        struct TwoStepApiClient {
+            call_count: Arc<AtomicUsize>,
+        }
+
+        impl ApiClient for TwoStepApiClient {
+            fn stream(
+                &mut self,
+                _request: ApiRequest,
+            ) -> Result<Vec<AssistantEvent>, RuntimeError> {
+                let n = self.call_count.fetch_add(1, Ordering::SeqCst);
+                match n {
+                    0 => Ok(vec![
+                        AssistantEvent::ToolUse {
+                            id: "tool-1".to_string(),
+                            name: "pause_tool".to_string(),
+                            input: "{}".to_string(),
+                        },
+                        AssistantEvent::MessageStop,
+                    ]),
+                    1 => Ok(vec![
+                        AssistantEvent::TextDelta("done".to_string()),
+                        AssistantEvent::MessageStop,
+                    ]),
+                    _ => Err(RuntimeError::new("unexpected extra API call")),
+                }
+            }
+        }
+
+        let mut runtime = ConversationRuntime::new(
+            Session::new(),
+            TwoStepApiClient {
+                call_count: Arc::clone(&call_count),
+            },
+            tool_executor,
+            vec!["system".to_string()],
+        )
+        .with_control_state(Arc::clone(&shared_control));
+
+        let summary = timeout(Duration::from_secs(2), runtime.run_turn("fast resume"))
+            .await
+            .expect("must not hang due to lost wakeup")
+            .expect("turn should succeed");
+
+        assert_eq!(summary.iterations, 2);
+        assert_eq!(call_count.load(Ordering::SeqCst), 2);
+    }
 }

--- a/crates/runtime/src/conversation.rs
+++ b/crates/runtime/src/conversation.rs
@@ -208,10 +208,10 @@ where
 
         loop {
             tokio::select! {
-                _ = self.control_state.wait_for_resume() => {
+                () = self.control_state.wait_for_resume() => {
                     break;
                 }
-                _ = sleep(Duration::from_millis(100)) => {
+                () = sleep(Duration::from_millis(100)) => {
                     if self.control_state.is_cancelled() {
                         break;
                     }

--- a/crates/runtime/src/conversation.rs
+++ b/crates/runtime/src/conversation.rs
@@ -1299,16 +1299,6 @@ mod tests {
     async fn fast_resume_no_lost_wakeup() {
         use crate::control::ControlState;
 
-        let shared_control = Arc::new(ControlState::default());
-        let call_count = Arc::new(AtomicUsize::new(0));
-
-        let control_for_tool = Arc::clone(&shared_control);
-        let tool_executor = StaticToolExecutor::new().register("pause_tool", move |_| {
-            control_for_tool.request_pause();
-            control_for_tool.resume();
-            Ok("instant-resumed".to_string())
-        });
-
         struct TwoStepApiClient {
             call_count: Arc<AtomicUsize>,
         }
@@ -1336,6 +1326,16 @@ mod tests {
                 }
             }
         }
+
+        let shared_control = Arc::new(ControlState::default());
+        let call_count = Arc::new(AtomicUsize::new(0));
+
+        let control_for_tool = Arc::clone(&shared_control);
+        let tool_executor = StaticToolExecutor::new().register("pause_tool", move |_| {
+            control_for_tool.request_pause();
+            control_for_tool.resume();
+            Ok("instant-resumed".to_string())
+        });
 
         let mut runtime = ConversationRuntime::new(
             Session::new(),

--- a/crates/runtime/src/conversation.rs
+++ b/crates/runtime/src/conversation.rs
@@ -180,6 +180,12 @@ where
     }
 
     #[must_use]
+    pub fn with_control_state(mut self, state: Arc<ControlState>) -> Self {
+        self.control_state = state;
+        self
+    }
+
+    #[must_use]
     pub fn control_state(&self) -> Arc<ControlState> {
         Arc::clone(&self.control_state)
     }

--- a/crates/runtime/src/conversation.rs
+++ b/crates/runtime/src/conversation.rs
@@ -542,14 +542,14 @@ mod tests {
         AutoCompactionEvent, ConversationRuntime, RuntimeError, StaticToolExecutor,
         DEFAULT_AUTO_COMPACTION_INPUT_TOKENS_THRESHOLD,
     };
-    use crate::observer::RuntimeObserver;
     use crate::compact::CompactionConfig;
+    use crate::observer::RuntimeObserver;
     use crate::prompt::{ProjectContext, SystemPromptBuilder};
     use crate::session::{ContentBlock, MessageRole, Session};
     use crate::usage::TokenUsage;
+    use std::path::PathBuf;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
-    use std::path::PathBuf;
     use tokio::time::{timeout, Duration};
 
     struct ScriptedApiClient {
@@ -918,7 +918,9 @@ mod tests {
         let run_turn = runtime.run_turn("hello");
         tokio::pin!(run_turn);
 
-        assert!(timeout(Duration::from_millis(50), &mut run_turn).await.is_err());
+        assert!(timeout(Duration::from_millis(50), &mut run_turn)
+            .await
+            .is_err());
         assert_eq!(call_count.load(Ordering::SeqCst), 0);
 
         control.resume();
@@ -948,7 +950,9 @@ mod tests {
         let run_turn = runtime.run_turn("hello");
         tokio::pin!(run_turn);
 
-        assert!(timeout(Duration::from_millis(50), &mut run_turn).await.is_err());
+        assert!(timeout(Duration::from_millis(50), &mut run_turn)
+            .await
+            .is_err());
         control.request_cancel();
 
         let error = timeout(Duration::from_secs(1), &mut run_turn)
@@ -980,7 +984,9 @@ mod tests {
         let run_turn = runtime.run_turn("hello");
         tokio::pin!(run_turn);
 
-        assert!(timeout(Duration::from_millis(50), &mut run_turn).await.is_err());
+        assert!(timeout(Duration::from_millis(50), &mut run_turn)
+            .await
+            .is_err());
         assert_eq!(
             state.lock().expect("pause observer state lock").events,
             vec!["started:Paused by user".to_string()]
@@ -1008,7 +1014,10 @@ mod tests {
         }
 
         impl ApiClient for PauseToolApiClient {
-            fn stream(&mut self, _request: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
+            fn stream(
+                &mut self,
+                _request: ApiRequest,
+            ) -> Result<Vec<AssistantEvent>, RuntimeError> {
                 let n = self.call_count.fetch_add(1, Ordering::SeqCst);
                 match n {
                     0 => Ok(vec![
@@ -1075,7 +1084,10 @@ mod tests {
         }
 
         impl ApiClient for MultiStepApiClient {
-            fn stream(&mut self, _request: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
+            fn stream(
+                &mut self,
+                _request: ApiRequest,
+            ) -> Result<Vec<AssistantEvent>, RuntimeError> {
                 let n = self.call_count.fetch_add(1, Ordering::SeqCst);
                 match n {
                     0 => Ok(vec![
@@ -1124,7 +1136,9 @@ mod tests {
         tokio::pin!(run_turn);
 
         assert!(
-            timeout(Duration::from_millis(100), &mut run_turn).await.is_err(),
+            timeout(Duration::from_millis(100), &mut run_turn)
+                .await
+                .is_err(),
             "should be blocked during pause"
         );
         assert_eq!(call_count.load(Ordering::SeqCst), 1);
@@ -1147,7 +1161,10 @@ mod tests {
         }
 
         impl ApiClient for ThreeStepApiClient {
-            fn stream(&mut self, _request: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
+            fn stream(
+                &mut self,
+                _request: ApiRequest,
+            ) -> Result<Vec<AssistantEvent>, RuntimeError> {
                 let n = self.call_count.fetch_add(1, Ordering::SeqCst);
                 match n {
                     0 | 1 => Ok(vec![

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1,6 +1,7 @@
 mod bootstrap;
 mod compact;
 mod config;
+mod control;
 mod conversation;
 mod json;
 mod mcp;
@@ -24,6 +25,7 @@ pub use config::{
     McpServerConfig, McpStdioServerConfig, McpTransport, McpWebSocketServerConfig, OAuthConfig,
     RuntimeConfig, RuntimeFeatureConfig, ScopedMcpServerConfig, ACRAWL_SETTINGS_SCHEMA_NAME,
 };
+pub use control::ControlState;
 pub use conversation::{
     auto_compaction_threshold_from_env, ApiClient, ApiRequest, AssistantEvent, AutoCompactionEvent,
     ConversationRuntime, RuntimeError, StaticToolExecutor, ToolError, ToolExecutor, TurnSummary,

--- a/crates/runtime/src/observer.rs
+++ b/crates/runtime/src/observer.rs
@@ -7,6 +7,12 @@ pub trait RuntimeObserver: Send {
         let _ = text;
     }
 
+    fn on_pause_started(&mut self, reason: &str) {
+        let _ = reason;
+    }
+
+    fn on_pause_ended(&mut self) {}
+
     fn on_tool_call_start(&mut self, id: &str, name: &str, input: &str) {
         let _ = (id, name, input);
     }
@@ -98,6 +104,14 @@ mod tests {
                 .usages
                 .push(*usage);
         }
+
+        fn on_pause_started(&mut self, _reason: &str) {
+            // No-op for test observer
+        }
+
+        fn on_pause_ended(&mut self) {
+            // No-op for test observer
+        }
     }
 
     struct NoOpObserver;
@@ -108,6 +122,8 @@ mod tests {
     fn test_no_op_observer_compiles() {
         let mut observer = NoOpObserver;
         observer.on_text_delta("hello");
+        observer.on_pause_started("Paused by user");
+        observer.on_pause_ended();
         observer.on_tool_call_start("tool-1", "add", "2,2");
         observer.on_tool_result("add", "4", false);
         observer.on_system_message("system");


### PR DESCRIPTION
## Summary

Adds a structured pause/resume mechanism so humans can intervene when the crawler hits obstacles (CAPTCHAs, logins, paywalls). Both the LLM agent (via `wait_for_human` tool) and the user (via `p` hotkey) can trigger a pause; the browser auto-switches to headed mode; human solves the problem; agent auto-reads the page and resumes.

## What's new

- **`wait_for_human` tool** (tool count 18 -> 19) -- LLM calls this when it detects a CAPTCHA, login wall, or paywall
- **Tri-state `ControlState`** (`CONTINUE`/`PAUSE`/`CANCEL`) replaces the old `AtomicBool` cancel flag
- **TUI `p` hotkey** -- user can pause mid-crawl; amber PAUSED status bar with Enter-to-resume
- **Classic REPL** -- prints pause message, blocks on stdin Enter, then resumes
- **Auto headless->headed switch** -- browser becomes visible on pause (cookies/URL preserved)
- **Auto page re-read on resume** -- agent receives fresh `{ page_url, page_title, page_content }` after human finishes
- **Non-interactive guard** -- `wait_for_human` errors in one-shot `prompt` mode
- **Sub-agent guard** -- cannot pause while child agents are active (shared bridge)
- **Proactive CAPTCHA recognition** -- system prompt step 3b checks every page result for blockers

## Architecture

```
LLM calls wait_for_human
  -> ToolEffect::Pause { reason }
  -> handle_pause():
      1. pause_browser_switch() -- export cookies, set HEADLESS=false, relaunch, restore
      2. control_state.request_pause()
      3. Block (tokio::select! loop polling cancel + Notify)
      4. [Human solves in browser, presses Enter in terminal]
      5. control_state.resume() unblocks
      6. auto_read_page_after_resume() -> JSON tool result to LLM
```

TUI detects pause via polling `cancel_flag.is_paused()` each render tick (observer event doesn't fire because handle_pause blocks inline before the runtime can notify).

## Testing

- 714 tests pass, 0 failures
- `cargo clippy --workspace --all-targets -- -D warnings` = 0 warnings  
- `cargo fmt --check` = clean
- 26 new test functions covering: control state, pause/resume cycles, cancel-during-pause, non-interactive guard, sub-agent guard, full integration flows

## Files changed

25 files, +1483/-51 lines across `runtime`, `crawler`, and `acrawl-cli` crates.