### PR TITLE
feat(crawler): refactor content extraction pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,6 +540,7 @@ name = "crawler"
 version = "0.3.1"
 dependencies = [
  "csv",
+ "htmd",
  "reqwest 0.12.28",
  "runtime",
  "serde",
@@ -622,7 +623,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
- "phf",
+ "phf 0.11.3",
 ]
 
 [[package]]
@@ -1145,6 +1146,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "htmd"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eee9b00ee2e599b4f86507157e3db786e7a3319fc225f0e9584151dbea2291d"
+dependencies = [
+ "html5ever",
+ "markup5ever_rcdom",
+ "phf 0.13.1",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
+dependencies = [
+ "log",
+ "markup5ever",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,6 +1635,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "markup5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.38.0+unofficial"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333171ccdf66e915257740d44e38ea5b1b19ce7b45d33cc35cb6f118fbd981ff"
+dependencies = [
+ "html5ever",
+ "markup5ever",
+ "tendril",
+ "xml5ever",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1677,6 +1722,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
@@ -1925,8 +1976,19 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros",
- "phf_shared",
+ "phf_macros 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -1935,8 +1997,18 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -1945,8 +2017,18 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -1955,8 +2037,21 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1967,6 +2062,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -2051,6 +2155,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -2775,6 +2885,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.13.1",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2884,6 +3019,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
+ "utf-8",
+]
+
+[[package]]
 name = "terminfo"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2891,8 +3036,8 @@ checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
  "nom 7.1.3",
- "phf",
- "phf_codegen",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
 ]
 
 [[package]]
@@ -2928,7 +3073,7 @@ dependencies = [
  "ordered-float",
  "pest",
  "pest_derive",
- "phf",
+ "phf 0.11.3",
  "sha2",
  "signal-hook",
  "siphasher",
@@ -3341,6 +3486,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3554,6 +3705,18 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
+dependencies = [
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]
@@ -3985,6 +4148,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xml5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dc9559429edf0cd3f327cc0afd9d6b36fa8cec6d93107b7fbe64f806b5f2d9"
+dependencies = [
+ "log",
+ "markup5ever",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/README.md
+++ b/README.md
@@ -159,28 +159,28 @@ The agent spawns up to 5 concurrent sub-agents, each on its own browser tab, to 
 
 | Tool | Description |
 |------|-------------|
-| `navigate` | Go to a URL. Uses HTTP first, auto-escalates to browser when JS is detected. |
-| `go_back` | Browser back button. |
-| `scroll` | Scroll up or down by pixel amount (default: 500px). |
-| `switch_tab` | Switch to a different browser tab by index. |
+| `navigate` | Go to a URL (supports `format`: markdown/text/html). Uses HTTP first, auto-escalates to browser when JS is detected. Returns structured content with a `page_map`. |
+| `go_back` | Browser back button. Returns `page_state` with the resulting page structure. |
+| `scroll` | Scroll up or down by pixel amount (`pixels`, default: 500). Returns `page_state` after scrolling. |
+| `switch_tab` | Switch to a different browser tab by index. Returns `page_state` of the new tab. |
 | `wait` | Wait for a CSS selector to appear or a timeout (up to 300s). |
 
 #### Interaction
 
 | Tool | Description |
 |------|-------------|
-| `click` | Click an element by CSS selector. |
-| `fill_form` | Fill form fields by selector or name, with optional auto-submit. |
-| `select_option` | Select a dropdown option by value, label, or index. |
-| `hover` | Hover over an element to reveal tooltips or menus. |
-| `press_key` | Press a keyboard key (Enter, Escape, Tab, etc.), optionally targeting an element. |
+| `click` | Click an element by CSS selector. Returns `page_state` after the click. |
+| `fill_form` | Fill form fields by selector or name, with optional auto-submit. Returns `page_state`. |
+| `select_option` | Select a dropdown option by value, label, or index. Returns `page_state`. |
+| `hover` | Hover over an element to reveal tooltips or menus. Returns `page_state`. |
+| `press_key` | Press a keyboard key (Enter, Escape, Tab, etc.), optionally targeting an element. Returns `page_state`. |
 | `execute_js` | Run arbitrary JavaScript in the page context and return the result. |
 
 #### Content Extraction
 
 | Tool | Description |
 |------|-------------|
-| `page_map` | Get the page's heading hierarchy with section sizes and text previews. |
+| `page_map` | Get the page's structural map: headings, landmarks, forms, links, and interactive element counts. |
 | `read_content` | Extract text by heading name or CSS selector, with offset/limit pagination for large pages. |
 | `list_resources` | List all links, images, and forms on the current page. |
 | `screenshot` | Capture a full-page screenshot (base64 PNG). |

--- a/crates/crawler/Cargo.toml
+++ b/crates/crawler/Cargo.toml
@@ -12,6 +12,7 @@ serde_json = "1"
 tokio = { version = "1", features = ["io-util", "macros", "process", "rt", "time"] }
 csv = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+htmd = "0.5"
 
 [lints]
 workspace = true

--- a/crates/crawler/src/fetcher.rs
+++ b/crates/crawler/src/fetcher.rs
@@ -649,8 +649,14 @@ mod tests {
             body: "<html><body><h1>Title</h1><a href=\"/link\">Click</a></body></html>".to_string(),
         };
         let page = http_response_to_page(resp);
-        assert!(page.markdown.contains("# "), "expected heading marker in markdown");
-        assert!(page.markdown.contains('['), "expected link syntax in markdown");
+        assert!(
+            page.markdown.contains("# "),
+            "expected heading marker in markdown"
+        );
+        assert!(
+            page.markdown.contains('['),
+            "expected link syntax in markdown"
+        );
     }
 
     #[test]

--- a/crates/crawler/src/fetcher.rs
+++ b/crates/crawler/src/fetcher.rs
@@ -13,6 +13,7 @@ pub struct FetchedPage {
     pub title: Option<String>,
     pub html: String,
     pub text: String,
+    pub markdown: String,
     pub fetched_via_browser: bool,
 }
 
@@ -350,6 +351,7 @@ impl FetchRouter {
             .map_err(|e| FetchError::Browser(e.to_string()))?;
 
         let text = extract_text(&page_info.html);
+        let markdown = crate::markdown::html_to_markdown(&page_info.html);
         let title = if page_info.title.is_empty() {
             extract_title(&page_info.html)
         } else {
@@ -361,6 +363,7 @@ impl FetchRouter {
             title,
             html: page_info.html,
             text,
+            markdown,
             fetched_via_browser: true,
         })
     }
@@ -369,11 +372,13 @@ impl FetchRouter {
 fn http_response_to_page(resp: HttpResponse) -> FetchedPage {
     let title = extract_title(&resp.body);
     let text = extract_text(&resp.body);
+    let markdown = crate::markdown::html_to_markdown(&resp.body);
     FetchedPage {
         url: resp.url,
         title,
         html: resp.body,
         text,
+        markdown,
         fetched_via_browser: false,
     }
 }
@@ -623,5 +628,56 @@ mod tests {
             .expect("fetch should succeed");
         assert!(page.title.is_some());
         assert!(page.text.contains("Example Domain"));
+    }
+
+    #[test]
+    fn http_response_to_page_has_markdown_field() {
+        let resp = HttpResponse {
+            url: "https://example.com".to_string(),
+            status: StatusCode::OK,
+            body: "<html><body><p>Hello world</p></body></html>".to_string(),
+        };
+        let page = http_response_to_page(resp);
+        assert!(!page.markdown.is_empty());
+    }
+
+    #[test]
+    fn http_response_to_page_markdown_has_structure() {
+        let resp = HttpResponse {
+            url: "https://example.com".to_string(),
+            status: StatusCode::OK,
+            body: "<html><body><h1>Title</h1><a href=\"/link\">Click</a></body></html>".to_string(),
+        };
+        let page = http_response_to_page(resp);
+        assert!(page.markdown.contains("# "), "expected heading marker in markdown");
+        assert!(page.markdown.contains('['), "expected link syntax in markdown");
+    }
+
+    #[test]
+    fn http_response_to_page_non_html_skips_markdown() {
+        let resp = HttpResponse {
+            url: "https://api.example.com/data".to_string(),
+            status: StatusCode::OK,
+            body: r#"{"key": "value"}"#.to_string(),
+        };
+        let page = http_response_to_page(resp);
+        assert!(
+            page.markdown.starts_with("```"),
+            "non-HTML input should be wrapped in a code block"
+        );
+    }
+
+    #[test]
+    fn http_response_to_page_markdown_field_exists_on_struct() {
+        let page = FetchedPage {
+            url: String::new(),
+            title: None,
+            html: String::new(),
+            text: String::new(),
+            markdown: String::new(),
+            fetched_via_browser: false,
+        };
+        // Compile-time check: the markdown field exists and is a String
+        let _: &String = &page.markdown;
     }
 }

--- a/crates/crawler/src/lib.rs
+++ b/crates/crawler/src/lib.rs
@@ -49,12 +49,13 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                 "type": "object",
                 "properties": {
                     "url": { "type": "string" },
-                    "format": { "type": "string", "enum": ["markdown", "text", "html"] }
+                    "format": { "type": "string", "enum": ["markdown", "text", "html"] },
+                    "content_depth": { "type": "string", "enum": ["full", "main", "slim", "none"], "default": "main" }
                 },
                 "required": ["url"],
                 "additionalProperties": false
             }),
-            instructions: Some("Always use full URLs including the protocol (https://). Returns markdown-formatted page content with an embedded page_map showing page structure. Use format='text' for plain text or format='html' for raw HTML. Read the content before taking further actions — the page_map.links array lets you navigate to linked pages without needing to click."),
+            instructions: Some("Always use full URLs including the protocol (https://). Returns page content with an embedded page_map showing page structure. Use content_depth to control context size: 'main' (default) extracts article/main content only, 'full' returns everything, 'slim' gives first 2000 chars of main content, 'none' skips content (page_map only). Use format='text' for plain text or format='html' for raw HTML. The page_map.links array lets you navigate to linked pages without needing to click."),
         },
         ToolSpec {
             name: "click",

--- a/crates/crawler/src/lib.rs
+++ b/crates/crawler/src/lib.rs
@@ -370,15 +370,27 @@ mod tests {
         let specs = mvp_tool_specs();
         let nav = specs.iter().find(|s| s.name == "navigate").unwrap();
         let schema_str = nav.input_schema.to_string();
-        assert!(schema_str.contains("format"), "navigate schema should have format param");
-        assert!(schema_str.contains("markdown"), "format enum should include markdown");
+        assert!(
+            schema_str.contains("format"),
+            "navigate schema should have format param"
+        );
+        assert!(
+            schema_str.contains("markdown"),
+            "format enum should include markdown"
+        );
     }
 
     #[test]
     fn page_map_spec_mentions_landmarks() {
         let specs = mvp_tool_specs();
         let pm = specs.iter().find(|s| s.name == "page_map").unwrap();
-        assert!(pm.description.contains("landmarks"), "page_map description should mention landmarks");
-        assert!(pm.instructions.unwrap_or("").contains("landmark"), "page_map instructions should mention landmark");
+        assert!(
+            pm.description.contains("landmarks"),
+            "page_map description should mention landmarks"
+        );
+        assert!(
+            pm.instructions.unwrap_or("").contains("landmark"),
+            "page_map instructions should mention landmark"
+        );
     }
 }

--- a/crates/crawler/src/lib.rs
+++ b/crates/crawler/src/lib.rs
@@ -109,7 +109,7 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                 "additionalProperties": false
             }),
 
-            instructions: None,
+            instructions: Some("Returns the URL navigated to and a `page_state` object with headings, landmarks, and links of the resulting page. Use page_state to understand what you landed on after going back."),
         },
         ToolSpec {
             name: "scroll",
@@ -210,7 +210,7 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                 "additionalProperties": false
             }),
 
