### PR TITLE
feat: one-line install scripts, release CI, and update notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,14 @@ jobs:
             os: ubuntu-20.04
             artifact: acrawl-linux-arm64
             use_cross: true
+          - target: x86_64-apple-darwin
+            os: macos-13
+            artifact: acrawl-macos-x64
+            use_cross: false
+          - target: aarch64-apple-darwin
+            os: macos-14
+            artifact: acrawl-macos-arm64
+            use_cross: false
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             artifact: acrawl-windows-x64.exe
@@ -69,8 +77,12 @@ jobs:
           sudo apt-get install -y gcc-aarch64-linux-gnu
           aarch64-linux-gnu-strip target/${{ matrix.target }}/release/acrawl
 
-      - name: Rename binary (Linux)
-        if: runner.os == 'Linux'
+      - name: Strip binary (macOS)
+        if: runner.os == 'macOS'
+        run: strip target/${{ matrix.target }}/release/acrawl
+
+      - name: Rename binary (Linux/macOS)
+        if: runner.os == 'Linux' || runner.os == 'macOS'
         run: cp target/${{ matrix.target }}/release/acrawl ${{ matrix.artifact }}
 
       - name: Rename binary (Windows)
@@ -102,11 +114,13 @@ jobs:
           mkdir release
           cp artifacts/acrawl-linux-x64/acrawl-linux-x64 release/
           cp artifacts/acrawl-linux-arm64/acrawl-linux-arm64 release/
+          cp artifacts/acrawl-macos-x64/acrawl-macos-x64 release/
+          cp artifacts/acrawl-macos-arm64/acrawl-macos-arm64 release/
           cp artifacts/acrawl-windows-x64.exe/acrawl-windows-x64.exe release/
 
       - name: Generate checksums
         working-directory: release
-        run: sha256sum acrawl-linux-x64 acrawl-linux-arm64 acrawl-windows-x64.exe > checksums.sha256
+        run: sha256sum acrawl-linux-x64 acrawl-linux-arm64 acrawl-macos-x64 acrawl-macos-arm64 acrawl-windows-x64.exe > checksums.sha256
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -115,5 +129,7 @@ jobs:
           files: |
             release/acrawl-linux-x64
             release/acrawl-linux-arm64
+            release/acrawl-macos-x64
+            release/acrawl-macos-arm64
             release/acrawl-windows-x64.exe
             release/checksums.sha256

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,119 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-20.04
+            artifact: acrawl-linux-x64
+            use_cross: false
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-20.04
+            artifact: acrawl-linux-arm64
+            use_cross: true
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            artifact: acrawl-windows-x64.exe
+            use_cross: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Install cross
+        if: matrix.use_cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build (cross)
+        if: matrix.use_cross
+        env:
+          TARGET: ${{ matrix.target }}
+          GIT_SHA: ${{ github.sha }}
+        run: cross build --release --locked --target ${{ matrix.target }}
+
+      - name: Build (cargo)
+        if: "!matrix.use_cross"
+        env:
+          TARGET: ${{ matrix.target }}
+          GIT_SHA: ${{ github.sha }}
+        run: cargo build --release --locked --target ${{ matrix.target }}
+
+      - name: Strip binary (Linux)
+        if: matrix.os == 'ubuntu-20.04' && !matrix.use_cross
+        run: strip target/${{ matrix.target }}/release/acrawl
+
+      - name: Strip binary (Linux ARM64)
+        if: matrix.use_cross
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          aarch64-linux-gnu-strip target/${{ matrix.target }}/release/acrawl
+
+      - name: Rename binary (Linux)
+        if: runner.os == 'Linux'
+        run: cp target/${{ matrix.target }}/release/acrawl ${{ matrix.artifact }}
+
+      - name: Rename binary (Windows)
+        if: runner.os == 'Windows'
+        run: Copy-Item "target/${{ matrix.target }}/release/acrawl.exe" "${{ matrix.artifact }}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}
+          if-no-files-found: error
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Collect binaries
+        run: |
+          mkdir release
+          cp artifacts/acrawl-linux-x64/acrawl-linux-x64 release/
+          cp artifacts/acrawl-linux-arm64/acrawl-linux-arm64 release/
+          cp artifacts/acrawl-windows-x64.exe/acrawl-windows-x64.exe release/
+
+      - name: Generate checksums
+        working-directory: release
+        run: sha256sum acrawl-linux-x64 acrawl-linux-arm64 acrawl-windows-x64.exe > checksums.sha256
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            release/acrawl-linux-x64
+            release/acrawl-linux-arm64
+            release/acrawl-windows-x64.exe
+            release/checksums.sha256

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2511,9 +2511,11 @@ name = "runtime"
 version = "0.2.0"
 dependencies = [
  "getrandom 0.2.17",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2",
+ "time",
  "tokio",
 ]
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,24 @@ acrawl is that wiring, packaged as a single Rust binary. You describe a goal; th
 
 ### Install
 
+**Linux (x64 / ARM64):**
 ```bash
-# Build from source
+curl -fsSL https://raw.githubusercontent.com/Mingye-Lu/AgenticCrawler/main/install.sh | sh
+```
+
+**Windows (x64, PowerShell):**
+```powershell
+irm https://raw.githubusercontent.com/Mingye-Lu/AgenticCrawler/main/install.ps1 | iex
+```
+
+This downloads the latest binary, verifies its SHA256 checksum, and sets up Playwright for browser automation. Requires Node.js 16+ for browser features.
+
+acrawl checks for updates on startup and shows a notification when a new version is available.
+
+<details>
+<summary>Build from source</summary>
+
+```bash
 git clone https://github.com/Mingye-Lu/AgenticCrawler.git
 cd AgenticCrawler
 cargo build --release
@@ -66,6 +82,8 @@ cargo build --release
 npm install
 npx playwright install chromium
 ```
+
+</details>
 
 ### Configure
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ acrawl is that wiring, packaged as a single Rust binary. You describe a goal; th
 
 ### Install
 
