### PR TITLE
feat(crawler): replace Playwright with CloakBrowser for stealth browsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
-      - run: npx playwright install --with-deps chromium
+      - run: node -e "require('cloakbrowser')"
       - run: cargo test --workspace
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
-      - run: node -e "require('cloakbrowser')"
+      - run: npx cloakbrowser install
       - run: cargo test --workspace
 
   build:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,6 @@ cargo test -p <crate> <test_name>                            # run a single test
 cargo clippy --workspace --all-targets -- -D warnings        # lints must be clean (workspace lints set pedantic = warn)
 cargo fmt --check                                            # format check
 
-npx playwright install chromium                              # required for the Playwright bridge
 ./target/release/acrawl                                      # launch REPL
 ./target/release/acrawl prompt "scrape all titles from example.com"   # one-shot
 ./target/release/acrawl --resume session.json /status /compact        # non-interactive session maintenance
@@ -39,7 +38,7 @@ Five crates under `crates/`, compiled with `resolver = "2"`:
 4. `runtime::PermissionPolicy` gates every tool call against the current `PermissionMode`. Each of the 19 `ToolSpec`s declares `required_permission` — extraction/listing are `ReadOnly`, `save_file` is `WorkspaceWrite`, the rest require `DangerFullAccess`.
 5. `runtime::UsageTracker` + `pricing_for_model` feed `/cost` and `/status`. `runtime::compact` watches `ACRAWL_AUTO_COMPACT_INPUT_TOKENS` (default 200k) and auto-compacts the session when the threshold trips.
 
-The Playwright bridge is notable: it is a **single embedded Node script** launched as a subprocess, not a Rust Playwright binding. This is why `npx playwright install chromium` is a runtime requirement, not a build-time one.
+The CloakBrowser bridge is notable: it is a **single embedded Node script** launched as a subprocess, using CloakBrowser (not stock Playwright) for stealth browsing. The browser binary auto-downloads on first use — no separate install step needed.
 
 ## Provider routing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Replaced Playwright with CloakBrowser as the browser engine — passes bot detection (reCAPTCHA v3 0.9, Cloudflare Turnstile, FingerprintJS) with source-level stealth patches
+- Human-like interaction enabled by default (Bézier mouse curves, natural keyboard timing)
+- Browser binary auto-downloads on first use (no separate `npx playwright install` step)
+
 ## [0.3.4] - 2026-05-14
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,9 +17,8 @@ git clone https://github.com/Mingye-Lu/AgenticCrawler.git
 cd AgenticCrawler
 cargo build --release
 
-# Browser automation requires Playwright's Chromium
+# Browser automation requires CloakBrowser (auto-downloads on first use)
 npm install
-npx playwright install chromium
 ```
 
 ## Code Style
@@ -53,7 +52,7 @@ crates/
   acrawl-cli/   CLI binary, TUI REPL, session management
   api/          LLM provider clients (Anthropic, OpenAI, Codex)
   commands/     Slash command registry
-  crawler/      Browser tools, agent loop, Playwright bridge
+  crawler/      Browser tools, agent loop, CloakBrowser bridge
   runtime/      ConversationRuntime, config, permissions, sessions
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 </p>
 
 <p align="center">
-  Single binary. No Python runtime. 19 tools. 24 LLM providers. Playwright for the hard parts.
+  Single binary. No Python runtime. 19 tools. 24 LLM providers. CloakBrowser for the hard parts.
 </p>
 
 ---
@@ -66,7 +66,7 @@ curl -fsSL https://raw.githubusercontent.com/Mingye-Lu/AgenticCrawler/main/insta
 irm https://raw.githubusercontent.com/Mingye-Lu/AgenticCrawler/main/install.ps1 | iex
 ```
 
-This downloads the latest binary, verifies its SHA256 checksum, and sets up Playwright for browser automation. Requires Node.js 16+ for browser features.
+This downloads the latest binary, verifies its SHA256 checksum, and sets up CloakBrowser for stealth browser automation. Requires Node.js 16+ for browser features.
 
 acrawl checks for updates on startup and shows a notification when a new version is available.
 
@@ -78,9 +78,8 @@ git clone https://github.com/Mingye-Lu/AgenticCrawler.git
 cd AgenticCrawler
 cargo build --release
 
-# Install Playwright's Chromium (required for browser automation)
+# Install CloakBrowser (required for browser automation — binary auto-downloads on first use)
 npm install