-            instructions: None,
+            instructions: Some("Returns tab count and a `page_state` object reflecting the switched-to tab's content (headings, landmarks, links). Use page_state to orient yourself in the new tab without needing a separate page_map call."),
         },
         ToolSpec {
             name: "list_resources",

--- a/crates/crawler/src/lib.rs
+++ b/crates/crawler/src/lib.rs
@@ -44,17 +44,17 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
     vec![
         ToolSpec {
             name: "navigate",
-            description: "Navigate to a URL and get page content",
+            description: "Navigate to a URL and get page content as structured markdown (default), plain text, or raw HTML",
             input_schema: json!({
                 "type": "object",
                 "properties": {
-                    "url": { "type": "string" }
+                    "url": { "type": "string" },
+                    "format": { "type": "string", "enum": ["markdown", "text", "html"] }
                 },
                 "required": ["url"],
                 "additionalProperties": false
             }),
-
-            instructions: Some("Always use full URLs including the protocol (https://). The response includes extracted page text — read it before taking further actions."),
+            instructions: Some("Always use full URLs including the protocol (https://). Returns markdown-formatted page content with an embedded page_map showing page structure. Use format='text' for plain text or format='html' for raw HTML. Read the content before taking further actions — the page_map.links array lets you navigate to linked pages without needing to click."),
         },
         ToolSpec {
             name: "click",
@@ -68,7 +68,7 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                 "additionalProperties": false
             }),
 
-            instructions: Some("May trigger navigation or page changes. Read the tool result before issuing another action."),
+            instructions: Some("May trigger navigation or page changes. The response includes post-action page state (URL, title, page structure) so you can see what changed. Use navigate with a direct URL from page_map.links instead of click when possible — it's more reliable."),
         },
         ToolSpec {
             name: "fill_form",
@@ -87,7 +87,7 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                 "additionalProperties": false
             }),
 
-            instructions: Some("Keys in `fields` can be CSS selectors (`#email`, `input[name=\"q\"]`) or plain field names/IDs that are resolved automatically. Set `submit` to true to submit after filling. Use `form_selector` when the page has multiple forms."),
+            instructions: Some("Keys in `fields` can be CSS selectors (`#email`, `input[name=\"q\"]`) or plain field names/IDs that are resolved automatically. Set `submit` to true to submit after filling. Use `form_selector` when the page has multiple forms. The response includes post-action page state showing the resulting URL and page structure."),
         },
         ToolSpec {
             name: "screenshot",
@@ -123,7 +123,7 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                 "additionalProperties": false
             }),
 
-            instructions: Some("Use to reveal lazy-loaded content or elements below the fold. Scroll down before concluding content is missing."),
+            instructions: Some("Use to reveal lazy-loaded content or elements below the fold. Returns updated page structure after scrolling. Scroll down before concluding content is missing."),
         },
         ToolSpec {
             name: "wait",
@@ -221,7 +221,7 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                 "additionalProperties": false
             }),
 
-            instructions: Some("Use to discover available links, forms, or images before interacting with them. Helps plan the next action when the page structure is unclear."),
+            instructions: Some("Use to discover available links, images, or forms. Note: page_map now also includes links and forms — use list_resources when you need ALL links (page_map caps at 50) or image details."),
         },
         ToolSpec {
             name: "save_file",
@@ -241,14 +241,14 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: "page_map",
-            description: "Get the page structure as a heading outline with section sizes and previews",
+            description: "Get comprehensive page structure: headings, landmarks, forms, interactive elements, and links",
             input_schema: json!({
                 "type": "object",
                 "properties": {},
                 "required": [],
                 "additionalProperties": false
             }),
-            instructions: Some("Returns the heading hierarchy of the current page as a list of sections, each with: level (1-6), text, id (if present), css_selector, char_count (characters in section), and preview (first ~100 chars). Use this to discover page structure before calling read_content. If sections is empty, the page has no semantic headings — fall back to read_content with a CSS selector."),
+            instructions: Some("Returns the full page anatomy: heading hierarchy (h1-h6 with section sizes), landmark regions (nav/main/aside/article/footer), forms (with field details), links (text + href, capped at 50), interactive element counts, and page metadata. Use links[].href with navigate instead of clicking when the URL is visible. If headings is empty, the page has no semantic headings — check landmarks instead."),
         },
         ToolSpec {
             name: "read_content",
@@ -363,5 +363,22 @@ mod tests {
                 spec.name
             );
         }
+    }
+
+    #[test]
+    fn navigate_spec_has_format_param() {
+        let specs = mvp_tool_specs();
+        let nav = specs.iter().find(|s| s.name == "navigate").unwrap();
+        let schema_str = nav.input_schema.to_string();
+        assert!(schema_str.contains("format"), "navigate schema should have format param");
+        assert!(schema_str.contains("markdown"), "format enum should include markdown");
+    }
+
+    #[test]
+    fn page_map_spec_mentions_landmarks() {
+        let specs = mvp_tool_specs();
+        let pm = specs.iter().find(|s| s.name == "page_map").unwrap();
+        assert!(pm.description.contains("landmarks"), "page_map description should mention landmarks");
+        assert!(pm.instructions.unwrap_or("").contains("landmark"), "page_map instructions should mention landmark");
     }
 }

--- a/crates/crawler/src/lib.rs
+++ b/crates/crawler/src/lib.rs
@@ -154,7 +154,7 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                 "additionalProperties": false
             }),
 
-            instructions: Some("Provide `selector` for the <select> element, then one of `value`, `label`, or `index` to identify the option."),
+            instructions: Some("Provide `selector` for the <select> element, then one of `value`, `label`, or `index` to identify the option. Returns a `page_state` with the updated page structure after selection."),
         },
         ToolSpec {
             name: "execute_js",
@@ -182,7 +182,7 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                 "additionalProperties": false
             }),
 
-            instructions: None,
+            instructions: Some("Use to reveal tooltips, dropdown menus, or hidden content. Returns a `page_state` with the updated page structure after hover."),
         },
         ToolSpec {
             name: "press_key",
@@ -197,7 +197,7 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                 "additionalProperties": false
             }),
 
-            instructions: None,
+            instructions: Some("Press Enter to submit, Escape to close modals, Tab to move focus, or arrow keys to navigate. Optional `selector` targets a specific element. Returns a `page_state` with the updated page structure after the keypress."),
         },
         ToolSpec {
             name: "switch_tab",

--- a/crates/crawler/src/lib.rs
+++ b/crates/crawler/src/lib.rs
@@ -4,6 +4,7 @@ mod agent;
 mod browser;
 mod fetcher;
 mod manager;
+pub mod markdown;
 mod output;
 mod playwright;
 mod prompt;
@@ -216,10 +217,7 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
             description: "List page resources (links, images, forms)",
             input_schema: json!({
                 "type": "object",
-                "properties": {
-                    "type_pattern": { "type": "string" },
-                    "name_pattern": { "type": "string" }
-                },
+                "properties": {},
                 "additionalProperties": false
             }),
 

--- a/crates/crawler/src/lib.rs
+++ b/crates/crawler/src/lib.rs
@@ -50,12 +50,13 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                 "properties": {
                     "url": { "type": "string" },
                     "format": { "type": "string", "enum": ["markdown", "text", "html"] },
-                    "content_depth": { "type": "string", "enum": ["full", "main", "slim", "none"], "default": "main" }
+                    "content_depth": { "type": "string", "enum": ["full", "main", "slim", "none"], "default": "main" },
+                    "strip_images": { "type": "boolean", "default": true }
                 },
                 "required": ["url"],
                 "additionalProperties": false
             }),
-            instructions: Some("Always use full URLs including the protocol (https://). Returns page content with an embedded page_map showing page structure. Use content_depth to control context size: 'main' (default) extracts article/main content only, 'full' returns everything, 'slim' gives first 2000 chars of main content, 'none' skips content (page_map only). Use format='text' for plain text or format='html' for raw HTML. The page_map.links array lets you navigate to linked pages without needing to click."),
+            instructions: Some("Always use full URLs including the protocol (https://). Returns page content with an embedded page_map showing page structure. Use content_depth to control context size: 'main' (default) extracts article/main content only, 'full' returns everything, 'slim' gives first 2000 chars of main content, 'none' skips content (page_map only). Images are stripped by default (strip_images=true) since they waste context — set false only when you need image URLs. The page_map.links array lets you navigate to linked pages without clicking."),
         },
         ToolSpec {
             name: "click",

--- a/crates/crawler/src/lib.rs
+++ b/crates/crawler/src/lib.rs
@@ -118,7 +118,7 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                 "type": "object",
                 "properties": {
                     "direction": { "type": "string", "enum": ["up", "down"] },
-                    "amount": { "type": "integer" }
+                    "pixels": { "type": "integer", "description": "Pixels to scroll (default: 500). Use 300–800 for a normal page scroll." }
                 },
                 "additionalProperties": false
             }),