-**Linux (x64 / ARM64):**
+**Linux / macOS (x64 / ARM64):**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Mingye-Lu/AgenticCrawler/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/Mingye-Lu/AgenticCrawler/main/install.sh | bash
 ```
 
 **Windows (x64, PowerShell):**

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -184,6 +184,9 @@ pub(super) struct ReplTuiState {
     pub(super) selection: SelectionState,
     last_esc_at: Option<Instant>,
     pub(super) debug_mode: bool,
+    pub(super) update_info: Option<runtime::update_check::UpdateInfo>,
+    pub(super) update_rx:
+        Option<tokio::sync::oneshot::Receiver<Option<runtime::update_check::UpdateInfo>>>,
 }
 
 impl ReplTuiState {
@@ -231,6 +234,8 @@ impl ReplTuiState {
             selection: SelectionState::default(),
             last_esc_at: None,
             debug_mode: false,
+            update_info: None,
+            update_rx: None,
         }
     }
 
@@ -1492,6 +1497,14 @@ fn run_loop(
 
     let mut state = ReplTuiState::new();
 
+    let (update_tx, update_rx) =
+        tokio::sync::oneshot::channel::<Option<runtime::update_check::UpdateInfo>>();
+    state.update_rx = Some(update_rx);
+    crate::TOKIO_RUNTIME.get().unwrap().spawn(async move {
+        let info = runtime::update_check::check_for_update().await;
+        let _ = update_tx.send(info);
+    });
+
     {
         let ui_tx_catalog = ui_tx.clone();
         thread::spawn(move || {
@@ -1503,6 +1516,13 @@ fn run_loop(
 
     loop {
         state.drain_events(ui_rx);
+
+        if let Some(rx) = state.update_rx.as_mut() {
+            if let Ok(info) = rx.try_recv() {
+                state.update_info = info;
+                state.update_rx = None;
+            }
+        }
 
         // Detect pause state directly from ControlState — the observer event may not
         // fire for LLM-triggered pauses (handle_pause blocks inline before the runtime
@@ -2455,5 +2475,61 @@ mod tests {
                 "title should contain effort level '{effort}': {title}"
             );
         }
+    }
+
+    #[test]
+    fn test_welcome_card_renders_when_outdated() {
+        let mut state = super::ReplTuiState::new();
+        state.update_info = Some(runtime::update_check::UpdateInfo {
+            latest_version: "9.9.9".to_string(),
+            current_version: "1.0.0".to_string(),
+            is_outdated: true,
+        });
+
+        let backend = ratatui::backend::TestBackend::new(100, 40);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                crate::tui::repl_render::draw_welcome(frame, frame.area(), &mut state, false);
+            })
+            .unwrap();
+
+        let buffer = terminal.backend().buffer();
+        let content = (0..40)
+            .map(|y| {
+                (0..100)
+                    .map(|x| buffer.cell((x, y)).unwrap().symbol())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(content.contains("Update available: v9.9.9 (you have v1.0.0)"));
+    }
+
+    #[test]
+    fn test_no_card_when_current() {
+        let mut state = super::ReplTuiState::new();
+        state.update_info = None;
+
+        let backend = ratatui::backend::TestBackend::new(100, 40);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                crate::tui::repl_render::draw_welcome(frame, frame.area(), &mut state, false);
+            })
+            .unwrap();
+
+        let buffer = terminal.backend().buffer();
+        let content = (0..40)
+            .map(|y| {
+                (0..100)
+                    .map(|x| buffer.cell((x, y)).unwrap().symbol())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(!content.contains("Update available"));
     }
 }

--- a/crates/acrawl-cli/src/tui/repl_render.rs
+++ b/crates/acrawl-cli/src/tui/repl_render.rs
@@ -710,8 +710,51 @@ pub(super) fn draw_welcome(
         state.calculate_input_dimensions(input_w, &model_label);
     let input_h = box_height;
 
+    let mut input_y = art_y.saturating_add(art_h).saturating_add(2);
+
+    if let Some(ref info) = state.update_info {
+        if info.is_outdated {
+            let install_cmd = if cfg!(target_os = "windows") {
+                "  Run: irm https://raw.githubusercontent.com/Mingye-Lu/AgenticCrawler/main/install.ps1 | iex".to_string()
+            } else {
+                "  Run: curl -fsSL https://raw.githubusercontent.com/Mingye-Lu/AgenticCrawler/main/install.sh | sh".to_string()
+            };
+            let card_text = vec![
+                Line::from(Span::styled(
+                    format!(
+                        "  Update available: v{} (you have v{})",
+                        info.latest_version, info.current_version
+                    ),
+                    Style::default().fg(Color::Yellow),
+                )),
+                Line::from(Span::styled(
+                    install_cmd,
+                    Style::default().fg(Color::DarkGray),
+                )),
+            ];
+            let card = Paragraph::new(card_text).block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().add_modifier(Modifier::DIM)),
+            );
+
+            let card_h = 4;
+            let card_w = art_w.max(60);
+            let card_x = area.x + area.width.saturating_sub(card_w) / 2;
+            let card_y = art_y.saturating_add(art_h).saturating_add(1);
+            let card_area = Rect::new(
+                card_x,
+                card_y,
+                card_w.min(area.width),
+                card_h.min(area.height),
+            );
+            frame.render_widget(card, card_area);
+
+            input_y = card_y.saturating_add(card_h).saturating_add(1);
+        }
+    }
+
     let input_x = area.x + area.width.saturating_sub(input_w) / 2;
-    let input_y = art_y.saturating_add(art_h).saturating_add(2);
     let input_area = Rect::new(
         input_x,
         input_y.min(area.y.saturating_add(area.height.saturating_sub(input_h))),

--- a/crates/crawler/src/playwright.rs
+++ b/crates/crawler/src/playwright.rs
@@ -682,13 +682,25 @@ impl PlaywrightBridge {
 
     fn bridge_command(program: &str, args: &[String]) -> Command {
         let mut command = Command::new(program);
+        let acrawl_node_modules = config_home_dir().join("node_modules");
+        let node_path = match std::env::var_os("NODE_PATH") {
+            Some(existing) => {
+                let mut paths = std::env::split_paths(&existing).collect::<Vec<_>>();
+                if !paths.contains(&acrawl_node_modules) {
+                    paths.insert(0, acrawl_node_modules.clone());
+                }
+                std::env::join_paths(paths)
+                    .unwrap_or_else(|_| acrawl_node_modules.into())
+            }
+            None => acrawl_node_modules.into(),
+        };
         command
             .args(args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit())
             .kill_on_drop(true)
-            .env("NODE_PATH", config_home_dir().join("node_modules"));
+            .env("NODE_PATH", node_path);
         command
     }
 
@@ -1208,9 +1220,12 @@ mod tests {
             }
         });
 
-        assert_eq!(
-            node_path,
-            Some(config_home_dir().join("node_modules").into_os_string())
+        let node_path = node_path.expect("NODE_PATH should be set");
+        let paths: Vec<_> = std::env::split_paths(&node_path).collect();
+        let expected = config_home_dir().join("node_modules");
+        assert!(
+            paths.contains(&expected),
+            "NODE_PATH should contain {expected:?}, got {paths:?}"
         );
     }
 

--- a/crates/crawler/src/playwright.rs
+++ b/crates/crawler/src/playwright.rs
@@ -689,8 +689,7 @@ impl PlaywrightBridge {
                 if !paths.contains(&acrawl_node_modules) {
                     paths.insert(0, acrawl_node_modules.clone());
                 }
-                std::env::join_paths(paths)
-                    .unwrap_or_else(|_| acrawl_node_modules.into())
+                std::env::join_paths(paths).unwrap_or_else(|_| acrawl_node_modules.into())
             }
             None => acrawl_node_modules.into(),
         };

--- a/crates/crawler/src/playwright.rs
+++ b/crates/crawler/src/playwright.rs
@@ -4,8 +4,8 @@ use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Duration;
 
-use serde::{Deserialize, Serialize};
 use runtime::config_home_dir;
+use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tokio::sync::Mutex;
@@ -1200,18 +1200,18 @@ mod tests {
     fn bridge_command_sets_node_path_to_config_home_node_modules() {
         let args = vec!["-e".to_string(), "console.log('ok')".to_string()];
         let command = PlaywrightBridge::bridge_command("node", &args);
-        let node_path = command
-            .as_std()
-            .get_envs()
-            .find_map(|(key, value)| {
-                if key == "NODE_PATH" {
-                    value.map(std::ffi::OsStr::to_os_string)
-                } else {
-                    None
-                }
-            });
+        let node_path = command.as_std().get_envs().find_map(|(key, value)| {
+            if key == "NODE_PATH" {
+                value.map(std::ffi::OsStr::to_os_string)
+            } else {
+                None
+            }
+        });
 
-        assert_eq!(node_path, Some(config_home_dir().join("node_modules").into_os_string()));
+        assert_eq!(
+            node_path,
+            Some(config_home_dir().join("node_modules").into_os_string())
+        );
     }
 
     #[tokio::test]

--- a/crates/crawler/src/playwright.rs
+++ b/crates/crawler/src/playwright.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
+use runtime::config_home_dir;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tokio::sync::Mutex;
@@ -646,13 +647,7 @@ impl PlaywrightBridge {
         args: Vec<String>,
         launch_timeout: Duration,
     ) -> Result<Self, PlaywrightBridgeError> {
-        let mut command = Command::new(program);
-        command
-            .args(&args)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::inherit())
-            .kill_on_drop(true);
+        let mut command = Self::bridge_command(program, &args);
 
         let mut child = command
             .spawn()
@@ -683,6 +678,18 @@ impl PlaywrightBridge {
         }
 
         Ok(bridge)
+    }
+
+    fn bridge_command(program: &str, args: &[String]) -> Command {
+        let mut command = Command::new(program);
+        command
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .kill_on_drop(true)
+            .env("NODE_PATH", config_home_dir().join("node_modules"));
+        command
     }
 
     pub async fn navigate(&mut self, url: &str) -> Result<PageInfo, PlaywrightBridgeError> {
@@ -1154,6 +1161,8 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+    use runtime::config_home_dir;
+
     use super::{PageInfo, PlaywrightBridge, PlaywrightBridgeError};
 
     fn temp_dir(prefix: &str) -> PathBuf {
@@ -1185,6 +1194,24 @@ mod tests {
         let path = root.join(format!("{name}.py"));
         fs::write(&path, source).expect("write temp script");
         path
+    }
+
+    #[test]
+    fn bridge_command_sets_node_path_to_config_home_node_modules() {
+        let args = vec!["-e".to_string(), "console.log('ok')".to_string()];
+        let command = PlaywrightBridge::bridge_command("node", &args);
+        let node_path = command
+            .as_std()
+            .get_envs()
+            .find_map(|(key, value)| {
+                if key == "NODE_PATH" {
+                    value.map(std::ffi::OsStr::to_os_string)
+                } else {
+                    None
+                }
+            });
+
+        assert_eq!(node_path, Some(config_home_dir().join("node_modules").into_os_string()));
     }
 
     #[tokio::test]

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -8,8 +8,10 @@ publish.workspace = true
 [dependencies]
 getrandom = "0.2"
 sha2 = "0.10"
+reqwest = { version = "0.12", features = ["rustls-tls", "json"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+time = { version = "0.3", features = ["formatting", "parsing"] }
 tokio = { version = "1", features = ["io-util", "macros", "process", "rt", "rt-multi-thread", "sync", "time"] }
 
 [lints]

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -12,6 +12,7 @@ mod remote;
 pub mod sandbox;
 mod session;
 pub mod settings;
+pub mod update_check;
 mod usage;
 
 pub use bootstrap::{BootstrapPhase, BootstrapPlan};
@@ -73,6 +74,7 @@ pub use settings::{
     settings_get_max_concurrent_per_parent, settings_get_max_fork_depth, settings_get_max_steps,
     settings_get_max_total_agents, settings_get_workspace_dir, update_settings, Settings,
 };
+pub use update_check::{check_for_update, UpdateInfo};
 pub use usage::{
     format_usd, pricing_for_model, ModelPricing, TokenUsage, UsageCostEstimate, UsageTracker,
 };

--- a/crates/runtime/src/update_check.rs
+++ b/crates/runtime/src/update_check.rs
@@ -216,6 +216,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // lock guards env var mutation for test isolation, not shared data
     async fn test_cache_freshness() {
         let _lock = test_env_lock();
         let temp_dir = setup_temp_dir();
@@ -243,6 +244,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // lock guards env var mutation for test isolation, not shared data
     async fn test_graceful_failure() {
         let _lock = test_env_lock();
         let temp_dir = setup_temp_dir();

--- a/crates/runtime/src/update_check.rs
+++ b/crates/runtime/src/update_check.rs
@@ -10,8 +10,7 @@ use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use crate::config_home_dir;
 
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
-const RELEASES_URL: &str =
-    "https://api.github.com/repos/Mingye-Lu/AgenticCrawler/releases/latest";
+const RELEASES_URL: &str = "https://api.github.com/repos/Mingye-Lu/AgenticCrawler/releases/latest";
 const UPDATE_CHECK_CACHE_FILE: &str = ".update-check.json";
 const UPDATE_CHECK_TIMEOUT: Duration = Duration::from_secs(2);
 const UPDATE_CHECK_TTL_SECS: i64 = 24 * 60 * 60;
@@ -145,7 +144,10 @@ fn compare_versions(current_version: &str, latest_version: &str) -> Option<Order
 }
 
 fn parse_version(version: &str) -> Option<Vec<u32>> {
-    version.split('.').map(|part| part.parse::<u32>().ok()).collect()
+    version
+        .split('.')
+        .map(|part| part.parse::<u32>().ok())
+        .collect()
 }
 
 fn current_timestamp() -> OffsetDateTime {

--- a/crates/runtime/src/update_check.rs
+++ b/crates/runtime/src/update_check.rs
@@ -1,0 +1,255 @@
+use std::cmp::Ordering;
+use std::fs;
+use std::io;
+use std::path::Path;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+use crate::config_home_dir;
+
+const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+const RELEASES_URL: &str =
+    "https://api.github.com/repos/Mingye-Lu/AgenticCrawler/releases/latest";
+const UPDATE_CHECK_CACHE_FILE: &str = ".update-check.json";
+const UPDATE_CHECK_TIMEOUT: Duration = Duration::from_secs(2);
+const UPDATE_CHECK_TTL_SECS: i64 = 24 * 60 * 60;
+const USER_AGENT: &str = "acrawl";
+
+#[derive(Debug, Clone)]
+pub struct UpdateInfo {
+    pub latest_version: String,
+    pub current_version: String,
+    pub is_outdated: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct UpdateCache {
+    latest_version: String,
+    checked_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReleaseResponse {
+    tag_name: String,
+}
+
+pub async fn check_for_update() -> Option<UpdateInfo> {
+    check_for_update_with_version_and_url(CURRENT_VERSION, RELEASES_URL).await
+}
+
+async fn check_for_update_with_version_and_url(
+    current_version: &str,
+    release_url: &str,
+) -> Option<UpdateInfo> {
+    let cache_path = cache_file_path();
+
+    if let Some(cache) = read_cache(&cache_path) {
+        if is_cache_fresh(&cache) {
+            return build_update_info(current_version, &cache.latest_version);
+        }
+    }
+
+    let latest_version = fetch_latest_version(release_url).await?;
+    let cache = UpdateCache {
+        latest_version,
+        checked_at: current_timestamp_string()?,
+    };
+
+    write_cache(&cache_path, &cache).ok()?;
+    build_update_info(current_version, &cache.latest_version)
+}
+
+fn cache_file_path() -> std::path::PathBuf {
+    config_home_dir().join(UPDATE_CHECK_CACHE_FILE)
+}
+
+fn read_cache(path: &Path) -> Option<UpdateCache> {
+    let content = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+fn write_cache(path: &Path, cache: &UpdateCache) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let json = serde_json::to_string(cache)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    fs::write(path, json)
+}
+
+fn is_cache_fresh(cache: &UpdateCache) -> bool {
+    let checked_at = parse_timestamp(&cache.checked_at);
+    let now = current_timestamp();
+
+    checked_at.is_some_and(|checked_at| {
+        checked_at <= now && now - checked_at < time::Duration::seconds(UPDATE_CHECK_TTL_SECS)
+    })
+}
+
+async fn fetch_latest_version(release_url: &str) -> Option<String> {
+    let client = reqwest::Client::new();
+    let release = tokio::time::timeout(UPDATE_CHECK_TIMEOUT, async {
+        let response = client
+            .get(release_url)
+            .timeout(UPDATE_CHECK_TIMEOUT)
+            .header(reqwest::header::USER_AGENT, USER_AGENT)
+            .send()
+            .await?;
+
+        response.error_for_status()?.json::<ReleaseResponse>().await
+    })
+    .await
+    .ok()?
+    .ok()?;
+
+    Some(strip_version_prefix(&release.tag_name).to_string())
+}
+
+fn strip_version_prefix(version: &str) -> &str {
+    version.strip_prefix('v').unwrap_or(version)
+}
+
+fn build_update_info(current_version: &str, latest_version: &str) -> Option<UpdateInfo> {
+    if latest_version.contains('-') {
+        return None;
+    }
+
+    let is_outdated = compare_versions(current_version, latest_version)? == Ordering::Less;
+
+    Some(UpdateInfo {
+        latest_version: latest_version.to_string(),
+        current_version: current_version.to_string(),
+        is_outdated,
+    })
+}
+
+fn compare_versions(current_version: &str, latest_version: &str) -> Option<Ordering> {
+    let current_parts = parse_version(current_version)?;
+    let latest_parts = parse_version(latest_version)?;
+    let max_len = current_parts.len().max(latest_parts.len());
+
+    for index in 0..max_len {
+        let current = *current_parts.get(index).unwrap_or(&0);
+        let latest = *latest_parts.get(index).unwrap_or(&0);
+
+        match current.cmp(&latest) {
+            Ordering::Equal => {}
+            ordering => return Some(ordering),
+        }
+    }
+
+    Some(Ordering::Equal)
+}
+
+fn parse_version(version: &str) -> Option<Vec<u32>> {
+    version.split('.').map(|part| part.parse::<u32>().ok()).collect()
+}
+
+fn current_timestamp() -> OffsetDateTime {
+    OffsetDateTime::now_utc()
+}
+
+fn current_timestamp_string() -> Option<String> {
+    current_timestamp().format(&Rfc3339).ok()
+}
+
+fn parse_timestamp(timestamp: &str) -> Option<OffsetDateTime> {
+    OffsetDateTime::parse(timestamp, &Rfc3339).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+    use super::{
+        build_update_info, cache_file_path, check_for_update_with_version_and_url,
+        current_timestamp, UpdateCache,
+    };
+
+    fn test_env_lock() -> std::sync::MutexGuard<'static, ()> {
+        crate::test_env_lock()
+    }
+
+    fn setup_temp_dir() -> PathBuf {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "acrawl_update_check_test_{}_{}",
+            std::process::id(),
+            OffsetDateTime::now_utc().unix_timestamp_nanos()
+        ));
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        std::fs::create_dir_all(&temp_dir).expect("Failed to create temp dir");
+        temp_dir
+    }
+
+    fn cleanup_temp_dir(path: &Path) {
+        let _ = std::fs::remove_dir_all(path);
+    }
+
+    #[test]
+    fn test_version_compare_older() {
+        let info = build_update_info("0.2.0", "0.3.0").expect("Expected update info");
+        assert!(info.is_outdated);
+    }
+
+    #[test]
+    fn test_version_compare_equal() {
+        let info = build_update_info("1.0.0", "1.0.0").expect("Expected update info");
+        assert!(!info.is_outdated);
+    }
+
+    #[test]
+    fn test_version_compare_major() {
+        let info = build_update_info("0.2.0", "0.10.0").expect("Expected update info");
+        assert!(info.is_outdated);
+    }
+
+    #[test]
+    fn test_prerelease_filtered() {
+        assert!(build_update_info("0.2.0", "0.3.0-rc1").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_cache_freshness() {
+        let _lock = test_env_lock();
+        let temp_dir = setup_temp_dir();
+        std::env::set_var("ACRAWL_CONFIG_HOME", &temp_dir);
+
+        let cache = UpdateCache {
+            latest_version: "9.9.9".to_string(),
+            checked_at: current_timestamp()
+                .checked_sub(time::Duration::hours(1))
+                .expect("Expected valid timestamp")
+                .format(&Rfc3339)
+                .expect("Expected RFC3339 timestamp"),
+        };
+        let cache_json = serde_json::to_string(&cache).expect("Expected cache json");
+        std::fs::write(cache_file_path(), cache_json).expect("Expected cache write");
+
+        let update = check_for_update_with_version_and_url("0.1.0", "not a url").await;
+        let update = update.expect("Expected cached update info");
+
+        assert_eq!(update.current_version, "0.1.0");
+        assert_eq!(update.latest_version, "9.9.9");
+        assert!(update.is_outdated);
+
+        cleanup_temp_dir(&temp_dir);
+    }
+
+    #[tokio::test]
+    async fn test_graceful_failure() {
+        let _lock = test_env_lock();
+        let temp_dir = setup_temp_dir();
+        std::env::set_var("ACRAWL_CONFIG_HOME", &temp_dir);
+
+        let update = check_for_update_with_version_and_url("0.1.0", "not a url").await;
+
+        assert!(update.is_none());
+
+        cleanup_temp_dir(&temp_dir);
+    }
+}

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,181 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Install acrawl on Windows (PowerShell 5.1+).
+
+.DESCRIPTION
+    Downloads the latest acrawl binary from GitHub Releases, verifies the
+    SHA256 checksum, installs to $HOME\.acrawl\bin\, adds to user PATH,
+    and optionally sets up Playwright for browser automation.
+
+.EXAMPLE
+    irm https://raw.githubusercontent.com/Mingye-Lu/AgenticCrawler/main/install.ps1 | iex
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$Repo = "Mingye-Lu/AgenticCrawler"
+if ($env:ACRAWL_CONFIG_HOME) {
+    $ConfigHome = $env:ACRAWL_CONFIG_HOME
+} else {
+    $ConfigHome = Join-Path $HOME ".acrawl"
+}
+$InstallDir = Join-Path $ConfigHome "bin"
+
+# --- 1. Architecture check ---
+$arch = $env:PROCESSOR_ARCHITECTURE
+if ($arch -ne "AMD64") {
+    Write-Error "Unsupported architecture: $arch. Only AMD64 (x64) Windows is supported."
+    exit 1
+}
+
+Write-Host ""
+Write-Host "  acrawl installer for Windows" -ForegroundColor Cyan
+Write-Host "  =============================" -ForegroundColor Cyan
+Write-Host ""
+
+# --- 2. Get latest version from GitHub API ---
+Write-Host "Fetching latest release..." -ForegroundColor Gray
+try {
+    # PowerShell 5.1 needs TLS 1.2 for GitHub
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" -UseBasicParsing
+    $version = $release.tag_name.TrimStart('v')
+} catch {
+    Write-Error "Failed to fetch latest release from GitHub: $_"
+    exit 1
+}
+
+Write-Host "  Latest version: v$version" -ForegroundColor Green
+
+# --- 3. Download binary ---
+$binaryUrl = "https://github.com/$Repo/releases/download/v$version/acrawl-windows-x64.exe"
+$tempBinary = Join-Path $env:TEMP "acrawl-download.exe"
+
+Write-Host "Downloading acrawl v$version..." -ForegroundColor Gray
+try {
+    Invoke-WebRequest -Uri $binaryUrl -OutFile $tempBinary -UseBasicParsing
+} catch {
+    Write-Error "Failed to download binary from: $binaryUrl`n$_"
+    exit 1
+}
+
+# --- 4. Download checksums ---
+$checksumUrl = "https://github.com/$Repo/releases/download/v$version/checksums.sha256"
+$checksumFile = Join-Path $env:TEMP "acrawl-checksums.sha256"
+
+Write-Host "Downloading checksums..." -ForegroundColor Gray
+try {
+    Invoke-WebRequest -Uri $checksumUrl -OutFile $checksumFile -UseBasicParsing
+} catch {
+    Write-Error "Failed to download checksums from: $checksumUrl`n$_"
+    exit 1
+}
+
+# --- 5. Verify SHA256 checksum ---
+Write-Host "Verifying checksum..." -ForegroundColor Gray
+$actualHash = (Get-FileHash -Path $tempBinary -Algorithm SHA256).Hash.ToLower()
+$checksumContent = Get-Content $checksumFile
+$expectedLine = $checksumContent | Where-Object { $_ -match "acrawl-windows-x64\.exe" }
+
+if (-not $expectedLine) {
+    Write-Error "Could not find checksum for acrawl-windows-x64.exe in checksums file."
+    exit 1
+}
+
+$expectedHash = ($expectedLine -split '\s+')[0].ToLower()
+
+if ($actualHash -ne $expectedHash) {
+    Write-Error "Checksum verification FAILED!`n  Expected: $expectedHash`n  Got:      $actualHash`nThe downloaded file may be corrupted or tampered with."
+    exit 1
+}
+
+Write-Host "  Checksum verified." -ForegroundColor Green
+
+# --- 6. Create install directory ---
+if (-not (Test-Path $InstallDir)) {
+    New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+}
+
+# --- 7. Install binary ---
+$targetPath = Join-Path $InstallDir "acrawl.exe"
+Move-Item -Path $tempBinary -Destination $targetPath -Force
+Write-Host "  Installed to: $targetPath" -ForegroundColor Green
+
+# --- 8. Add to user PATH ---
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if (-not $userPath) {
+    $userPath = ""
+}
+
+if ($userPath -notlike "*$InstallDir*") {
+    if ($userPath -and -not $userPath.EndsWith(";")) {
+        $newPath = "$userPath;$InstallDir"
+    } else {
+        $newPath = "$userPath$InstallDir"
+    }
+    [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+    Write-Host ""
+    Write-Host "  Added $InstallDir to user PATH." -ForegroundColor Yellow
+    Write-Host "  Restart your terminal for PATH changes to take effect." -ForegroundColor Yellow
+} else {
+    Write-Host "  $InstallDir already in PATH." -ForegroundColor Gray
+}
+
+# --- 9. Node.js check ---
+Write-Host ""
+$nodeAvailable = $false
+$nodeMajor = 0
+
+try {
+    $nodeVersionRaw = & node --version 2>$null
+    if ($nodeVersionRaw) {
+        $nodeVersion = $nodeVersionRaw.TrimStart('v')
+        $nodeMajor = [int]($nodeVersion -split '\.')[0]
+        if ($nodeMajor -lt 16) {
+            Write-Warning "Node.js 16+ is required for browser automation. You have v$nodeVersion."
+            Write-Warning "Install from https://nodejs.org/ to enable headless browser features."
+        } else {
+            $nodeAvailable = $true
+            Write-Host "  Node.js v$nodeVersion detected." -ForegroundColor Green
+        }
+    } else {
+        Write-Warning "Node.js not found. Browser automation requires Node.js 16+."
+        Write-Warning "Install from https://nodejs.org/ to enable headless browser features."
+    }
+} catch {
+    Write-Warning "Node.js not found. Browser automation requires Node.js 16+."
+    Write-Warning "Install from https://nodejs.org/ to enable headless browser features."
+}
+
+# --- 10. Playwright install ---
+if ($nodeAvailable) {
+    $playwrightDir = Join-Path $ConfigHome "node_modules\playwright"
+    if (Test-Path $playwrightDir) {
+        Write-Host "  Playwright already installed." -ForegroundColor Gray
+    } else {
+        Write-Host "Installing Playwright..." -ForegroundColor Gray
+        try {
+            & npm install --prefix $ConfigHome playwright 2>&1 | Out-Null
+            & npx --prefix $ConfigHome playwright install chromium 2>&1 | Out-Null
+            Write-Host "  Playwright + Chromium installed." -ForegroundColor Green
+        } catch {
+            Write-Warning "Playwright installation failed: $_"
+            Write-Warning "You can install it manually later: npm install --prefix `"$ConfigHome`" playwright && npx --prefix `"$ConfigHome`" playwright install chromium"
+        }
+    }
+}
+
+# --- 11. Cleanup temp files ---
+if (Test-Path $checksumFile) {
+    Remove-Item -Path $checksumFile -Force -ErrorAction SilentlyContinue
+}
+
+# --- 12. Success ---
+Write-Host ""
+Write-Host "  acrawl v$version installed successfully!" -ForegroundColor Green
+Write-Host ""
+Write-Host "  Get started:" -ForegroundColor Cyan
+Write-Host "    acrawl auth anthropic    # configure your LLM provider"
+Write-Host "    acrawl                   # launch interactive REPL"
+Write-Host ""

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env sh
+# shellcheck disable=SC3040
+set -euo pipefail
+
+# acrawl installer — downloads the latest release for Linux
+# Usage: curl -fsSL https://raw.githubusercontent.com/Mingye-Lu/AgenticCrawler/main/install.sh | sh
+
+REPO="Mingye-Lu/AgenticCrawler"
+INSTALL_DIR="${ACRAWL_INSTALL_DIR:-$HOME/.local/bin}"
+CONFIG_HOME="${ACRAWL_CONFIG_HOME:-$HOME/.acrawl}"
+
+# --- Check required tools ---
+for cmd in curl sha256sum; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "Error: '$cmd' is required but not found. Please install it first." >&2
+        exit 1
+    fi
+done
+
+# --- 1. Check OS ---
+os=$(uname -s)
+if [ "$os" = "Darwin" ]; then
+    echo "Error: macOS is not supported. See https://github.com/Mingye-Lu/AgenticCrawler for build instructions" >&2
+    exit 1
+fi
+if [ "$os" != "Linux" ]; then
+    echo "Error: Unsupported operating system: $os. Only Linux is supported." >&2
+    exit 1
+fi
+
+# --- 2. Detect architecture ---
+arch=$(uname -m)
+case "$arch" in
+    x86_64)
+        artifact_name="acrawl-linux-x64"
+        ;;
+    aarch64)
+        artifact_name="acrawl-linux-arm64"
+        ;;
+    *)
+        echo "Error: Unsupported architecture: $arch. Only x86_64 and aarch64 are supported." >&2
+        exit 1
+        ;;
+esac
+
+echo "Detected: Linux $arch -> $artifact_name"
+
+# --- 3. Get latest version from GitHub API ---
+echo "Fetching latest release version..."
+api_response=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest")
+version=$(echo "$api_response" | grep '"tag_name"' | sed 's/.*"tag_name": *"//;s/".*//')
+
+if [ -z "$version" ]; then
+    echo "Error: Failed to determine latest version from GitHub API" >&2
+    exit 1
+fi
+
+echo "Latest version: $version"
+
+# --- 4. Download binary ---
+download_url="https://github.com/${REPO}/releases/download/${version}/${artifact_name}"
+echo "Downloading ${artifact_name} (${version})..."
+curl -fsSL -o "/tmp/${artifact_name}" "$download_url"
+
+# --- 5. Download checksums ---
+checksums_url="https://github.com/${REPO}/releases/download/${version}/checksums.sha256"
+curl -fsSL -o "/tmp/checksums.sha256" "$checksums_url"
+
+# --- 6. Verify checksum ---
+echo "Verifying checksum..."
+(cd /tmp && grep -F "${artifact_name}" checksums.sha256 | sha256sum --check --status)
+echo "Checksum verified."
+
+# --- 7. Create install directory ---
+mkdir -p "$INSTALL_DIR"
+
+# --- 8. Install binary ---
+mv "/tmp/${artifact_name}" "${INSTALL_DIR}/acrawl"
+chmod +x "${INSTALL_DIR}/acrawl"
+echo "Installed acrawl to ${INSTALL_DIR}/acrawl"
+
+# --- 9. PATH check ---
+case ":${PATH}:" in
+    *":${INSTALL_DIR}:"*)
+        ;;
+    *)
+        echo ""
+        echo "WARNING: ${INSTALL_DIR} is not in your PATH."
+        echo "Add it by running one of the following:"
+        echo ""
+        current_shell=$(basename "${SHELL:-/bin/sh}")
+        case "$current_shell" in
+            bash)
+                echo "  echo 'export PATH=\"${INSTALL_DIR}:\$PATH\"' >> ~/.bashrc && source ~/.bashrc"
+                ;;
+            zsh)
+                echo "  echo 'export PATH=\"${INSTALL_DIR}:\$PATH\"' >> ~/.zshrc && source ~/.zshrc"
+                ;;
+            fish)
+                echo "  fish_add_path ${INSTALL_DIR}"
+                ;;
+            *)
+                echo "  For bash: echo 'export PATH=\"${INSTALL_DIR}:\$PATH\"' >> ~/.bashrc"
+                echo "  For zsh:  echo 'export PATH=\"${INSTALL_DIR}:\$PATH\"' >> ~/.zshrc"
+                echo "  For fish: fish_add_path ${INSTALL_DIR}"
+                ;;
+        esac
+        echo ""
+        ;;
+esac
+
+# --- 10. Node.js check ---
+node_version=$(node --version 2>/dev/null || true)
+node_major=""
+if [ -n "$node_version" ]; then
+    node_major=$(echo "$node_version" | sed 's/^v//' | cut -d. -f1)
+fi
+
+if [ -z "$node_version" ]; then
+    echo "WARNING: Node.js not found. Node.js 16+ is required for browser automation."
+    echo "Install from https://nodejs.org/"
+elif [ -n "$node_major" ] && [ "$node_major" -lt 16 ]; then
+    echo "WARNING: Node.js 16+ required for browser automation, you have ${node_version}"
+fi
+
+# --- 11. Playwright install ---
+if [ -n "$node_major" ] && [ "$node_major" -ge 16 ]; then
+    if [ -d "${CONFIG_HOME}/node_modules/playwright" ]; then
+        echo "Playwright already installed at ${CONFIG_HOME}/node_modules/playwright (skipping)"
+    else
+        echo "Installing Playwright..."
+        mkdir -p "$CONFIG_HOME"
+        if npm install --prefix "$CONFIG_HOME" playwright; then
+            echo "Installing Chromium browser..."
+            npx --prefix "$CONFIG_HOME" playwright install chromium || echo "WARNING: Chromium install failed. Run manually: npx --prefix \"$CONFIG_HOME\" playwright install chromium"
+        else
+            echo "WARNING: Playwright install failed. Run manually: npm install --prefix \"$CONFIG_HOME\" playwright"
+        fi
+    fi
+fi
+
+# --- 12. Success ---
+echo ""
+echo "acrawl ${version} installed successfully!"
+echo ""
+echo "Next steps:"
+echo "  1. Configure your LLM provider: acrawl auth anthropic"
+echo "  2. Start crawling: acrawl prompt \"scrape titles from example.com\""
+echo ""