-npx playwright install chromium
 ```
 
 </details>
@@ -409,7 +408,7 @@ flowchart LR
 1. The agent receives a goal and builds a multi-step plan via a [7-section system prompt](crates/crawler/src/prompt.rs) covering identity, operating procedure, data integrity, constraints, error recovery, completion protocol, and parallel exploration guidance.
 2. Each turn, it picks from its 19 tools based on what it observes on the page.
 3. `navigate` hits the FetchRouter, which tries HTTP first and auto-escalates to a headless Chromium browser when JavaScript, auth redirects, or framework markers are detected.
-4. The browser is driven by an embedded Node.js subprocess (the PlaywrightBridge) speaking newline-delimited JSON over stdio — not a Rust Playwright binding.
+4. The browser is driven by an embedded Node.js subprocess (the PlaywrightBridge) speaking newline-delimited JSON over stdio — uses CloakBrowser for stealth browsing, not stock Playwright.
 5. For multi-page tasks, the agent can `fork` child agents onto separate browser tabs, each with independent state and step budgets. `wait_for_subagents` or `done` merges results.
 6. When context grows large, auto-compaction summarizes older messages while preserving recent turns, tool usage, pending work, and file references.
 7. The agent calls `done` when the goal is met, or stops when the step limit is reached.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ curl -fsSL https://raw.githubusercontent.com/Mingye-Lu/AgenticCrawler/main/insta
 irm https://raw.githubusercontent.com/Mingye-Lu/AgenticCrawler/main/install.ps1 | iex
 ```
 
-This downloads the latest binary, verifies its SHA256 checksum, and sets up CloakBrowser for stealth browser automation. Requires Node.js 16+ for browser features.
+This downloads the latest binary, verifies its SHA256 checksum, and sets up CloakBrowser for stealth browser automation. Requires Node.js 20+ for browser features.
 
 acrawl checks for updates on startup and shows a notification when a new version is available.
 

--- a/crates/acrawl-cli/src/self_update.rs
+++ b/crates/acrawl-cli/src/self_update.rs
@@ -56,7 +56,7 @@ pub async fn run_self_update() -> Result<(), Box<dyn std::error::Error>> {
     let current_exe = env::current_exe()?;
     replace_binary(&current_exe, &binary_bytes)?;
 
-    install_playwright_if_needed().await;
+    install_cloakbrowser_if_needed().await;
 
     println!("Updated to v{version} successfully!");
     Ok(())
@@ -138,32 +138,24 @@ fn replace_binary(
     Ok(())
 }
 
-async fn install_playwright_if_needed() {
-    let playwright_dir = config_home_dir().join("node_modules").join("playwright");
-    if playwright_dir.exists() {
+async fn install_cloakbrowser_if_needed() {
+    let cloakbrowser_dir = config_home_dir().join("node_modules").join("cloakbrowser");
+    if cloakbrowser_dir.exists() {
         return;
     }
 
-    println!("Installing Playwright...");
+    println!("Installing CloakBrowser...");
     let config_home = config_home_dir();
     let npm_result = tokio::process::Command::new("npm")
         .args(["install", "--prefix"])
         .arg(&config_home)
-        .arg("playwright")
+        .arg("cloakbrowser")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .status()
         .await;
 
     if npm_result.is_ok_and(|s| s.success()) {
-        let _ = tokio::process::Command::new("npx")
-            .args(["--prefix"])
-            .arg(&config_home)
-            .args(["playwright", "install", "chromium"])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .await;
-        println!("Playwright installed.");
+        println!("CloakBrowser installed.");
     }
 }

--- a/crates/acrawl-cli/src/tui/repl_render.rs
+++ b/crates/acrawl-cli/src/tui/repl_render.rs
@@ -693,7 +693,7 @@ pub(super) fn draw_welcome(
         )));
     }
     lines.push(Line::from(""));
-    let version_str = format!("v{VERSION} · Playwright ready");
+    let version_str = format!("v{VERSION} · CloakBrowser ready");
     let max_w = ascii
         .iter()
         .map(|s| text_display_width(s))

--- a/crates/crawler/src/lib.rs
+++ b/crates/crawler/src/lib.rs
@@ -397,4 +397,36 @@ mod tests {
             "page_map instructions should mention landmark"
         );
     }