--- a/crates/crawler/src/markdown.rs
+++ b/crates/crawler/src/markdown.rs
@@ -1,0 +1,202 @@
+use htmd::HtmlToMarkdown;
+use std::sync::LazyLock;
+
+static CONVERTER: LazyLock<HtmlToMarkdown> = LazyLock::new(|| {
+    HtmlToMarkdown::builder()
+        .skip_tags(vec!["script", "style", "noscript", "iframe", "head", "svg"])
+        .build()
+});
+
+pub const DEFAULT_MAX_MARKDOWN_CHARS: usize = 32_000;
+
+pub fn html_to_markdown(html: &str) -> String {
+    if is_non_html_input(html) {
+        return wrap_in_code_block(html);
+    }
+
+    let markdown = CONVERTER.convert(html).unwrap_or_else(|_| html.to_string());
+
+    normalize_markdown(&markdown)
+}
+
+#[must_use]
+pub fn html_to_markdown_capped(html: &str, max_chars: usize) -> (String, bool) {
+    let markdown = html_to_markdown(html);
+    let max_chars = std::env::var("ACRAWL_MAX_MARKDOWN_CHARS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(max_chars);
+
+    truncate_markdown(markdown, max_chars)
+}
+
+fn is_non_html_input(input: &str) -> bool {
+    let trimmed = input.trim_start();
+
+    trimmed.starts_with('{')
+        || trimmed.starts_with('[')
+        || trimmed.starts_with("%PDF")
+        || contains_binary_controls(trimmed)
+}
+
+fn contains_binary_controls(input: &str) -> bool {
+    input
+        .chars()
+        .any(|ch| ch.is_control() && !matches!(ch, '\n' | '\r' | '\t'))
+}
+
+fn wrap_in_code_block(content: &str) -> String {
+    format!("```\n{content}\n```")
+}
+
+fn normalize_markdown(markdown: &str) -> String {
+    let mut normalized = String::with_capacity(markdown.len());
+    let mut in_code_block = false;
+
+    for line in markdown.lines() {
+        if line.starts_with("```") {
+            in_code_block = !in_code_block;
+            normalized.push_str(line);
+        } else if !in_code_block {
+            if let Some(rest) = line.strip_prefix("* ") {
+                normalized.push_str("- ");
+                normalized.push_str(rest.trim_start());
+            } else {
+                normalized.push_str(line);
+            }
+        } else {
+            normalized.push_str(line);
+        }
+
+        normalized.push('\n');
+    }
+
+    if !markdown.ends_with('\n') && !normalized.is_empty() {
+        normalized.pop();
+    }
+
+    normalized
+}
+
+fn truncate_markdown(markdown: String, max_chars: usize) -> (String, bool) {
+    if markdown.chars().count() <= max_chars {
+        return (markdown, false);
+    }
+
+    let truncated = markdown
+        .char_indices()
+        .nth(max_chars)
+        .map_or(markdown.clone(), |(idx, _)| markdown[..idx].to_string());
+
+    (truncated, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn html_to_markdown_preserves_headings() {
+        let markdown = html_to_markdown("<h1>Title</h1>");
+        assert!(markdown.contains("# Title"));
+    }
+
+    #[test]
+    fn html_to_markdown_preserves_links() {
+        let markdown = html_to_markdown("<a href=\"https://example.com\">text</a>");
+        assert!(markdown.contains("[text](https://example.com)"));
+    }
+
+    #[test]
+    fn html_to_markdown_preserves_lists() {
+        let markdown = html_to_markdown("<ul><li>item</li></ul>");
+        assert!(markdown.contains("- item"));
+    }
+
+    #[test]
+    fn html_to_markdown_preserves_code_blocks() {
+        let markdown = html_to_markdown("<pre><code>fn main()</code></pre>");
+        assert!(markdown.contains("```"));
+        assert!(markdown.contains("fn main()"));
+    }
+
+    #[test]
+    fn html_to_markdown_preserves_tables() {
+        let html =
+            "<table><tr><th>Name</th><th>Value</th></tr><tr><td>foo</td><td>bar</td></tr></table>";
+        let markdown = html_to_markdown(html);
+        assert!(markdown.contains('|'));
+        assert!(markdown.contains("Name"));
+        assert!(markdown.contains("foo"));
+    }
+
+    #[test]
+    fn html_to_markdown_strips_script_style() {
+        let html = "<script>alert('x')</script><style>body{color:red;}</style><p>content</p>";
+        let markdown = html_to_markdown(html);
+        assert!(markdown.contains("content"));
+        assert!(!markdown.contains("alert"));
+        assert!(!markdown.contains("color:red"));
+    }
+
+    #[test]
+    fn html_to_markdown_handles_malformed_html() {
+        let markdown = html_to_markdown("<div><h1>Title<p>body");
+        assert!(markdown.contains("Title"));
+        assert!(markdown.contains("body"));
+    }
+
+    #[test]
+    fn html_to_markdown_capped_truncates() {
+        let html = format!("<p>{}</p>", "a".repeat(DEFAULT_MAX_MARKDOWN_CHARS + 256));
+        let (markdown, was_truncated) = html_to_markdown_capped(&html, DEFAULT_MAX_MARKDOWN_CHARS);
+        assert_eq!(markdown.chars().count(), DEFAULT_MAX_MARKDOWN_CHARS);
+        assert!(was_truncated);
+    }
+
+    #[test]
+    fn html_to_markdown_capped_no_truncate_small() {
+        let (markdown, was_truncated) = html_to_markdown_capped("<p>short text</p>", 128);
+        assert!(!was_truncated);
+        assert!(markdown.contains("short text"));
+    }
+
+    #[test]
+    fn html_to_markdown_non_html_passthrough() {
+        let markdown = html_to_markdown("{\"key\": \"value\"}");
+        assert_eq!(markdown, "```\n{\"key\": \"value\"}\n```");
+    }
+
+    #[test]
+    fn html_to_markdown_real_page_structure() {
+        let html = r#"
+            <html>
+                <head><title>Example</title></head>
+                <body>
+                    <header>
+                        <h1>Docs</h1>
+                        <p>Welcome to the docs.</p>
+                    </header>
+                    <main>
+                        <section>
+                            <h2>Getting Started</h2>
+                            <p>Read the <a href="https://example.com/guide">guide</a>.</p>
+                        </section>
+                        <section>
+                            <h2>Reference</h2>
+                            <ul>
+                                <li>API</li>
+                                <li>Examples</li>
+                            </ul>
+                        </section>
+                    </main>
+                </body>
+            </html>
+        "#;
+
+        let markdown = html_to_markdown(html);
+        assert!(markdown.contains("# Docs"));
+        assert!(markdown.contains("## Getting Started"));
+        assert!(markdown.contains("[guide](https://example.com/guide)"));
+    }
+}

--- a/crates/crawler/src/markdown.rs
+++ b/crates/crawler/src/markdown.rs
@@ -14,7 +14,9 @@ pub fn html_to_markdown(html: &str) -> String {
         return wrap_in_code_block(html);
     }
 
-    let markdown = CONVERTER.convert(html).unwrap_or_else(|_| html.to_string());
+    let markdown = CONVERTER
+        .convert(html)
+        .unwrap_or_else(|_| strip_tags_fallback(html));
 
     normalize_markdown(&markdown)
 }
@@ -45,8 +47,56 @@ fn contains_binary_controls(input: &str) -> bool {
         .any(|ch| ch.is_control() && !matches!(ch, '\n' | '\r' | '\t'))
 }
 
+fn strip_tags_fallback(html: &str) -> String {
+    let mut out = html.to_string();
+
+    for tag in ["script", "style", "noscript"] {
+        let open = format!("<{tag}");
+        let close = format!("</{tag}>");
+        let mut clean = String::with_capacity(out.len());
+        let src_lower = out.to_ascii_lowercase();
+        let mut pos = 0;
+        while pos < out.len() {
+            if let Some(start) = src_lower[pos..].find(&open) {
+                clean.push_str(&out[pos..pos + start]);
+                let abs = pos + start;
+                if let Some(end) = src_lower[abs..].find(&close) {
+                    pos = abs + end + close.len();
+                } else {
+                    pos = out.len();
+                }
+            } else {
+                clean.push_str(&out[pos..]);
+                break;
+            }
+        }
+        out = clean;
+    }
+
+    let mut result = String::with_capacity(out.len());
+    let mut inside_tag = false;
+    for ch in out.chars() {
+        match ch {
+            '<' => {
+                inside_tag = true;
+                result.push(' ');
+            }
+            '>' if inside_tag => inside_tag = false,
+            _ if !inside_tag => result.push(ch),
+            _ => {}
+        }
+    }
+
+    result
+}
+
 fn wrap_in_code_block(content: &str) -> String {
-    format!("```\n{content}\n```")
+    // Find a fence that doesn't clash with content
+    let mut fence = "```".to_string();
+    while content.contains(&fence) {
+        fence.push('`');
+    }
+    format!("{fence}\n{content}\n{fence}")
 }
 
 fn normalize_markdown(markdown: &str) -> String {

--- a/crates/crawler/src/markdown.rs
+++ b/crates/crawler/src/markdown.rs
@@ -3,7 +3,9 @@ use std::sync::LazyLock;
 
 static CONVERTER: LazyLock<HtmlToMarkdown> = LazyLock::new(|| {
     HtmlToMarkdown::builder()
-        .skip_tags(vec!["script", "style", "noscript", "iframe", "head", "svg"])
+        .skip_tags(vec![
+            "script", "style", "noscript", "iframe", "head", "svg", "nav", "footer",
+        ])
         .build()
 });
 
@@ -87,6 +89,56 @@ fn strip_tags_fallback(html: &str) -> String {
         }
     }
 
+    result
+}
+
+#[must_use]
+pub fn extract_main_html(html: &str) -> String {
+    if let Some(content) = extract_tag_inner(html, "main") {
+        return content;
+    }
+    if let Some(content) = extract_tag_inner(html, "article") {
+        return content;
+    }
+    let mut result = html.to_string();
+    for tag in ["nav", "footer", "header", "aside"] {
+        result = remove_tag_block(&result, tag);
+    }
+    result
+}
+
+fn extract_tag_inner(html: &str, tag: &str) -> Option<String> {
+    let lower = html.to_ascii_lowercase();
+    let open = format!("<{tag}");
+    let close = format!("</{tag}>");
+
+    let start_pos = lower.find(&open)?;
+    let tag_end = html[start_pos..].find('>')? + start_pos + 1;
+    let close_pos = lower[tag_end..].find(&close)? + tag_end;
+
+    Some(html[tag_end..close_pos].to_string())
+}
+
+fn remove_tag_block(html: &str, tag: &str) -> String {
+    let open = format!("<{tag}");
+    let close = format!("</{tag}>");
+    let mut result = String::with_capacity(html.len());
+    let lower = html.to_ascii_lowercase();
+    let mut pos = 0;
+    while pos < html.len() {
+        if let Some(start) = lower[pos..].find(&open) {
+            result.push_str(&html[pos..pos + start]);
+            let abs = pos + start;
+            if let Some(end) = lower[abs..].find(&close) {
+                pos = abs + end + close.len();
+            } else {
+                pos = html.len();
+            }
+        } else {
+            result.push_str(&html[pos..]);
+            break;
+        }
+    }
     result
 }
 

--- a/crates/crawler/src/playwright.rs
+++ b/crates/crawler/src/playwright.rs
@@ -304,13 +304,16 @@ async function bootstrap() {
             selector: cssPath(el),
             text_preview: (el.innerText || '').trim().slice(0, 120),
           }));
+          const total_landmarks = landmarks.length;
+          const cappedLandmarks = landmarks.slice(0, 20);
 
-          const forms = Array.from(document.querySelectorAll('form')).map((f) => ({
-            action: f.action || '',
-            method: f.method || 'get',
-            id: f.id || null,
-            selector: cssPath(f),
-            fields: Array.from(f.querySelectorAll('input, select, textarea')).map((el) => {
+          const MAX_FORMS = 10;
+          const MAX_FIELDS_PER_FORM = 30;
+          const allForms = Array.from(document.querySelectorAll('form'));
+          const total_forms = allForms.length;
+          const forms = allForms.slice(0, MAX_FORMS).map((f) => {
+            const allFields = Array.from(f.querySelectorAll('input, select, textarea'));
+            const fields = allFields.slice(0, MAX_FIELDS_PER_FORM).map((el) => {
               const label = el.id
                 ? document.querySelector(`label[for="${CSS.escape(el.id)}"]`)?.textContent?.trim() || el.placeholder || ''
                 : el.placeholder || '';
@@ -320,20 +323,32 @@ async function bootstrap() {
                 label,
                 required: Boolean(el.required),
               };
-            }),
-          }));
+            });
+            return {
+              action: f.action || '',
+              method: f.method || 'get',
+              id: f.id || null,
+              selector: cssPath(f),
+              fields,
+              total_fields: allFields.length,
+            };
+          });
 
           const seenHrefs = new Set();