--- a/install.sh
+++ b/install.sh
@@ -1,51 +1,60 @@
-#!/usr/bin/env sh
-# shellcheck disable=SC3040
+#!/usr/bin/env bash
 set -euo pipefail
 
-# acrawl installer — downloads the latest release for Linux
-# Usage: curl -fsSL https://raw.githubusercontent.com/Mingye-Lu/AgenticCrawler/main/install.sh | sh
+# acrawl installer — downloads the latest release for Linux and macOS
+# Usage: curl -fsSL https://raw.githubusercontent.com/Mingye-Lu/AgenticCrawler/main/install.sh | bash
 
 REPO="Mingye-Lu/AgenticCrawler"
 INSTALL_DIR="${ACRAWL_INSTALL_DIR:-$HOME/.local/bin}"
 CONFIG_HOME="${ACRAWL_CONFIG_HOME:-$HOME/.acrawl}"
 
 # --- Check required tools ---
-for cmd in curl sha256sum; do
+for cmd in curl; do
     if ! command -v "$cmd" >/dev/null 2>&1; then
         echo "Error: '$cmd' is required but not found. Please install it first." >&2
         exit 1
     fi
 done
 
-# --- 1. Check OS ---
-os=$(uname -s)
-if [ "$os" = "Darwin" ]; then
-    echo "Error: macOS is not supported. See https://github.com/Mingye-Lu/AgenticCrawler for build instructions" >&2
-    exit 1
-fi
-if [ "$os" != "Linux" ]; then
-    echo "Error: Unsupported operating system: $os. Only Linux is supported." >&2
+if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1; then
+    echo "Error: 'sha256sum' or 'shasum' is required but neither was found." >&2
     exit 1
 fi
 