+
+    #[tokio::test]
+    async fn test_cloakbrowser_launch_smoke() {
+        use super::{PlaywrightBridge, PlaywrightBridgeError};
+
+        // Self-skip if not in CI and CloakBrowser not installed locally
+        let in_ci = std::env::var("CI").is_ok();
+        let cloakbrowser_installed = runtime::config_home_dir()
+            .join("node_modules")
+            .join("cloakbrowser")
+            .exists();
+        if !in_ci && !cloakbrowser_installed {
+            eprintln!("test_cloakbrowser_launch_smoke: skipping — CloakBrowser not installed");
+            return;
+        }
+
+        // If installed, launch the bridge and verify bootstrap succeeds
+        let result = PlaywrightBridge::new().await;
+        match result {
+            Ok(bridge) => {
+                let _ = bridge.close().await;
+            }
+            Err(PlaywrightBridgeError::PlaywrightNotInstalled(_)) => {
+                eprintln!(
+                    "test_cloakbrowser_launch_smoke: skipping — CloakBrowser binary not available"
+                );
+            }
+            Err(e) => {
+                panic!("Unexpected error launching CloakBrowser bridge: {e}");
+            }
+        }
+    }
 }

--- a/crates/crawler/src/playwright.rs
+++ b/crates/crawler/src/playwright.rs
@@ -20,21 +20,6 @@ const CLOSE_COMMAND_TIMEOUT: Duration = Duration::from_secs(2);
 const PLAYWRIGHT_BRIDGE_NODE_SCRIPT: &str = r#"
 const readline = require('node:readline');
 