-          const links = Array.from(document.querySelectorAll('a[href]')).flatMap((a) => {
+          const MAX_LINKS = 50;
+          let total_links = 0;
+          const links = [];
+          for (const a of document.querySelectorAll('a[href]')) {
             const text = (a.textContent || '').trim();
             const rawHref = a.getAttribute('href') || '';
             const href = a.href || rawHref;
-            if (!text || rawHref.startsWith('#') || seenHrefs.has(href)) {
-              return [];
-            }
+            if (!text || rawHref.startsWith('#') || seenHrefs.has(href)) continue;
             seenHrefs.add(href);
-            return [{ text, href, selector: cssPath(a) }];
-          });
+            total_links++;
+            if (links.length < MAX_LINKS) {
+              links.push({ text, href, selector: cssPath(a) });
+            }
+          }
 
           const interactive = {
             buttons: document.querySelectorAll('button').length,
@@ -348,7 +363,7 @@ async function bootstrap() {
             url: window.location.href,
           };
 
-          return { headings, landmarks, forms, links, interactive, meta };
+          return { headings, landmarks: cappedLandmarks, forms, links, interactive, meta, total_landmarks, total_forms, total_links };
         });
         process.stdout.write(JSON.stringify({ event: 'bridge_response', ok: true, result }) + '\n');
       } catch (error) {

--- a/crates/crawler/src/playwright.rs
+++ b/crates/crawler/src/playwright.rs
@@ -261,7 +261,7 @@ async function bootstrap() {
 
     if (command.action === 'page_map') {
       try {
-        const sections = await page.evaluate(() => {
+        const result = await page.evaluate(() => {
           function cssPath(el) {
             if (el.id) return '#' + CSS.escape(el.id);
             const parts = [];
@@ -278,8 +278,8 @@ async function bootstrap() {
             }
             return parts.join(' > ');
           }
-          const headings = Array.from(document.querySelectorAll('h1, h2, h3, h4, h5, h6'));
-          return headings.map((el) => {
+
+          const headings = Array.from(document.querySelectorAll('h1, h2, h3, h4, h5, h6')).map((el) => {
             const level = parseInt(el.tagName[1]);
             const text = el.innerText.trim();
             const id = el.id || null;
@@ -296,8 +296,61 @@ async function bootstrap() {
             const preview = char_count > 100 ? content.slice(0, 100).trim() + '...' : content.trim();
             return { level, text, id, selector, char_count, preview };
           });
+
+          const landmarks = Array.from(document.querySelectorAll('nav, main, aside, article, footer, header, section[aria-label], [role="navigation"], [role="main"], [role="complementary"]')).map((el) => ({
+            tag: el.tagName.toLowerCase(),
+            role: el.getAttribute('role'),
+            id: el.id || null,
+            selector: cssPath(el),
+            text_preview: (el.innerText || '').trim().slice(0, 120),
+          }));
+
+          const forms = Array.from(document.querySelectorAll('form')).map((f) => ({
+            action: f.action || '',
+            method: f.method || 'get',
+            id: f.id || null,
+            selector: cssPath(f),
+            fields: Array.from(f.querySelectorAll('input, select, textarea')).map((el) => {
+              const label = el.id
+                ? document.querySelector(`label[for="${CSS.escape(el.id)}"]`)?.textContent?.trim() || el.placeholder || ''
+                : el.placeholder || '';
+              return {
+                name: el.name || '',
+                type: el.type || el.tagName.toLowerCase(),
+                label,
+                required: Boolean(el.required),
+              };
+            }),
+          }));
+
+          const seenHrefs = new Set();
+          const links = Array.from(document.querySelectorAll('a[href]')).flatMap((a) => {
+            const text = (a.textContent || '').trim();
+            const rawHref = a.getAttribute('href') || '';
+            const href = a.href || rawHref;
+            if (!text || rawHref.startsWith('#') || seenHrefs.has(href)) {
+              return [];
+            }
+            seenHrefs.add(href);
+            return [{ text, href, selector: cssPath(a) }];
+          });
+
+          const interactive = {
+            buttons: document.querySelectorAll('button').length,
+            inputs: document.querySelectorAll('input').length,
+            selects: document.querySelectorAll('select').length,
+            textareas: document.querySelectorAll('textarea').length,
+          };
+
+          const meta = {
+            title: document.title,
+            description: document.querySelector('meta[name="description"]')?.content || '',
+            url: window.location.href,
+          };
+
+          return { headings, landmarks, forms, links, interactive, meta };
         });
-        process.stdout.write(JSON.stringify({ event: 'bridge_response', ok: true, result: { sections } }) + '\n');
+        process.stdout.write(JSON.stringify({ event: 'bridge_response', ok: true, result }) + '\n');
       } catch (error) {
         process.stdout.write(JSON.stringify({ event: 'bridge_response', ok: false, error: { kind: 'page_map_error', message: String(error) } }) + '\n');
       }

--- a/crates/crawler/src/tools/click.rs
+++ b/crates/crawler/src/tools/click.rs
@@ -33,9 +33,12 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
         .await
         .map_err(|e| ToolError(e.to_string()))?;
 
+    let page_state = super::feedback::post_action_page_state(browser).await;
+
     Ok(ToolEffect::reply_json(&serde_json::json!({
         "success": true,
-        "message": format!("Clicked element: {}", params.selector)
+        "message": format!("Clicked element: {}", params.selector),
+        "page_state": page_state
     })))
 }
 
@@ -76,5 +79,22 @@ mod tests {
         let input = json!({"selector": "div.container > ul > li:nth-child(2) a"});
         let result = parse_input(&input).unwrap();
         assert_eq!(result.selector, "div.container > ul > li:nth-child(2) a");
+    }
+
+    #[test]
+    fn click_response_includes_page_state() {
+        let mock_pm = json!({
+            "headings": [], "landmarks": [], "forms": [], "links": [],
+            "interactive": {}, "meta": {"title": "Test", "url": "https://test.com", "description": ""}
+        });
+        let page_state = crate::tools::feedback::build_page_state_from_map(mock_pm);
+        let response = json!({
+            "success": true,
+            "message": "Clicked element: .btn",
+            "page_state": page_state
+        });
+        assert!(response["page_state"]["url"].is_string());
+        assert!(response["page_state"]["title"].is_string());
+        assert!(!response["page_state"]["page_map"].is_null());
     }
 }

--- a/crates/crawler/src/tools/feedback.rs
+++ b/crates/crawler/src/tools/feedback.rs
@@ -1,0 +1,170 @@
+#![allow(dead_code, reason = "callers wired in subsequent tasks")]
+
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tokio::time::timeout;
+
+use crate::browser::BrowserContext;
+
+use super::page_map::apply_page_map_caps;
+
+const FEEDBACK_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Build structured page state from a raw `page_map` value.
+///
+/// Applies caps, extracts url/title from meta, and strips `forms` and
+/// `interactive` fields to keep interaction responses concise.
+pub fn build_page_state_from_map(mut pm: Value) -> Value {
+    apply_page_map_caps(&mut pm);
+
+    let url = pm
+        .get("meta")
+        .and_then(|m| m.get("url"))
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_string();
+
+    let title = pm
+        .get("meta")
+        .and_then(|m| m.get("title"))
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_string();
+
+    if let Some(obj) = pm.as_object_mut() {
+        obj.remove("forms");
+        obj.remove("interactive");
+    }
+
+    json!({
+        "url": url,
+        "title": title,
+        "page_map": pm
+    })
+}
+
+fn fallback_value() -> Value {
+    json!({
+        "url": "unknown",
+        "title": "unknown",
+        "page_map": null
+    })
+}
+
+/// Best-effort post-action page state for interaction tool responses.
+///
+/// Calls the bridge `page_map` with a 3-second timeout. On success, returns
+/// structured url + title + trimmed `page_map`. On any failure, returns a
+/// fallback with null `page_map` — never propagates errors.
+pub async fn post_action_page_state(browser: &mut BrowserContext) -> Value {
+    let result = timeout(FEEDBACK_TIMEOUT, async {
+        let mut bridge = browser.acquire_bridge().await?;
+        bridge.page_map().await
+    })
+    .await;
+
+    match result {
+        Ok(Ok(pm)) => build_page_state_from_map(pm),
+        _ => fallback_value(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{build_page_state_from_map, fallback_value};
+
+    #[test]
+    fn feedback_fallback_value_has_correct_shape() {
+        let val = fallback_value();
+
+        assert_eq!(val["url"], "unknown");
+        assert_eq!(val["title"], "unknown");
+        assert!(val["page_map"].is_null(), "page_map should be null");
+
+        let obj = val.as_object().expect("fallback should be an object");
+        assert!(obj.contains_key("url"));
+        assert!(obj.contains_key("title"));
+        assert!(obj.contains_key("page_map"));
+        assert_eq!(obj.len(), 3, "fallback should have exactly 3 keys");
+    }
+
+    #[test]
+    fn feedback_success_value_from_mock_page_map() {
+        let mock_page_map = json!({
+            "headings": [
+                {
+                    "level": 1,
+                    "text": "Welcome",
+                    "id": "welcome",
+                    "selector": "#welcome",
+                    "char_count": 100,
+                    "preview": "Welcome to the site"
+                }
+            ],
+            "landmarks": [
+                {
+                    "tag": "nav",
+                    "role": "navigation",
+                    "id": "nav",
+                    "selector": "#nav",
+                    "text_preview": "Main nav"
+                }
+            ],
+            "forms": [
+                {
+                    "action": "/login",
+                    "method": "post",
+                    "id": "login-form",
+                    "selector": "#login-form",
+                    "fields": [{"name": "email", "type": "email"}]
+                }
+            ],
+            "links": [
+                {
+                    "text": "Home",
+                    "href": "https://example.com",
+                    "selector": "a.home"
+                }
+            ],
+            "interactive": {
+                "buttons": 3,
+                "inputs": 2,
+                "selects": 1,
+                "textareas": 0
+            },
+            "meta": {
+                "title": "Example Page",
+                "url": "https://example.com/page",
+                "description": "A test page"
+            }
+        });
+
+        let result = build_page_state_from_map(mock_page_map);
+
+        assert_eq!(result["url"], "https://example.com/page");
+        assert_eq!(result["title"], "Example Page");
+        assert!(!result["page_map"].is_null(), "page_map should not be null");
+
+        let pm = &result["page_map"];
+        assert!(pm["headings"].is_array());
+        assert!(pm["landmarks"].is_array());
+        assert!(pm["links"].is_array());
+        assert!(pm["meta"].is_object());
+
+        assert!(
+            pm.get("forms").is_none(),
+            "forms should be removed from page_map"
+        );
+        assert!(
+            pm.get("interactive").is_none(),
+            "interactive should be removed from page_map"
+        );
+
+        assert!(pm.get("truncated_links").is_some());
+        assert!(pm.get("truncated_forms").is_some());
+        assert!(pm.get("truncated_landmarks").is_some());
+    }
+}

--- a/crates/crawler/src/tools/feedback.rs
+++ b/crates/crawler/src/tools/feedback.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code, reason = "callers wired in subsequent tasks")]
-
 use std::time::Duration;
 
 use serde_json::{json, Value};

--- a/crates/crawler/src/tools/fill_form.rs
+++ b/crates/crawler/src/tools/fill_form.rs
@@ -78,13 +78,16 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
             .map_err(|e| ToolError(format!("failed to submit form: {e}")))?;
     }
 
+    let page_state = super::feedback::post_action_page_state(browser).await;
+
     let field_count = params.fields.len();
     Ok(ToolEffect::reply_json(&serde_json::json!({
         "success": true,
         "message": format!(
             "Filled {field_count} field(s){}",
             if params.submit { " and submitted form" } else { "" }
-        )
+        ),
+        "page_state": page_state
     })))
 }
 
@@ -152,5 +155,23 @@ mod tests {
         let result = parse_input(&input).unwrap();
         assert!(!result.submit);
         assert_eq!(result.form_selector, "form");
+    }
+
+    #[test]
+    fn fill_form_response_includes_page_state() {
+        use serde_json::json;
+        let mock_pm = json!({
+            "headings": [], "landmarks": [], "forms": [], "links": [],
+            "interactive": {}, "meta": {"title": "Test", "url": "https://test.com", "description": ""}
+        });
+        let page_state = crate::tools::feedback::build_page_state_from_map(mock_pm);
+        let response = json!({
+            "success": true,
+            "message": "Filled 2 field(s) and submitted form",
+            "page_state": page_state
+        });
+        assert!(response["page_state"]["url"].is_string());
+        assert!(response["page_state"]["title"].is_string());
+        assert!(!response["page_state"]["page_map"].is_null());
     }
 }

--- a/crates/crawler/src/tools/go_back.rs
+++ b/crates/crawler/src/tools/go_back.rs
@@ -14,8 +14,12 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
         .await
         .map_err(|e| ToolError(e.to_string()))?;
 
+    let page_state = super::feedback::post_action_page_state(browser).await;
+
     Ok(ToolEffect::reply_json(&serde_json::json!({
-        "url": url
+        "success": true,
+        "url": url,
+        "page_state": page_state
     })))
 }
 

--- a/crates/crawler/src/tools/hover.rs
+++ b/crates/crawler/src/tools/hover.rs
@@ -22,9 +22,12 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
         .await
         .map_err(|e| ToolError(e.to_string()))?;
 
+    let page_state = super::feedback::post_action_page_state(browser).await;
+
     Ok(ToolEffect::reply_json(&json!({
         "success": true,
-        "message": format!("Hovered over: {selector}")
+        "message": format!("Hovered over: {selector}"),
+        "page_state": page_state
     })))
 }
 
@@ -51,5 +54,22 @@ mod tests {
     fn fails_with_non_string() {
         let input = json!({"selector": 123});
         assert!(parse_input(&input).is_err());
+    }
+
+    #[test]
+    fn hover_response_includes_page_state() {
+        let mock_pm = json!({
+            "headings": [], "landmarks": [], "forms": [], "links": [],
+            "interactive": {}, "meta": {"title": "Test", "url": "https://test.com", "description": ""}
+        });
+        let page_state = crate::tools::feedback::build_page_state_from_map(mock_pm);
+        let response = json!({
+            "success": true,
+            "message": "Hovered over: .menu-item",
+            "page_state": page_state
+        });
+        assert!(response["page_state"]["url"].is_string());
+        assert!(response["page_state"]["title"].is_string());
+        assert!(!response["page_state"]["page_map"].is_null());
     }
 }

--- a/crates/crawler/src/tools/list_resources.rs
+++ b/crates/crawler/src/tools/list_resources.rs
@@ -3,20 +3,8 @@ use serde_json::{json, Value};
 use crate::browser::BrowserContext;
 use crate::{ToolEffect, ToolError};
 