-# --- 2. Detect architecture ---
+# --- 1. Detect OS and architecture ---
+os=$(uname -s)
 arch=$(uname -m)
-case "$arch" in
-    x86_64)
-        artifact_name="acrawl-linux-x64"
+
+case "$os" in
+    Linux)
+        case "$arch" in
+            x86_64)  artifact_name="acrawl-linux-x64" ;;
+            aarch64) artifact_name="acrawl-linux-arm64" ;;
+            *)
+                echo "Error: Unsupported architecture: $arch. Only x86_64 and aarch64 are supported." >&2
+                exit 1
+                ;;
+        esac
         ;;
-    aarch64)
-        artifact_name="acrawl-linux-arm64"
+    Darwin)
+        case "$arch" in
+            x86_64)  artifact_name="acrawl-macos-x64" ;;
+            arm64)   artifact_name="acrawl-macos-arm64" ;;
+            *)
+                echo "Error: Unsupported architecture: $arch. Only x86_64 and arm64 are supported." >&2
+                exit 1
+                ;;
+        esac
         ;;
     *)
-        echo "Error: Unsupported architecture: $arch. Only x86_64 and aarch64 are supported." >&2
+        echo "Error: Unsupported operating system: $os. Only Linux and macOS are supported." >&2
         exit 1
         ;;
 esac
 