-let launch;
-try {
-  ({ launch } = require('cloakbrowser'));
-} catch (_error) {
-  process.stdout.write(JSON.stringify({
-    event: 'bridge_bootstrap',
-    ok: false,
-    error: {
-      kind: 'playwright_not_installed',
-      message: 'CloakBrowser package not found. Install with `npm install cloakbrowser`.'
-    }
-  }) + '\n');
-  process.exit(1);
-}
-
 function parseHeadless() {
   const raw = process.env.HEADLESS;
   if (raw === undefined) return true;
@@ -61,6 +46,22 @@ async function resolveFillSelector(pg, raw) {
 }
 
 async function bootstrap() {
+  let launch;
+  try {
+    ({ launch } = await import('cloakbrowser'));
+  } catch (_error) {
+    process.stdout.write(JSON.stringify({
+      event: 'bridge_bootstrap',
+      ok: false,
+      error: {
+        kind: 'playwright_not_installed',
+        message: 'CloakBrowser package not found. Install with `npm install cloakbrowser`.'
+      }
+    }) + '\n');
+    process.exit(1);
+    return;
+  }
+  console.log = (...args) => process.stderr.write(args.map(String).join(' ') + '\n');
   const browser = await launch({ headless: parseHeadless(), humanize: true });
   const context = await browser.newContext();
   let page = await context.newPage();

--- a/crates/crawler/src/playwright.rs
+++ b/crates/crawler/src/playwright.rs
@@ -634,29 +634,29 @@ impl fmt::Display for PlaywrightBridgeError {
         match self {
             Self::ProcessSpawn { command, source } => write!(
                 f,
-                "failed to spawn `{command}` for Playwright bridge: {source}. Ensure Node.js and Playwright are installed"
+                "failed to spawn `{command}` for CloakBrowser bridge: {source}. Ensure Node.js and CloakBrowser are installed"
             ),
             Self::LaunchTimeout { timeout } => write!(
                 f,
-                "Playwright bridge launch exceeded {} seconds",
+                "CloakBrowser bridge launch exceeded {} seconds",
                 timeout.as_secs()
             ),
-            Self::Protocol(message) => write!(f, "Playwright bridge protocol error: {message}"),
+            Self::Protocol(message) => write!(f, "CloakBrowser bridge protocol error: {message}"),
             Self::PlaywrightNotInstalled(message) => write!(
                 f,
-                "Playwright is not installed: {message}. Install with `npm install playwright` and `npx playwright install chromium`"
+                "CloakBrowser is not installed: {message}. Install with `npm install cloakbrowser`"
             ),
-            Self::Io(error) => write!(f, "Playwright bridge I/O error: {error}"),
-            Self::Json(error) => write!(f, "Playwright bridge JSON error: {error}"),
-            Self::ChildClosed => write!(f, "Playwright bridge process closed unexpectedly"),
+            Self::Io(error) => write!(f, "CloakBrowser bridge I/O error: {error}"),
+            Self::Json(error) => write!(f, "CloakBrowser bridge JSON error: {error}"),
+            Self::ChildClosed => write!(f, "CloakBrowser bridge process closed unexpectedly"),
             Self::ShutdownTimeout { timeout } => write!(
                 f,
-                "Playwright bridge did not shut down within {} seconds",
+                "CloakBrowser bridge did not shut down within {} seconds",
                 timeout.as_secs()
             ),
             Self::CommandTimeout { timeout } => write!(
                 f,
-                "Playwright bridge command timed out after {} seconds",
+                "CloakBrowser bridge command timed out after {} seconds",
                 timeout.as_secs()
             ),
         }

--- a/crates/crawler/src/playwright.rs
+++ b/crates/crawler/src/playwright.rs
@@ -20,16 +20,16 @@ const CLOSE_COMMAND_TIMEOUT: Duration = Duration::from_secs(2);
 const PLAYWRIGHT_BRIDGE_NODE_SCRIPT: &str = r#"
 const readline = require('node:readline');
 
-let playwright;
+let launch;
 try {
-  playwright = require('playwright');
+  ({ launch } = require('cloakbrowser'));
 } catch (_error) {
   process.stdout.write(JSON.stringify({
     event: 'bridge_bootstrap',
     ok: false,
     error: {
       kind: 'playwright_not_installed',
-      message: 'Playwright package not found. Install with `npm install playwright` and browser binaries with `npx playwright install chromium`.'
+      message: 'CloakBrowser package not found. Install with `npm install cloakbrowser`.'
     }
   }) + '\n');
   process.exit(1);
@@ -61,7 +61,7 @@ async function resolveFillSelector(pg, raw) {
 }
 
 async function bootstrap() {
-  const browser = await playwright.chromium.launch({ headless: parseHeadless() });
+  const browser = await launch({ headless: parseHeadless(), humanize: true });
   const context = await browser.newContext();
   let page = await context.newPage();
   const pages = [page];

--- a/install.ps1
+++ b/install.ps1
@@ -131,19 +131,19 @@ try {
     if ($nodeVersionRaw) {
         $nodeVersion = $nodeVersionRaw.TrimStart('v')
         $nodeMajor = [int]($nodeVersion -split '\.')[0]
-        if ($nodeMajor -lt 16) {
-            Write-Warning "Node.js 16+ is required for browser automation. You have v$nodeVersion."
+        if ($nodeMajor -lt 20) {
+            Write-Warning "Node.js 20+ is required for browser automation. You have v$nodeVersion."
             Write-Warning "Install from https://nodejs.org/ to enable headless browser features."
         } else {
             $nodeAvailable = $true
             Write-Host "  Node.js v$nodeVersion detected." -ForegroundColor Green
         }
     } else {
-        Write-Warning "Node.js not found. Browser automation requires Node.js 16+."
+        Write-Warning "Node.js not found. Browser automation requires Node.js 20+."
         Write-Warning "Install from https://nodejs.org/ to enable headless browser features."
     }
 } catch {
-    Write-Warning "Node.js not found. Browser automation requires Node.js 16+."
+    Write-Warning "Node.js not found. Browser automation requires Node.js 20+."
     Write-Warning "Install from https://nodejs.org/ to enable headless browser features."
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -6,7 +6,7 @@
 .DESCRIPTION
     Downloads the latest acrawl binary from GitHub Releases, verifies the
     SHA256 checksum, installs to $HOME\.acrawl\bin\, adds to user PATH,
-    and optionally sets up Playwright for browser automation.
+    and optionally sets up CloakBrowser for browser automation.
 
 .EXAMPLE
     irm https://raw.githubusercontent.com/Mingye-Lu/AgenticCrawler/main/install.ps1 | iex
@@ -147,20 +147,19 @@ try {
     Write-Warning "Install from https://nodejs.org/ to enable headless browser features."
 }
 
-# --- 10. Playwright install ---
+# --- 10. CloakBrowser install ---
 if ($nodeAvailable) {
-    $playwrightDir = Join-Path $ConfigHome "node_modules\playwright"
-    if (Test-Path $playwrightDir) {
-        Write-Host "  Playwright already installed." -ForegroundColor Gray
+    $cloakbrowserDir = Join-Path $ConfigHome "node_modules\cloakbrowser"
+    if (Test-Path $cloakbrowserDir) {
+        Write-Host "  CloakBrowser already installed." -ForegroundColor Gray
     } else {
-        Write-Host "Installing Playwright..." -ForegroundColor Gray
+        Write-Host "Installing CloakBrowser..." -ForegroundColor Gray
         try {
-            & npm install --prefix $ConfigHome playwright 2>&1 | Out-Null
-            & npx --prefix $ConfigHome playwright install chromium 2>&1 | Out-Null
-            Write-Host "  Playwright + Chromium installed." -ForegroundColor Green
+            & npm install --prefix $ConfigHome cloakbrowser 2>&1 | Out-Null
+            Write-Host "  CloakBrowser installed." -ForegroundColor Green
         } catch {
-            Write-Warning "Playwright installation failed: $_"
-            Write-Warning "You can install it manually later: npm install --prefix `"$ConfigHome`" playwright && npx --prefix `"$ConfigHome`" playwright install chromium"
+            Write-Warning "CloakBrowser installation failed: $_"
+            Write-Warning "You can install it manually later: npm install --prefix `"$ConfigHome`" cloakbrowser"
         }
     }
 }

--- a/install.sh
+++ b/install.sh
@@ -136,18 +136,17 @@ elif [ -n "$node_major" ] && [ "$node_major" -lt 16 ]; then
     echo "WARNING: Node.js 16+ required for browser automation, you have ${node_version}"
 fi
 
-# --- 10. Playwright install ---
+# --- 10. CloakBrowser install ---
 if [ -n "$node_major" ] && [ "$node_major" -ge 16 ]; then
-    if [ -d "${CONFIG_HOME}/node_modules/playwright" ]; then
-        echo "Playwright already installed at ${CONFIG_HOME}/node_modules/playwright (skipping)"
+    if [ -d "${CONFIG_HOME}/node_modules/cloakbrowser" ]; then
+        echo "CloakBrowser already installed at ${CONFIG_HOME}/node_modules/cloakbrowser (skipping)"
     else
-        echo "Installing Playwright..."
+        echo "Installing CloakBrowser..."
         mkdir -p "$CONFIG_HOME"
-        if npm install --prefix "$CONFIG_HOME" playwright; then
-            echo "Installing Chromium browser..."
-            npx --prefix "$CONFIG_HOME" playwright install chromium || echo "WARNING: Chromium install failed. Run manually: npx --prefix \"$CONFIG_HOME\" playwright install chromium"
+        if npm install --prefix "$CONFIG_HOME" cloakbrowser; then
+            echo "CloakBrowser installed."
         else
-            echo "WARNING: Playwright install failed. Run manually: npm install --prefix \"$CONFIG_HOME\" playwright"
+            echo "WARNING: CloakBrowser install failed. Run manually: npm install --prefix \"$CONFIG_HOME\" cloakbrowser"
         fi
     fi
 fi

--- a/install.sh
+++ b/install.sh
@@ -130,14 +130,14 @@ if [ -n "$node_version" ]; then
 fi
 
 if [ -z "$node_version" ]; then
-    echo "WARNING: Node.js not found. Node.js 16+ is required for browser automation."
+    echo "WARNING: Node.js not found. Node.js 20+ is required for browser automation."
     echo "Install from https://nodejs.org/"
-elif [ -n "$node_major" ] && [ "$node_major" -lt 16 ]; then
-    echo "WARNING: Node.js 16+ required for browser automation, you have ${node_version}"
+elif [ -n "$node_major" ] && [ "$node_major" -lt 20 ]; then
+    echo "WARNING: Node.js 20+ required for browser automation, you have ${node_version}"
 fi
 
 # --- 10. CloakBrowser install ---
-if [ -n "$node_major" ] && [ "$node_major" -ge 16 ]; then
+if [ -n "$node_major" ] && [ "$node_major" -ge 20 ]; then
     if [ -d "${CONFIG_HOME}/node_modules/cloakbrowser" ]; then
         echo "CloakBrowser already installed at ${CONFIG_HOME}/node_modules/cloakbrowser (skipping)"
     else

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,41 +4,86 @@
   "requires": true,
   "packages": {
     "": {
-      "hasInstallScript": true,
       "dependencies": {
-        "playwright": "^1.52.0"
+        "cloakbrowser": "^0.3.26",
+        "playwright-core": "^1.52.0"
       }
     },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
       "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+        "node": ">=18.0.0"
       }
     },
-    "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.59.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/cloakbrowser": {
+      "version": "0.3.28",
+      "resolved": "https://registry.npmjs.org/cloakbrowser/-/cloakbrowser-0.3.28.tgz",
+      "integrity": "sha512-33IeHiST1V2vbWbLmCFI/tykMsrd6zOwjgM1+669AclA2n0p4RTBLUk5WLUe5AuaTLcjfkE7uKdLi79H39XeAg==",
+      "license": "MIT",
+      "dependencies": {
+        "tar": "^7.0.0"
       },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
+      "bin": {
+        "cloakbrowser": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "mmdb-lib": ">=2.0.0",
+        "playwright-core": ">=1.53.0",
+        "puppeteer-core": ">=21.0.0",
+        "socks-proxy-agent": ">=10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "mmdb-lib": {
+          "optional": true
+        },
+        "playwright-core": {
+          "optional": true
+        },
+        "puppeteer-core": {
+          "optional": true
+        },
+        "socks-proxy-agent": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/playwright-core": {
@@ -49,6 +94,31 @@
       "bin": {
         "playwright-core": "cli.js"
       },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,8 @@
 {
   "private": true,
   "description": "Runtime Node.js dependencies for acrawl's Playwright browser bridge",
-  "scripts": {
-    "postinstall": "npx playwright install chromium"
-  },
   "dependencies": {
-    "playwright": "^1.52.0"
+    "cloakbrowser": "^0.3.26",
+    "playwright-core": "^1.52.0"
   }
 }


### PR DESCRIPTION
## Summary

Replaces stock Playwright with [CloakBrowser](https://cloakbrowser.dev/) — a Chromium fork with 57 source-level C++ patches that passes reCAPTCHA v3 (score 0.9), Cloudflare Turnstile, FingerprintJS, and other bot detection systems that stock Playwright fails.

## Changes

### Core (`crates/crawler/src/playwright.rs`)
- Bridge script now uses ESM dynamic `import('cloakbrowser')` (CloakBrowser is ESM-only; `require()` does not work)
- Launch call: `playwright.chromium.launch({ headless })` → `launch({ headless: parseHeadless(), humanize: true })`
- `humanize: true` enables Bézier mouse curves, natural keyboard timing, and realistic scroll — always on, not user-configurable
- `console.log` redirected to `stderr` before `launch()` so binary download-progress lines don't corrupt the NDJSON pipe
- Error messages updated to reference CloakBrowser; all Rust type names (`PlaywrightBridge`, `PlaywrightBridgeError`, `PLAYWRIGHT_BRIDGE_NODE_SCRIPT`) are **unchanged** — rename is a separate PR

### Dependencies (`package.json`)
- `playwright` removed; `cloakbrowser ^0.3.26` + `playwright-core ^1.52.0` added
- `postinstall` script removed — CloakBrowser auto-downloads its binary on first `launch()`

### Install & CI
- `install.sh` / `install.ps1`: check/install `cloakbrowser` instead of `playwright`; removed `npx playwright install chromium` step
- `crates/acrawl-cli/src/self_update.rs`: `install_playwright_if_needed` → `install_cloakbrowser_if_needed`; removed the `npx playwright install chromium` sub-command
- `.github/workflows/ci.yml`: `npx playwright install --with-deps chromium` → `npx cloakbrowser install` (pre-downloads the binary before `cargo test`)

### Docs & Changelog
- README, AGENTS.md, CONTRIBUTING.md: setup commands and description updated; `PlaywrightBridge` Rust type name preserved in architecture sections
- CHANGELOG: `[Unreleased]` section added

### Test
- `test_cloakbrowser_launch_smoke`: self-skipping (not `#[ignore]`) — passes when binary present (CI), gracefully skips when absent (local dev)

## Non-obvious implementation detail

CloakBrowser is **ESM-only** (`type: module`, no `require` export). The existing bridge used `require('cloakbrowser')` which throws `ERR_PACKAGE_PATH_NOT_EXPORTED`. Fix: move to `await import('cloakbrowser')` inside the existing `async function bootstrap()`. Additionally, `console.log()` writes download-progress to **stdout** (not stderr), which would corrupt the NDJSON protocol pipe on first install; redirecting it to `process.stderr.write` before `launch()` fixes this.

## Test results

```
cargo test --workspace   →  825 passed, 0 failed
cargo clippy             →  0 warnings
cargo fmt --check        →  clean
```