-pub fn parse_input(input: &Value) -> (Option<String>, Option<String>) {
-    let type_pattern = input
-        .get("type_pattern")
-        .and_then(|v| v.as_str())
-        .map(String::from);
-    let name_pattern = input
-        .get("name_pattern")
-        .and_then(|v| v.as_str())
-        .map(String::from);
-    (type_pattern, name_pattern)
-}
-
 pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<ToolEffect, ToolError> {
-    let (_type_pattern, _name_pattern) = parse_input(input);
+    let _ = input;
 
     let result = browser
         .acquire_bridge()
@@ -39,29 +27,20 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
-
     use super::*;
 
     #[test]
-    fn parses_empty_input() {
-        let input = json!({});
-        let (tp, np) = parse_input(&input);
-        assert!(tp.is_none());
-        assert!(np.is_none());
-    }
-
-    #[test]
-    fn parses_type_pattern() {
-        let input = json!({"type_pattern": "image"});
-        let (tp, _np) = parse_input(&input);
-        assert_eq!(tp.as_deref(), Some("image"));
-    }
-
-    #[test]
-    fn parses_name_pattern() {
-        let input = json!({"name_pattern": "logo"});
-        let (_tp, np) = parse_input(&input);
-        assert_eq!(np.as_deref(), Some("logo"));
+    fn list_resources_schema_has_no_filter_params() {
+        let specs = crate::mvp_tool_specs();
+        let spec = specs.iter().find(|s| s.name == "list_resources").unwrap();
+        let schema_str = spec.input_schema.to_string();
+        assert!(
+            !schema_str.contains("type_pattern"),
+            "type_pattern should be removed from schema"
+        );
+        assert!(
+            !schema_str.contains("name_pattern"),
+            "name_pattern should be removed from schema"
+        );
     }
 }

--- a/crates/crawler/src/tools/list_resources.rs
+++ b/crates/crawler/src/tools/list_resources.rs
@@ -27,8 +27,6 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     #[test]
     fn list_resources_schema_has_no_filter_params() {
         let specs = crate::mvp_tool_specs();

--- a/crates/crawler/src/tools/mod.rs
+++ b/crates/crawler/src/tools/mod.rs
@@ -1,4 +1,5 @@
 pub mod click;
+pub mod feedback;
 pub mod fill_form;
 pub mod fork;
 pub mod go_back;

--- a/crates/crawler/src/tools/navigate.rs
+++ b/crates/crawler/src/tools/navigate.rs
@@ -174,12 +174,10 @@ fn resolve_content(
 
     let max_chars = match depth {
         ContentDepth::Slim => SLIM_MAX_CHARS,
-        _ => {
-            std::env::var("ACRAWL_MAX_MARKDOWN_CHARS")
-                .ok()
-                .and_then(|v| v.parse().ok())
-                .unwrap_or(DEFAULT_MAX_MARKDOWN_CHARS)
-        }
+        _ => std::env::var("ACRAWL_MAX_MARKDOWN_CHARS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_MAX_MARKDOWN_CHARS),
     };
 
     match depth {
@@ -343,14 +341,21 @@ mod tests {
 
     #[test]
     fn resolve_content_none_returns_empty() {
-        let (content, truncated) = resolve_content("<p>hello</p>", "hello", "hello", "markdown", &ContentDepth::None);
+        let (content, truncated) = resolve_content(
+            "<p>hello</p>",
+            "hello",
+            "hello",
+            "markdown",
+            &ContentDepth::None,
+        );
         assert!(content.is_empty());
         assert!(!truncated);
     }
 
     #[test]
     fn resolve_content_main_extracts_article() {
-        let html = r"<nav>Menu</nav><main><h1>Title</h1><p>Body text</p></main><footer>Footer</footer>";
+        let html =
+            r"<nav>Menu</nav><main><h1>Title</h1><p>Body text</p></main><footer>Footer</footer>";
         let md = html_to_markdown(html);
         let (content, _) = resolve_content(html, "text", &md, "markdown", &ContentDepth::Main);
         assert!(content.contains("Title"));
@@ -373,7 +378,8 @@ mod tests {
         let body = "a".repeat(5000);
         let html = format!("<main><p>{body}</p></main>");
         let md = html_to_markdown(&html);
-        let (content, truncated) = resolve_content(&html, "text", &md, "markdown", &ContentDepth::Slim);
+        let (content, truncated) =
+            resolve_content(&html, "text", &md, "markdown", &ContentDepth::Slim);
         assert!(truncated);
         assert!(content.chars().count() <= SLIM_MAX_CHARS);
     }

--- a/crates/crawler/src/tools/navigate.rs
+++ b/crates/crawler/src/tools/navigate.rs
@@ -21,6 +21,7 @@ struct NavigateInput {
     url: String,
     format: String,
     content_depth: ContentDepth,
+    strip_images: bool,
 }
 
 fn parse_input(input: &Value) -> Result<NavigateInput, CrawlError> {
@@ -60,10 +61,16 @@ fn parse_input(input: &Value) -> Result<NavigateInput, CrawlError> {
         }
     };
 
+    let strip_images = input
+        .get("strip_images")
+        .and_then(Value::as_bool)
+        .unwrap_or(true);
+
     Ok(NavigateInput {
         url: url.to_string(),
         format: format.to_string(),
         content_depth,
+        strip_images,
     })
 }
 
@@ -77,6 +84,48 @@ fn cap_content(content: &str, max_chars: usize) -> (String, bool) {
         );
         (truncated, true)
     }
+}
+
+fn strip_markdown_images(md: &str) -> String {
+    let mut result = String::with_capacity(md.len());
+    let mut chars = md.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '!' && chars.peek() == Some(&'[') {
+            chars.next();
+            let mut depth = 1;
+            let mut found_close = false;
+            for c in chars.by_ref() {
+                if c == '[' {
+                    depth += 1;
+                } else if c == ']' {
+                    depth -= 1;
+                    if depth == 0 {
+                        found_close = true;
+                        break;
+                    }
+                }
+            }
+            if found_close && chars.peek() == Some(&'(') {
+                chars.next();
+                let mut paren_depth = 1;
+                for c in chars.by_ref() {
+                    if c == '(' {
+                        paren_depth += 1;
+                    } else if c == ')' {
+                        paren_depth -= 1;
+                        if paren_depth == 0 {
+                            break;
+                        }
+                    }
+                }
+            }
+        } else {
+            result.push(ch);
+        }
+    }
+
+    result
 }
 
 fn extract_headings_from_markdown(md: &str) -> Value {
@@ -174,6 +223,12 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
         &params.format,
         &params.content_depth,
     );
+
+    let content = if params.strip_images && params.format == "markdown" {
+        strip_markdown_images(&content)
+    } else {
+        content
+    };
 
     browser.set_navigated_url(&page.url, page.fetched_via_browser);
 
@@ -377,5 +432,40 @@ mod tests {
         assert_eq!(headings[1]["text"], "H2");
         assert_eq!(headings[2]["level"], 3);
         assert_eq!(headings[2]["text"], "H3");
+    }
+
+    #[test]
+    fn strip_images_removes_markdown_images() {
+        let md = "Before ![alt text](https://example.com/img.png) after";
+        let stripped = strip_markdown_images(md);
+        assert_eq!(stripped, "Before  after");
+    }
+
+    #[test]
+    fn strip_images_handles_nested_brackets() {
+        let md = "Text ![complex [alt]](url) more";
+        let stripped = strip_markdown_images(md);
+        assert_eq!(stripped, "Text  more");
+    }
+
+    #[test]
+    fn strip_images_preserves_regular_links() {
+        let md = "Click [here](https://example.com) to continue";
+        let stripped = strip_markdown_images(md);
+        assert_eq!(stripped, md);
+    }
+
+    #[test]
+    fn parse_strip_images_defaults_to_true() {
+        let input = json!({"url": "https://x.com"});
+        let result = parse_input(&input).unwrap();
+        assert!(result.strip_images);
+    }
+
+    #[test]
+    fn parse_strip_images_can_be_disabled() {
+        let input = json!({"url": "https://x.com", "strip_images": false});
+        let result = parse_input(&input).unwrap();
+        assert!(!result.strip_images);
     }
 }

--- a/crates/crawler/src/tools/navigate.rs
+++ b/crates/crawler/src/tools/navigate.rs
@@ -2,14 +2,25 @@ use serde_json::{json, Value};
 
 use crate::browser::BrowserContext;
 use crate::fetcher::FetchRouter;
-use crate::markdown::DEFAULT_MAX_MARKDOWN_CHARS;
+use crate::markdown::{extract_main_html, html_to_markdown, DEFAULT_MAX_MARKDOWN_CHARS};
 use crate::tools::page_map::apply_page_map_caps;
 use crate::{CrawlError, ToolEffect, ToolError};
+
+const SLIM_MAX_CHARS: usize = 2000;
+
+#[derive(Debug, PartialEq)]
+enum ContentDepth {
+    Full,
+    Main,
+    Slim,
+    None,
+}
 
 #[derive(Debug)]
 struct NavigateInput {
     url: String,
     format: String,
+    content_depth: ContentDepth,
 }
 
 fn parse_input(input: &Value) -> Result<NavigateInput, CrawlError> {
@@ -33,9 +44,26 @@ fn parse_input(input: &Value) -> Result<NavigateInput, CrawlError> {
         ));
     }
 
+    let content_depth = match input
+        .get("content_depth")
+        .and_then(Value::as_str)
+        .unwrap_or("main")
+    {
+        "full" => ContentDepth::Full,
+        "main" => ContentDepth::Main,
+        "slim" => ContentDepth::Slim,
+        "none" => ContentDepth::None,
+        _ => {
+            return Err(CrawlError::new(
+                "content_depth must be one of: full, main, slim, none",
+            ))
+        }
+    };
+
     Ok(NavigateInput {
         url: url.to_string(),
         format: format.to_string(),
+        content_depth,
     })
 }
 
@@ -84,6 +112,50 @@ fn extract_headings_from_markdown(md: &str) -> Value {
     })
 }
 