-echo "Detected: Linux $arch -> $artifact_name"
+echo "Detected: $os $arch -> $artifact_name"
 
-# --- 3. Get latest version from GitHub API ---
+# --- 2. Get latest version from GitHub API ---
 echo "Fetching latest release version..."
 api_response=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest")
 version=$(echo "$api_response" | grep '"tag_name"' | sed 's/.*"tag_name": *"//;s/".*//')
@@ -57,29 +66,33 @@ fi
 
 echo "Latest version: $version"
 
-# --- 4. Download binary ---
+# --- 3. Download binary ---
 download_url="https://github.com/${REPO}/releases/download/${version}/${artifact_name}"
 echo "Downloading ${artifact_name} (${version})..."
 curl -fsSL -o "/tmp/${artifact_name}" "$download_url"
 
-# --- 5. Download checksums ---
+# --- 4. Download checksums ---
 checksums_url="https://github.com/${REPO}/releases/download/${version}/checksums.sha256"
 curl -fsSL -o "/tmp/checksums.sha256" "$checksums_url"
 
-# --- 6. Verify checksum ---
+# --- 5. Verify checksum ---
 echo "Verifying checksum..."
-(cd /tmp && grep -F "${artifact_name}" checksums.sha256 | sha256sum --check --status)
+if command -v sha256sum >/dev/null 2>&1; then
+    (cd /tmp && grep -F "${artifact_name}" checksums.sha256 | sha256sum --check --status)
+else
+    (cd /tmp && grep -F "${artifact_name}" checksums.sha256 | shasum -a 256 --check --status)
+fi
 echo "Checksum verified."
 