+fn resolve_content(
+    html: &str,
+    text: &str,
+    markdown: &str,
+    format: &str,
+    depth: &ContentDepth,
+) -> (String, bool) {
+    if *depth == ContentDepth::None {
+        return (String::new(), false);
+    }
+
+    let max_chars = match depth {
+        ContentDepth::Slim => SLIM_MAX_CHARS,
+        _ => {
+            std::env::var("ACRAWL_MAX_MARKDOWN_CHARS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(DEFAULT_MAX_MARKDOWN_CHARS)
+        }
+    };
+
+    match depth {
+        ContentDepth::Full => match format {
+            "markdown" => cap_content(markdown, max_chars),
+            "text" => cap_content(text, max_chars),
+            "html" => cap_content(html, max_chars),
+            _ => unreachable!(),
+        },
+        ContentDepth::Main | ContentDepth::Slim => {
+            let main_html = extract_main_html(html);
+            match format {
+                "markdown" => {
+                    let md = html_to_markdown(&main_html);
+                    cap_content(&md, max_chars)
+                }
+                "text" => cap_content(text, max_chars),
+                "html" => cap_content(&main_html, max_chars),
+                _ => unreachable!(),
+            }
+        }
+        ContentDepth::None => unreachable!(),
+    }
+}
+
 pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<ToolEffect, ToolError> {
     let params = parse_input(input)?;
 
@@ -94,12 +166,14 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
         .map_err(|e| ToolError(e.to_string()))?;
 
     let title = page.title.clone().unwrap_or_default();
-    let (content, truncated) = match params.format.as_str() {
-        "markdown" => cap_content(&page.markdown, DEFAULT_MAX_MARKDOWN_CHARS),
-        "text" => cap_content(&page.text, 32_000),
-        "html" => cap_content(&page.html, 32_000),
-        _ => unreachable!("parse_input validates format"),
-    };
+
+    let (content, truncated) = resolve_content(
+        &page.html,
+        &page.text,
+        &page.markdown,
+        &params.format,
+        &params.content_depth,
+    );
 
     browser.set_navigated_url(&page.url, page.fetched_via_browser);
 
@@ -142,6 +216,12 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
         "title": title,
         "content": content,
         "format": params.format,
+        "content_depth": match params.content_depth {
+            ContentDepth::Full => "full",
+            ContentDepth::Main => "main",
+            ContentDepth::Slim => "slim",
+            ContentDepth::None => "none",
+        },
         "truncated": truncated,
         "content_length": content_length,
         "page_map": page_map
@@ -176,6 +256,71 @@ mod tests {
         let input = json!({"url": "https://example.com", "format": "pdf"});
         let err = parse_input(&input).unwrap_err();
         assert!(err.to_string().contains("format"));
+    }
+
+    #[test]
+    fn navigate_parse_content_depth_defaults_to_main() {
+        let input = json!({"url": "https://example.com"});
+        let result = parse_input(&input).unwrap();
+        assert_eq!(result.content_depth, ContentDepth::Main);
+    }
+
+    #[test]
+    fn navigate_parse_content_depth_all_values() {
+        for (val, expected) in [
+            ("full", ContentDepth::Full),
+            ("main", ContentDepth::Main),
+            ("slim", ContentDepth::Slim),
+            ("none", ContentDepth::None),
+        ] {
+            let input = json!({"url": "https://x.com", "content_depth": val});
+            let result = parse_input(&input).unwrap();
+            assert_eq!(result.content_depth, expected);
+        }
+    }
+
+    #[test]
+    fn navigate_parse_content_depth_rejects_invalid() {
+        let input = json!({"url": "https://x.com", "content_depth": "deep"});
+        let err = parse_input(&input).unwrap_err();
+        assert!(err.to_string().contains("content_depth"));
+    }
+
+    #[test]
+    fn resolve_content_none_returns_empty() {
+        let (content, truncated) = resolve_content("<p>hello</p>", "hello", "hello", "markdown", &ContentDepth::None);
+        assert!(content.is_empty());
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn resolve_content_main_extracts_article() {
+        let html = r"<nav>Menu</nav><main><h1>Title</h1><p>Body text</p></main><footer>Footer</footer>";
+        let md = html_to_markdown(html);
+        let (content, _) = resolve_content(html, "text", &md, "markdown", &ContentDepth::Main);
+        assert!(content.contains("Title"));
+        assert!(content.contains("Body text"));
+        assert!(!content.contains("Menu"));
+        assert!(!content.contains("Footer"));
+    }
+
+    #[test]
+    fn resolve_content_full_includes_everything() {
+        let html = r"<header><p>Header</p></header><main><p>Body</p></main>";
+        let md = html_to_markdown(html);
+        let (content, _) = resolve_content(html, "text", &md, "markdown", &ContentDepth::Full);
+        assert!(content.contains("Header"));
+        assert!(content.contains("Body"));
+    }
+
+    #[test]
+    fn resolve_content_slim_caps_at_2000() {
+        let body = "a".repeat(5000);
+        let html = format!("<main><p>{body}</p></main>");
+        let md = html_to_markdown(&html);
+        let (content, truncated) = resolve_content(&html, "text", &md, "markdown", &ContentDepth::Slim);
+        assert!(truncated);
+        assert!(content.chars().count() <= SLIM_MAX_CHARS);
     }
 
     #[test]

--- a/crates/crawler/src/tools/navigate.rs
+++ b/crates/crawler/src/tools/navigate.rs
@@ -2,7 +2,7 @@ use serde_json::{json, Value};
 
 use crate::browser::BrowserContext;
 use crate::fetcher::FetchRouter;
-use crate::markdown::{html_to_markdown_capped, DEFAULT_MAX_MARKDOWN_CHARS};
+use crate::markdown::DEFAULT_MAX_MARKDOWN_CHARS;
 use crate::tools::page_map::apply_page_map_caps;
 use crate::{CrawlError, ToolEffect, ToolError};
 
@@ -95,7 +95,7 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
 
     let title = page.title.clone().unwrap_or_default();
     let (content, truncated) = match params.format.as_str() {
-        "markdown" => html_to_markdown_capped(&page.html, DEFAULT_MAX_MARKDOWN_CHARS),
+        "markdown" => cap_content(&page.markdown, DEFAULT_MAX_MARKDOWN_CHARS),
         "text" => cap_content(&page.text, 32_000),
         "html" => cap_content(&page.html, 32_000),
         _ => unreachable!("parse_input validates format"),
@@ -127,7 +127,7 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
             }),
         }
     } else {
-        let mut value = extract_headings_from_markdown(&content);
+        let mut value = extract_headings_from_markdown(&page.markdown);
         if let Some(meta) = value.get_mut("meta").and_then(Value::as_object_mut) {
             meta.insert("url".to_string(), json!(page.url.clone()));
             meta.insert("title".to_string(), json!(title.clone()));
@@ -151,7 +151,7 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::markdown::{html_to_markdown_capped, DEFAULT_MAX_MARKDOWN_CHARS};
+    use crate::markdown::html_to_markdown_capped;
     use serde_json::json;
 
     #[test]

--- a/crates/crawler/src/tools/navigate.rs
+++ b/crates/crawler/src/tools/navigate.rs
@@ -1,12 +1,15 @@
-use serde_json::Value;
+use serde_json::{json, Value};
 
 use crate::browser::BrowserContext;
 use crate::fetcher::FetchRouter;
+use crate::markdown::{html_to_markdown_capped, DEFAULT_MAX_MARKDOWN_CHARS};
+use crate::tools::page_map::apply_page_map_caps;
 use crate::{CrawlError, ToolEffect, ToolError};
 
 #[derive(Debug)]
 struct NavigateInput {
     url: String,
+    format: String,
 }
 
 fn parse_input(input: &Value) -> Result<NavigateInput, CrawlError> {
@@ -19,19 +22,62 @@ fn parse_input(input: &Value) -> Result<NavigateInput, CrawlError> {
         return Err(CrawlError::new("url must not be empty"));
     }
 
+    let format = input
+        .get("format")
+        .and_then(Value::as_str)
+        .unwrap_or("markdown");
+
+    if !matches!(format, "markdown" | "text" | "html") {
+        return Err(CrawlError::new("format must be one of: markdown, text, html"));
+    }
+
     Ok(NavigateInput {
         url: url.to_string(),
+        format: format.to_string(),
     })
 }
 
-fn truncate_html(html: &str, max_chars: usize) -> String {
-    let char_count = html.chars().count();
-    if char_count <= max_chars {
-        html.to_string()
+fn cap_content(content: &str, max_chars: usize) -> (String, bool) {
+    if content.chars().count() <= max_chars {
+        (content.to_string(), false)
     } else {
-        let truncated: String = html.chars().take(max_chars).collect();
-        format!("{truncated}...")
+        let truncated = content
+            .char_indices()
+            .nth(max_chars)
+            .map_or_else(|| content.to_string(), |(idx, _)| content[..idx].to_string());
+        (truncated, true)
     }
+}
+
+fn extract_headings_from_markdown(md: &str) -> Value {
+    let headings = md
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            let hash_count = trimmed.chars().take_while(|ch| *ch == '#').count();
+            if !(1..=6).contains(&hash_count) {
+                return None;
+            }
+
+            let text = trimmed.strip_prefix(&"#".repeat(hash_count))?.strip_prefix(' ')?;
+
+            Some(json!({
+                "level": hash_count,
+                "text": text,
+                "id": Value::Null,
+                "selector": Value::Null
+            }))
+        })
+        .collect::<Vec<_>>();
+
+    json!({
+        "headings": headings,
+        "meta": {
+            "url": "",
+            "title": "",
+            "description": ""
+        }
+    })
 }
 
 pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<ToolEffect, ToolError> {
@@ -43,65 +89,144 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
         .await
         .map_err(|e| ToolError(e.to_string()))?;
 
+    let title = page.title.clone().unwrap_or_default();
+    let (content, truncated) = match params.format.as_str() {
+        "markdown" => html_to_markdown_capped(&page.html, DEFAULT_MAX_MARKDOWN_CHARS),
+        "text" => cap_content(&page.text, 32_000),
+        "html" => cap_content(&page.html, 32_000),
+        _ => unreachable!("parse_input validates format"),
+    };
+
     browser.set_navigated_url(&page.url, page.fetched_via_browser);
 
-    Ok(ToolEffect::reply_json(&serde_json::json!({
-        "title": page.title.unwrap_or_default(),
+    let page_map = if page.fetched_via_browser {
+        match browser.acquire_bridge().await {
+            Ok(mut bridge) => match bridge.page_map().await {
+                Ok(mut value) => {
+                    apply_page_map_caps(&mut value);
+                    value
+                }
+                Err(_) => json!({
+                    "headings": [],
+                    "meta": {
+                        "url": page.url.clone(),
+                        "title": ""
+                    }
+                }),
+            },
+            Err(_) => json!({
+                "headings": [],
+                "meta": {
+                    "url": page.url.clone(),
+                    "title": ""
+                }
+            }),
+        }
+    } else {
+        let mut value = extract_headings_from_markdown(&content);
+        if let Some(meta) = value.get_mut("meta").and_then(Value::as_object_mut) {
+            meta.insert("url".to_string(), json!(page.url.clone()));
+            meta.insert("title".to_string(), json!(title.clone()));
+        }
+        value
+    };
+
+    let content_length = content.chars().count();
+
+    Ok(ToolEffect::reply_json(&json!({
         "url": page.url,
-        "text": truncate_html(&page.text, 4000),
-        "html_summary": truncate_html(&page.html, 2000)
+        "title": title,
+        "content": content,
+        "format": params.format,
+        "truncated": truncated,
+        "content_length": content_length,
+        "page_map": page_map
     })))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::markdown::{html_to_markdown_capped, DEFAULT_MAX_MARKDOWN_CHARS};
     use serde_json::json;
 
     #[test]
-    fn parse_valid_url() {
+    fn navigate_parse_format_defaults_to_markdown() {
         let input = json!({"url": "https://example.com"});
-        let result = parse_input(&input);
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().url, "https://example.com");
+        let result = parse_input(&input).unwrap();
+        assert_eq!(result.url, "https://example.com");
+        assert_eq!(result.format, "markdown");
     }
 
     #[test]
-    fn parse_missing_url_returns_error() {
-        let input = json!({});
+    fn navigate_parse_format_accepts_text_html_markdown() {
+        for format in ["text", "html", "markdown"] {
+            let input = json!({"url": "https://example.com", "format": format});
+            let result = parse_input(&input).unwrap();
+            assert_eq!(result.format, format);
+        }
+    }
+
+    #[test]
+    fn navigate_parse_format_rejects_invalid() {
+        let input = json!({"url": "https://example.com", "format": "pdf"});
         let err = parse_input(&input).unwrap_err();
-        assert!(err.to_string().contains("url"));
+        assert!(err.to_string().contains("format"));
     }
 
     #[test]
-    fn parse_empty_url_returns_error() {
-        let input = json!({"url": ""});
-        let err = parse_input(&input).unwrap_err();
-        assert!(err.to_string().contains("empty"));
+    fn navigate_response_has_new_shape() {
+        let result = extract_headings_from_markdown("# Title\n\n## Section");
+        assert!(result.get("headings").is_some());
+        assert!(result.get("meta").is_some());
+        assert!(result["meta"].get("url").is_some());
+        assert!(result["meta"].get("title").is_some());
+        assert!(result["meta"].get("description").is_some());
     }
 
     #[test]
-    fn parse_non_string_url_returns_error() {
-        let input = json!({"url": 42});
-        assert!(parse_input(&input).is_err());
+    fn navigate_markdown_content_has_structure() {
+        let (content, truncated) = html_to_markdown_capped(
+            r#"<h1>Docs</h1><p>Read the <a href="https://example.com/guide">guide</a>.</p>"#,
+            DEFAULT_MAX_MARKDOWN_CHARS,
+        );
+        assert!(!truncated);
+        assert!(content.contains("# Docs"));
+        assert!(content.contains("[guide](https://example.com/guide)"));
     }
 
     #[test]
-    fn truncate_html_short_text_unchanged() {
-        assert_eq!(truncate_html("short", 100), "short");
+    fn navigate_text_format_backward_compat() {
+        let input = "a".repeat(33_000);
+        let (content, truncated) = cap_content(&input, 32_000);
+        assert!(truncated);
+        assert_eq!(content.chars().count(), 32_000);
     }
 
     #[test]
-    fn truncate_html_long_text_is_truncated() {
-        let long = "a".repeat(3000);
-        let result = truncate_html(&long, 2000);
-        assert!(result.ends_with("..."));
-        assert_eq!(result.len(), 2003);
+    fn navigate_truncation_flag_set_on_large_content() {
+        let html = format!("<p>{}</p>", "a".repeat(DEFAULT_MAX_MARKDOWN_CHARS + 256));
+        let (_content, truncated) = html_to_markdown_capped(&html, DEFAULT_MAX_MARKDOWN_CHARS);
+        assert!(truncated);
     }
 
     #[test]
-    fn truncate_html_exact_boundary() {
-        let exact = "x".repeat(2000);
-        assert_eq!(truncate_html(&exact, 2000), exact);
+    fn navigate_page_map_included_in_response() {
+        let result = extract_headings_from_markdown("# Title");
+        assert_eq!(result["headings"].as_array().map(Vec::len), Some(1));
+        assert!(result["meta"].is_object());
+    }
+
+    #[test]
+    fn extract_headings_from_markdown_finds_all_levels() {
+        let result = extract_headings_from_markdown("# H1\n## H2\n### H3");
+        let headings = result["headings"].as_array().unwrap();
+        assert_eq!(headings.len(), 3);
+        assert_eq!(headings[0]["level"], 1);
+        assert_eq!(headings[0]["text"], "H1");
+        assert_eq!(headings[1]["level"], 2);
+        assert_eq!(headings[1]["text"], "H2");
+        assert_eq!(headings[2]["level"], 3);
+        assert_eq!(headings[2]["text"], "H3");
     }
 }

--- a/crates/crawler/src/tools/navigate.rs
+++ b/crates/crawler/src/tools/navigate.rs
@@ -28,7 +28,9 @@ fn parse_input(input: &Value) -> Result<NavigateInput, CrawlError> {
         .unwrap_or("markdown");
 
     if !matches!(format, "markdown" | "text" | "html") {
-        return Err(CrawlError::new("format must be one of: markdown, text, html"));
+        return Err(CrawlError::new(
+            "format must be one of: markdown, text, html",
+        ));
     }
 
     Ok(NavigateInput {
@@ -41,10 +43,10 @@ fn cap_content(content: &str, max_chars: usize) -> (String, bool) {
     if content.chars().count() <= max_chars {
         (content.to_string(), false)
     } else {
-        let truncated = content
-            .char_indices()
-            .nth(max_chars)
-            .map_or_else(|| content.to_string(), |(idx, _)| content[..idx].to_string());
+        let truncated = content.char_indices().nth(max_chars).map_or_else(
+            || content.to_string(),
+            |(idx, _)| content[..idx].to_string(),
+        );
         (truncated, true)
     }
 }
@@ -59,7 +61,9 @@ fn extract_headings_from_markdown(md: &str) -> Value {
                 return None;
             }
 
-            let text = trimmed.strip_prefix(&"#".repeat(hash_count))?.strip_prefix(' ')?;
+            let text = trimmed
+                .strip_prefix(&"#".repeat(hash_count))?
+                .strip_prefix(' ')?;
 
             Some(json!({
                 "level": hash_count,

--- a/crates/crawler/src/tools/page_map.rs
+++ b/crates/crawler/src/tools/page_map.rs
@@ -23,13 +23,16 @@ pub fn apply_page_map_caps(value: &mut Value) {
 }
 
 fn truncate_array_field(value: &mut Value, key: &str, max_len: usize) -> bool {
-    value.get_mut(key).and_then(Value::as_array_mut).is_some_and(|items| {
-        let was_truncated = items.len() > max_len;
-        if was_truncated {
-            items.truncate(max_len);
-        }
-        was_truncated
-    })
+    value
+        .get_mut(key)
+        .and_then(Value::as_array_mut)
+        .is_some_and(|items| {
+            let was_truncated = items.len() > max_len;
+            if was_truncated {
+                items.truncate(max_len);
+            }
+            was_truncated
+        })
 }
 
 pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<ToolEffect, ToolError> {
@@ -114,8 +117,17 @@ mod tests {
 
         apply_page_map_caps(&mut value);
 
-        let object = value.as_object().expect("page_map payload should be an object");
-        for key in ["headings", "landmarks", "forms", "links", "interactive", "meta"] {
+        let object = value
+            .as_object()
+            .expect("page_map payload should be an object");
+        for key in [
+            "headings",
+            "landmarks",
+            "forms",
+            "links",
+            "interactive",
+            "meta",
+        ] {
             assert!(object.contains_key(key), "missing key: {key}");
         }
     }

--- a/crates/crawler/src/tools/page_map.rs
+++ b/crates/crawler/src/tools/page_map.rs
@@ -3,10 +3,39 @@ use serde_json::Value;
 use crate::browser::BrowserContext;
 use crate::{ToolEffect, ToolError};
 
+const MAX_PAGE_MAP_LINKS: usize = 50;
+const MAX_PAGE_MAP_FORMS: usize = 10;
+const MAX_PAGE_MAP_LANDMARKS: usize = 20;
+
+pub fn apply_page_map_caps(value: &mut Value) {
+    let truncated_links = truncate_array_field(value, "links", MAX_PAGE_MAP_LINKS);
+    let truncated_forms = truncate_array_field(value, "forms", MAX_PAGE_MAP_FORMS);
+    let truncated_landmarks = truncate_array_field(value, "landmarks", MAX_PAGE_MAP_LANDMARKS);
+
+    if let Some(object) = value.as_object_mut() {
+        object.insert("truncated_links".to_string(), Value::Bool(truncated_links));
+        object.insert("truncated_forms".to_string(), Value::Bool(truncated_forms));
+        object.insert(
+            "truncated_landmarks".to_string(),
+            Value::Bool(truncated_landmarks),
+        );
+    }
+}
+
+fn truncate_array_field(value: &mut Value, key: &str, max_len: usize) -> bool {
+    value.get_mut(key).and_then(Value::as_array_mut).is_some_and(|items| {
+        let was_truncated = items.len() > max_len;
+        if was_truncated {
+            items.truncate(max_len);
+        }
+        was_truncated
+    })
+}
+
 pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<ToolEffect, ToolError> {
     let _ = input;
 
-    let result = browser
+    let mut result = browser
         .acquire_bridge()
         .await
         .map_err(|e| ToolError(e.to_string()))?
@@ -14,9 +43,210 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
         .await
         .map_err(|e| ToolError(e.to_string()))?;
 
+    apply_page_map_caps(&mut result);
+
     Ok(ToolEffect::reply_json(&result))
 }
 
-// Unit tests are intentionally omitted: `page_map` takes no input parameters
-// and its `execute` function requires a live Playwright bridge, so meaningful
-// coverage comes from the integration tests in `crates/crawler/tests/`.
+#[cfg(test)]
+mod tests {
+    use serde_json::{json, Value};
+
+    use super::apply_page_map_caps;
+
+    #[test]
+    fn page_map_response_structure_has_all_sections() {
+        let mut value = json!({
+            "headings": [
+                {
+                    "level": 1,
+                    "text": "Title",
+                    "id": "title",
+                    "selector": "#title",
+                    "char_count": 42,
+                    "preview": "Preview"
+                }
+            ],
+            "landmarks": [
+                {
+                    "tag": "main",
+                    "role": "main",
+                    "id": "content",
+                    "selector": "#content",
+                    "text_preview": "Main content"
+                }
+            ],
+            "forms": [
+                {
+                    "action": "/submit",
+                    "method": "post",
+                    "id": "contact",
+                    "selector": "#contact",
+                    "fields": [
+                        {
+                            "name": "email",
+                            "type": "email",
+                            "label": "Email",
+                            "required": true
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "text": "Docs",
+                    "href": "https://example.com/docs",
+                    "selector": "a"
+                }
+            ],
+            "interactive": {
+                "buttons": 1,
+                "inputs": 2,
+                "selects": 3,
+                "textareas": 4
+            },
+            "meta": {
+                "title": "Example",
+                "description": "Description",
+                "url": "https://example.com"
+            }
+        });
+
+        apply_page_map_caps(&mut value);
+
+        let object = value.as_object().expect("page_map payload should be an object");
+        for key in ["headings", "landmarks", "forms", "links", "interactive", "meta"] {
+            assert!(object.contains_key(key), "missing key: {key}");
+        }
+    }
+
+    #[test]
+    fn page_map_headings_format_matches_spec() {
+        let mut value = json!({
+            "headings": [
+                {
+                    "level": 2,
+                    "text": "Overview",
+                    "id": "overview",
+                    "selector": "#overview",
+                    "char_count": 12,
+                    "preview": "Quick summary"
+                }
+            ],
+            "landmarks": [],
+            "forms": [],
+            "links": [],
+            "interactive": {},
+            "meta": {}
+        });
+
+        apply_page_map_caps(&mut value);
+
+        let heading = value
+            .get("headings")
+            .and_then(Value::as_array)
+            .and_then(|headings| headings.first())
+            .and_then(Value::as_object)
+            .expect("expected a heading object");
+
+        for key in ["level", "text", "id", "selector"] {
+            assert!(heading.contains_key(key), "missing heading field: {key}");
+        }
+    }
+
+    #[test]
+    fn page_map_caps_links_at_50() {
+        let mut value = json!({
+            "headings": [],
+            "landmarks": [],
+            "forms": [],
+            "links": (0..100)
+                .map(|index| json!({
+                    "text": format!("Link {index}"),
+                    "href": format!("https://example.com/{index}"),
+                    "selector": format!("a:nth-of-type({})", index + 1)
+                }))
+                .collect::<Vec<_>>(),
+            "interactive": {},
+            "meta": {}
+        });
+
+        apply_page_map_caps(&mut value);
+
+        assert_eq!(value["links"].as_array().map(Vec::len), Some(50));
+        assert_eq!(value["truncated_links"], json!(true));
+    }
+
+    #[test]
+    fn page_map_caps_forms_at_10() {
+        let mut value = json!({
+            "headings": [],
+            "landmarks": [],
+            "forms": (0..20)
+                .map(|index| json!({
+                    "action": format!("/submit/{index}"),
+                    "method": "post",
+                    "id": format!("form-{index}"),
+                    "selector": format!("#form-{index}"),
+                    "fields": []
+                }))
+                .collect::<Vec<_>>(),
+            "links": [],
+            "interactive": {},
+            "meta": {}
+        });
+
+        apply_page_map_caps(&mut value);
+
+        assert_eq!(value["forms"].as_array().map(Vec::len), Some(10));
+        assert_eq!(value["truncated_forms"], json!(true));
+    }
+
+    #[test]
+    fn page_map_caps_landmarks_at_20() {
+        let mut value = json!({
+            "headings": [],
+            "landmarks": (0..30)
+                .map(|index| json!({
+                    "tag": "section",
+                    "role": "navigation",
+                    "id": format!("landmark-{index}"),
+                    "selector": format!("#landmark-{index}"),
+                    "text_preview": format!("Landmark {index}")
+                }))
+                .collect::<Vec<_>>(),
+            "forms": [],
+            "links": [],
+            "interactive": {},
+            "meta": {}
+        });
+
+        apply_page_map_caps(&mut value);
+
+        assert_eq!(value["landmarks"].as_array().map(Vec::len), Some(20));
+        assert_eq!(value["truncated_landmarks"], json!(true));
+    }
+
+    #[test]
+    fn page_map_no_truncation_when_under_cap() {
+        let mut value = json!({
+            "headings": [],
+            "landmarks": [],
+            "forms": [],
+            "links": (0..5)
+                .map(|index| json!({
+                    "text": format!("Link {index}"),
+                    "href": format!("https://example.com/{index}"),
+                    "selector": format!("a:nth-of-type({})", index + 1)
+                }))
+                .collect::<Vec<_>>(),
+            "interactive": {},
+            "meta": {}
+        });
+
+        apply_page_map_caps(&mut value);
+
+        assert_eq!(value["links"].as_array().map(Vec::len), Some(5));
+        assert_eq!(value["truncated_links"], json!(false));
+    }
+}

--- a/crates/crawler/src/tools/press_key.rs
+++ b/crates/crawler/src/tools/press_key.rs
@@ -34,9 +34,12 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
         .await
         .map_err(|e| ToolError(e.to_string()))?;
 
+    let page_state = super::feedback::post_action_page_state(browser).await;
+
     Ok(ToolEffect::reply_json(&json!({
         "success": true,
-        "message": format!("Pressed key: {}", parsed.key)
+        "message": format!("Pressed key: {}", parsed.key),
+        "page_state": page_state
     })))
 }
 
@@ -66,5 +69,22 @@ mod tests {
     fn fails_without_key() {
         let input = json!({"selector": "#input"});
         assert!(parse_input(&input).is_err());
+    }
+
+    #[test]
+    fn press_key_response_includes_page_state() {
+        let mock_pm = json!({
+            "headings": [], "landmarks": [], "forms": [], "links": [],
+            "interactive": {}, "meta": {"title": "Test", "url": "https://test.com", "description": ""}
+        });
+        let page_state = crate::tools::feedback::build_page_state_from_map(mock_pm);
+        let response = json!({
+            "success": true,
+            "message": "Pressed key: Enter",
+            "page_state": page_state
+        });
+        assert!(response["page_state"]["url"].is_string());
+        assert!(response["page_state"]["title"].is_string());
+        assert!(!response["page_state"]["page_map"].is_null());
     }
 }

--- a/crates/crawler/src/tools/scroll.rs
+++ b/crates/crawler/src/tools/scroll.rs
@@ -36,9 +36,12 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
         .await
         .map_err(|e| ToolError(e.to_string()))?;
 
+    let page_state = super::feedback::post_action_page_state(browser).await;
+
     Ok(ToolEffect::reply_json(&json!({
         "success": true,
-        "message": format!("Scrolled {direction} {pixels}px")
+        "message": format!("Scrolled {direction} {pixels}px"),
+        "page_state": page_state
     })))
 }
 
@@ -76,5 +79,22 @@ mod tests {
     fn rejects_invalid_direction() {
         let input = json!({"direction": "left"});
         assert!(parse_input(&input).is_err());
+    }
+
+    #[test]
+    fn scroll_response_includes_page_state() {
+        let mock_pm = json!({
+            "headings": [], "landmarks": [], "forms": [], "links": [],
+            "interactive": {}, "meta": {"title": "Test", "url": "https://test.com", "description": ""}
+        });
+        let page_state = crate::tools::feedback::build_page_state_from_map(mock_pm);
+        let response = json!({
+            "success": true,
+            "message": "Scrolled down 500px",
+            "page_state": page_state
+        });
+        assert!(response["page_state"]["url"].is_string());
+        assert!(response["page_state"]["title"].is_string());
+        assert!(!response["page_state"]["page_map"].is_null());
     }
 }

--- a/crates/crawler/src/tools/scroll.rs
+++ b/crates/crawler/src/tools/scroll.rs
@@ -17,8 +17,8 @@ pub fn parse_input(input: &Value) -> Result<(String, i64), CrawlError> {
     }
 
     let pixels = input
-        .get("amount")
-        .or_else(|| input.get("pixels"))
+        .get("pixels")
+        .or_else(|| input.get("amount"))
         .and_then(serde_json::Value::as_i64)
         .unwrap_or(500);
 
@@ -53,10 +53,18 @@ mod tests {
 
     #[test]
     fn parses_direction_and_pixels() {
-        let input = json!({"direction": "down", "amount": 300});
+        let input = json!({"direction": "down", "pixels": 300});
         let (dir, px) = parse_input(&input).unwrap();
         assert_eq!(dir, "down");
         assert_eq!(px, 300);
+    }
+
+    #[test]
+    fn accepts_legacy_amount_key() {
+        let input = json!({"direction": "down", "amount": 200});
+        let (dir, px) = parse_input(&input).unwrap();
+        assert_eq!(dir, "down");
+        assert_eq!(px, 200);
     }
 
     #[test]

--- a/crates/crawler/src/tools/select_option.rs
+++ b/crates/crawler/src/tools/select_option.rs
@@ -36,9 +36,12 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
         .await
         .map_err(|e| ToolError(e.to_string()))?;
 
+    let page_state = super::feedback::post_action_page_state(browser).await;
+
     Ok(ToolEffect::reply_json(&json!({
         "success": true,
-        "message": format!("Selected '{}' in {}", parsed.value, parsed.selector)
+        "message": format!("Selected '{}' in {}", parsed.value, parsed.selector),
+        "page_state": page_state
     })))
 }
 
@@ -73,5 +76,22 @@ mod tests {
     fn fails_without_value() {
         let input = json!({"selector": "#country"});
         assert!(parse_input(&input).is_err());
+    }
+
+    #[test]
+    fn select_option_response_includes_page_state() {
+        let mock_pm = json!({
+            "headings": [], "landmarks": [], "forms": [], "links": [],
+            "interactive": {}, "meta": {"title": "Test", "url": "https://test.com", "description": ""}
+        });
+        let page_state = crate::tools::feedback::build_page_state_from_map(mock_pm);
+        let response = json!({
+            "success": true,
+            "message": "Selected 'US' in #country",
+            "page_state": page_state
+        });
+        assert!(response["page_state"]["url"].is_string());
+        assert!(response["page_state"]["title"].is_string());
+        assert!(!response["page_state"]["page_map"].is_null());
     }
 }

--- a/crates/crawler/src/tools/switch_tab.rs
+++ b/crates/crawler/src/tools/switch_tab.rs
@@ -30,26 +30,17 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
         browser.set_page_index(page_index);
     }
 
-    let url = result
-        .get("url")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-    let title = result
-        .get("title")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
     let tab_count = result
         .get("tab_count")
         .and_then(serde_json::Value::as_i64)
         .unwrap_or(0);
 
+    let page_state = super::feedback::post_action_page_state(browser).await;
+
     Ok(ToolEffect::reply_json(&json!({
         "success": true,
-        "url": url,
-        "title": title,
-        "tab_count": tab_count
+        "tab_count": tab_count,
+        "page_state": page_state
     })))
 }
 

--- a/crates/crawler/tests/integration_test.rs
+++ b/crates/crawler/tests/integration_test.rs
@@ -1,4 +1,4 @@
-use crawler::{CrawlerAgent, ToolEffect, ToolRegistry};
+use crawler::{CrawlerAgent, FetchedPage, ToolEffect, ToolRegistry};
 use runtime::{ApiClient, ApiRequest, AssistantEvent, RuntimeError, ToolExecutor};
 use serde_json::{json, Value};
 
@@ -21,11 +21,19 @@ impl ApiClient for MockApiClient {
 
 fn mock_registry() -> ToolRegistry {
     let mut registry = ToolRegistry::new();
+    register_page_map_mock(&mut registry);
+    register_navigate_mock(&mut registry);
+    register_click_mock(&mut registry);
+    register_read_content_mock(&mut registry);
+    registry
+}
+
+fn register_page_map_mock(registry: &mut ToolRegistry) {
     registry.register(
         "page_map",
         Box::new(|_input| {
             Ok(ToolEffect::reply_json(&json!({
-                "sections": [
+                "headings": [
                     {
                         "level": 1,
                         "text": "Example Domain",
@@ -34,10 +42,87 @@ fn mock_registry() -> ToolRegistry {
                         "char_count": 200,
                         "preview": "This domain is for use in..."
                     }
-                ]
+                ],
+                "landmarks": [],
+                "forms": [],
+                "links": [{
+                    "text": "More information",
+                    "href": "https://www.iana.org/domains/example",
+                    "selector": "a"
+                }],
+                "interactive": {
+                    "buttons": 0,
+                    "inputs": 0,
+                    "selects": 0,
+                    "textareas": 0
+                },
+                "meta": {
+                    "title": "Example Domain",
+                    "description": "",
+                    "url": "https://example.com"
+                },
+                "truncated_links": false,
+                "truncated_forms": false,
+                "truncated_landmarks": false
             })))
         }),
     );
+}
+
+fn register_navigate_mock(registry: &mut ToolRegistry) {
+    registry.register(
+        "navigate",
+        Box::new(|_input| {
+            Ok(ToolEffect::reply_json(&json!({
+                "url": "https://example.com",
+                "title": "Example Domain",
+                "content": "# Example Domain\n\nThis domain...",
+                "format": "markdown",
+                "truncated": false,
+                "content_length": 45,
+                "page_map": {
+                    "headings": [{
+                        "level": 1,
+                        "text": "Example Domain"
+                    }],
+                    "meta": {
+                        "url": "https://example.com",
+                        "title": "Example Domain",
+                        "description": ""
+                    }
+                }
+            })))
+        }),
+    );
+}
+
+fn register_click_mock(registry: &mut ToolRegistry) {
+    registry.register(
+        "click",
+        Box::new(|_input| {
+            Ok(ToolEffect::reply_json(&json!({
+                "success": true,
+                "message": "Clicked element: .btn",
+                "page_state": {
+                    "url": "https://example.com/result",
+                    "title": "Result",
+                    "page_map": {
+                        "headings": [],
+                        "landmarks": [],
+                        "links": [],
+                        "meta": {
+                            "title": "Result",
+                            "url": "https://example.com/result",
+                            "description": ""
+                        }
+                    }
+                }
+            })))
+        }),
+    );
+}
+
+fn register_read_content_mock(registry: &mut ToolRegistry) {
     registry.register(
         "read_content",
         Box::new(|_input| {
@@ -52,7 +137,6 @@ fn mock_registry() -> ToolRegistry {
             })))
         }),
     );
-    registry
 }
 
 #[tokio::test]
@@ -66,10 +150,10 @@ async fn crawler_agent_execute_dispatches_registered_tool() {
 
     let parsed: Value = serde_json::from_str(&output).expect("tool output should be valid JSON");
     assert!(
-        parsed["sections"].is_array(),
-        "page_map should return sections array"
+        parsed["headings"].is_array(),
+        "page_map should return headings array"
     );
-    assert_eq!(parsed["sections"][0]["text"], "Example Domain");
+    assert_eq!(parsed["headings"][0]["text"], "Example Domain");
 }
 
 #[tokio::test]
@@ -84,4 +168,84 @@ async fn crawler_agent_run_completes_full_pipeline_with_mock_llm() {
 
     assert_eq!(result.steps_executed, 1);
     assert_eq!(result.summary, "Pipeline completed");
+}
+
+#[tokio::test]
+async fn navigate_markdown_end_to_end() {
+    let mut agent = CrawlerAgent::new_lazy(mock_registry());
+
+    let output = agent
+        .execute("navigate", r#"{"url":"https://example.com"}"#)
+        .await
+        .expect("navigate should execute successfully");
+
+    let parsed: Value = serde_json::from_str(&output).expect("tool output should be valid JSON");
+    assert!(
+        parsed["content"]
+            .as_str()
+            .is_some_and(|content| content.contains('#')),
+        "navigate should return markdown content"
+    );
+    assert!(parsed["page_map"]["headings"].is_array());
+    assert_eq!(parsed["format"], "markdown");
+    assert!(
+        parsed.get("text").is_none(),
+        "navigate should not expose old text field"
+    );
+    assert!(
+        parsed.get("html_summary").is_none(),
+        "navigate should not expose old html_summary field"
+    );
+}
+
+#[tokio::test]
+async fn interaction_tool_returns_page_state() {
+    let mut agent = CrawlerAgent::new_lazy(mock_registry());
+
+    let output = agent
+        .execute("click", r#"{"selector":".btn"}"#)
+        .await
+        .expect("click should execute successfully");
+
+    let parsed: Value = serde_json::from_str(&output).expect("tool output should be valid JSON");
+    assert!(parsed.get("page_state").is_some());
+    assert!(parsed["page_state"]["url"].is_string());
+    assert!(parsed["page_state"]["title"].is_string());
+}
+
+#[tokio::test]
+async fn page_map_expanded_structure() {
+    let mut agent = CrawlerAgent::new_lazy(mock_registry());
+
+    let output = agent
+        .execute("page_map", r"{}")
+        .await
+        .expect("page_map should execute successfully");
+
+    let parsed: Value = serde_json::from_str(&output).expect("tool output should be valid JSON");
+    for key in [
+        "headings",
+        "landmarks",
+        "forms",
+        "links",
+        "interactive",
+        "meta",
+    ] {
+        assert!(parsed.get(key).is_some(), "page_map should include {key}");
+    }
+}
+
+#[test]
+fn http_fetch_path_has_markdown() {
+    let page = FetchedPage {
+        url: "https://example.com".to_string(),
+        title: Some("Title".to_string()),
+        html: "<h1>Title</h1>".to_string(),
+        text: "Title".to_string(),
+        markdown: "# Title\n\nSome content".to_string(),
+        fetched_via_browser: false,
+    };
+
+    assert!(page.markdown.contains('#'));
+    assert!(page.markdown.contains("Some content"));
 }


### PR DESCRIPTION
## Summary

Refactors the crawler's content extraction to give the LLM agent richer, more consistent feedback after every action.

### Key changes

- **Shared markdown module** (`htmd` crate) — consistent HTML→Markdown conversion with safe fallbacks and capped output
- **Expanded `page_map`** — now returns headings, landmarks, forms, links, interactive counts, and metadata (was headings-only)
- **Post-action `page_state`** on all interaction tools — click, fill_form, scroll, hover, press_key, select_option, go_back, switch_tab all return structural context of the resulting page
- **`navigate` format param** — supports `markdown` (default), `text`, `html` output; always includes a `page_map`
- **Performance caps in JS** — links (50), forms (10, 30 fields each), landmarks (20) are capped inside `page.evaluate` to avoid large stdio transfers and feedback timeouts
- **Resilient markdown conversion** — fallback strips tags instead of leaking raw HTML; code fences handle embedded backticks

### Breaking changes

- `scroll` input param renamed `amount` → `pixels`
- `switch_tab` response no longer has top-level `url`/`title` (moved into `page_state`)
- `page_map` response shape expanded (new fields: `landmarks`, `forms`, `links`, `interactive`, `meta`)

### Stats

21 files changed, +1538/-150 across 18 commits. All 239 tests pass, clippy pedantic clean.