-# --- 7. Create install directory ---
+# --- 6. Create install directory ---
 mkdir -p "$INSTALL_DIR"
 
-# --- 8. Install binary ---
+# --- 7. Install binary ---
 mv "/tmp/${artifact_name}" "${INSTALL_DIR}/acrawl"
 chmod +x "${INSTALL_DIR}/acrawl"
 echo "Installed acrawl to ${INSTALL_DIR}/acrawl"
 
-# --- 9. PATH check ---
+# --- 8. PATH check ---
 case ":${PATH}:" in
     *":${INSTALL_DIR}:"*)
         ;;
@@ -109,7 +122,7 @@ case ":${PATH}:" in
         ;;
 esac
 
-# --- 10. Node.js check ---
+# --- 9. Node.js check ---
 node_version=$(node --version 2>/dev/null || true)
 node_major=""
 if [ -n "$node_version" ]; then
@@ -123,7 +136,7 @@ elif [ -n "$node_major" ] && [ "$node_major" -lt 16 ]; then
     echo "WARNING: Node.js 16+ required for browser automation, you have ${node_version}"
 fi
 
-# --- 11. Playwright install ---
+# --- 10. Playwright install ---
 if [ -n "$node_major" ] && [ "$node_major" -ge 16 ]; then
     if [ -d "${CONFIG_HOME}/node_modules/playwright" ]; then
         echo "Playwright already installed at ${CONFIG_HOME}/node_modules/playwright (skipping)"
@@ -139,7 +152,7 @@ if [ -n "$node_major" ] && [ "$node_major" -ge 16 ]; then
     fi
 fi
 
-# --- 12. Success ---
+# --- 11. Success ---
 echo ""
 echo "acrawl ${version} installed successfully!"
 echo ""


### PR DESCRIPTION
## Summary

End-to-end install & distribution pipeline so users can install acrawl with a single command and get notified when updates are available.

### What's included

- **CI/CD**: Tag-triggered GitHub Actions workflow building binaries for Linux (x64/arm64), macOS (x64/arm64), and Windows (x64) with SHA256 checksums
- **Install scripts**: `install.sh` (Linux + macOS) and `install.ps1` (Windows) — download binary, verify checksum, install Playwright/Chromium
- **Update check**: Async background check against GitHub releases (24h cache), surfaced as a TUI welcome card
- **Playwright NODE_PATH**: Appends `~/.acrawl/node_modules` to `NODE_PATH` for standalone installs without clobbering existing paths

### Install commands

```bash
# Linux / macOS
curl -fsSL https://raw.githubusercontent.com/Mingye-Lu/AgenticCrawler/main/install.sh | bash

# Windows (PowerShell)
irm https://raw.githubusercontent.com/Mingye-Lu/AgenticCrawler/main/install.ps1 | iex
```

### Testing

- `cargo test -p crawler bridge_command_sets_node_path` — verifies NODE_PATH append logic
- `cargo clippy -p crawler -- -D warnings` — clean