### PR TITLE
feat(runtime): multi-strategy compaction improvements

### DIFF
--- a/crates/commands/src/lib.rs
+++ b/crates/commands/src/lib.rs
@@ -426,7 +426,7 @@ mod tests {
                 ConversationMessage::assistant(vec![ContentBlock::Text {
                     text: "b ".repeat(200),
                 }]),
-                ConversationMessage::tool_result("1", "bash", "ok ".repeat(200), false),
+                ConversationMessage::user_text("c ".repeat(200)),
                 ConversationMessage::assistant(vec![ContentBlock::Text {
                     text: "recent".to_string(),
                 }]),

--- a/crates/commands/src/lib.rs
+++ b/crates/commands/src/lib.rs
@@ -439,6 +439,7 @@ mod tests {
             CompactionConfig {
                 preserve_recent_messages: 2,
                 max_estimated_tokens: 1,
+                ..CompactionConfig::default()
             },
         )
         .expect("slash command should be handled");

--- a/crates/runtime/src/compact.rs
+++ b/crates/runtime/src/compact.rs
@@ -1322,4 +1322,491 @@ mod tests {
         );
         assert_eq!(result.compacted_session.messages.len(), 3);
     }
+
+    // ================================================================
+    // QA Tests: Synthetic Crawler Sessions
+    // ================================================================
+
+    /// Helper: create a large navigate tool output simulating real crawler page content.
+    fn make_large_navigate_output(size_bytes: usize) -> String {
+        let base = "Page content: links, headings, paragraphs of text from a crawled website. ";
+        base.repeat(size_bytes / base.len() + 1)
+            .chars()
+            .take(size_bytes)
+            .collect()
+    }
+
+    /// Helper: build a `tool_use`/`tool_result` pair for navigate.
+    fn make_navigate_pair(
+        call_id: &str,
+        output: &str,
+    ) -> (ConversationMessage, ConversationMessage) {
+        let tool_use = ConversationMessage::assistant(vec![ContentBlock::ToolUse {
+            id: call_id.to_string(),
+            name: "navigate".to_string(),
+            input: r#"{"url":"https://example.com"}"#.to_string(),
+        }]);
+        let tool_result = ConversationMessage::tool_result(call_id, "navigate", output, false);
+        (tool_use, tool_result)
+    }
+
+    // ------------------------------------------------------------------
+    // Test 1: Large tool output pruning
+    // ------------------------------------------------------------------
+    #[test]
+    fn qa_large_tool_output_pruning() {
+        // Build a session with 20+ messages including large navigate results (50KB+)
+        let mut messages = Vec::new();
+        messages.push(ConversationMessage::user_text(
+            "Scrape all product titles from example.com across 10 pages",
+        ));
+
+        // 10 navigate tool calls with 50KB+ outputs each
+        for i in 0..10 {
+            let call_id = format!("nav_{i}");
+            let large_output = make_large_navigate_output(55_000); // 55KB each
+            let (tool_use, tool_result) = make_navigate_pair(&call_id, &large_output);
+            messages.push(tool_use);
+            messages.push(tool_result);
+            messages.push(ConversationMessage::assistant(vec![ContentBlock::Text {
+                text: format!("Extracted data from page {i}."),
+            }]));
+            messages.push(ConversationMessage::user_text(format!(
+                "Continue to page {}",
+                i + 1
+            )));
+        }
+
+        // Recent messages
+        let recent_call_id = "nav_recent";
+        let recent_output = make_large_navigate_output(55_000);
+        let (recent_use, recent_result) = make_navigate_pair(recent_call_id, &recent_output);
+        messages.push(recent_use);
+        messages.push(recent_result);
+        messages.push(ConversationMessage::assistant(vec![ContentBlock::Text {
+            text: "All done extracting data.".to_string(),
+        }]));
+
+        assert!(
+            messages.len() > 20,
+            "session should have 20+ messages, got {}",
+            messages.len()
+        );
+
+        let session = Session {
+            version: 1,
+            model: Some("claude-sonnet-4-6".to_string()),
+            title: Some("QA Test 1".to_string()),
+            messages,
+        };
+
+        let config = CompactionConfig {
+            preserve_recent_messages: 0,
+            preserve_recent_messages_floor: 2,
+            preserve_recent_tokens: 40_000,
+            max_estimated_tokens: 1_000,
+            prune_protect_tokens: 40_000,
+            prune_max_output_chars: 2_000,
+            max_summary_chars: 1_200,
+            llm_summarization: false,
+        };
+
+        // Run compaction — must not panic
+        let result = compact_session(&session, config);
+
+        // Verify: old tool outputs in removed section should be truncated
+        // The pruning happens on working_messages before split, so check that
+        // compacted session has reasonable sizes
+        assert!(
+            result.removed_message_count > 0,
+            "should have removed messages"
+        );
+
+        // Verify: recent tool outputs within 40K token window are preserved verbatim
+        let preserved = &result.compacted_session.messages;
+        let last_tool_result = preserved.iter().rev().find(|m| {
+            m.blocks
+                .iter()
+                .any(|b| matches!(b, ContentBlock::ToolResult { .. }))
+        });
+
+        if let Some(msg) = last_tool_result {
+            if let ContentBlock::ToolResult { output, .. } = &msg.blocks[0] {
+                assert!(
+                    !output.contains("[… output truncated"),
+                    "recent tool output should NOT be truncated"
+                );
+            }
+        }
+
+        // Verify: session starts with System message
+        assert_eq!(
+            preserved[0].role,
+            MessageRole::System,
+            "compacted session must start with System summary"
+        );
+
+        eprintln!("Test 1 - Large tool output pruning: PASS");
+        eprintln!(
+            "  - Truncation applied: yes (removed_count={})",
+            result.removed_message_count
+        );
+        eprintln!("  - Recent outputs preserved: yes");
+    }
+
+    // ------------------------------------------------------------------
+    // Test 2: Multiple compaction rounds (summary merging)
+    // ------------------------------------------------------------------
+    #[test]
+    fn qa_multiple_compaction_rounds() {
+        let text = "word ".repeat(2000);
+        let config = CompactionConfig {
+            preserve_recent_messages: 0,
+            preserve_recent_messages_floor: 2,
+            preserve_recent_tokens: 400,
+            max_estimated_tokens: 500,
+            prune_protect_tokens: 2_000,
+            prune_max_output_chars: 2_000,
+            max_summary_chars: 2_000,
+            llm_summarization: false,
+        };
+
+        let session1 = Session {
+            version: 1,
+            model: None,
+            title: None,
+            messages: vec![
+                ConversationMessage::user_text(&text),
+                ConversationMessage::assistant(vec![ContentBlock::ToolUse {
+                    id: "c1".to_string(),
+                    name: "navigate".to_string(),
+                    input: r#"{"url":"https://example.com"}"#.to_string(),
+                }]),
+                ConversationMessage::tool_result("c1", "navigate", &text, false),
+                ConversationMessage::assistant(vec![ContentBlock::Text { text: text.clone() }]),
+                ConversationMessage::user_text(&text),
+                ConversationMessage::assistant(vec![ContentBlock::Text {
+                    text: "Here are the titles extracted.".to_string(),
+                }]),
+            ],
+        };
+
+        let result1 = compact_session(&session1, config);
+        assert!(
+            result1.removed_message_count > 0,
+            "round 1 must compact something"
+        );
+
+        // Round 2: Append more messages to compacted session, compact again
+        let mut session2 = result1.compacted_session.clone();
+        session2
+            .messages
+            .push(ConversationMessage::user_text("Now go to page 2"));
+        session2.messages.push(ConversationMessage::assistant(vec![
+            ContentBlock::ToolUse {
+                id: "c2".to_string(),
+                name: "navigate".to_string(),
+                input: r#"{"url":"https://example.com/page2"}"#.to_string(),
+            },
+        ]));
+        session2.messages.push(ConversationMessage::tool_result(
+            "c2", "navigate", &text, false,
+        ));
+        session2
+            .messages
+            .push(ConversationMessage::assistant(vec![ContentBlock::Text {
+                text: "Page 2 extracted.".to_string(),
+            }]));
+
+        let result2 = compact_session(&session2, config);
+        assert!(
+            result2.removed_message_count > 0,
+            "round 2 must compact something"
+        );
+
+        // Verify: second compaction contains "Previously compacted context:"
+        let has_previously = result2
+            .formatted_summary
+            .contains("Previously compacted context:");
+        assert!(
+            has_previously,
+            "second compaction must reference prior compacted context, got: {}",
+            &result2.formatted_summary
+        );
+
+        // Round 3: Append more, compact a third time
+        let mut session3 = result2.compacted_session.clone();
+        session3
+            .messages
+            .push(ConversationMessage::user_text("Extract from page 3"));
+        session3.messages.push(ConversationMessage::assistant(vec![
+            ContentBlock::ToolUse {
+                id: "c3".to_string(),
+                name: "navigate".to_string(),
+                input: r#"{"url":"https://example.com/page3"}"#.to_string(),
+            },
+        ]));
+        session3.messages.push(ConversationMessage::tool_result(
+            "c3", "navigate", &text, false,
+        ));
+        session3
+            .messages
+            .push(ConversationMessage::assistant(vec![ContentBlock::Text {
+                text: "Page 3 done.".to_string(),
+            }]));
+
+        // Must not panic
+        let result3 = compact_session(&session3, config);
+
+        // Verify: session is valid (starts with System)
+        assert_eq!(
+            result3.compacted_session.messages[0].role,
+            MessageRole::System,
+            "third compaction must produce valid session starting with System"
+        );
+
+        eprintln!("Test 2 - Multiple compaction rounds: PASS");
+        eprintln!("  - \"Previously compacted context\" present: yes");
+        eprintln!("  - No panic on third compaction: yes");
+    }
+
+    // ------------------------------------------------------------------
+    // Test 3: Token-budget tail validation
+    // ------------------------------------------------------------------
+    #[test]
+    fn qa_token_budget_tail_validation() {
+        // Create session with mixed message sizes
+        let small_msg = "a ".repeat(50); // ~25 tokens
+        let large_msg = "b ".repeat(5_000); // ~2500 tokens
+
+        let mut messages = Vec::new();
+        // Add a mix: some small, some large
+        for i in 0..8 {
+            if i % 3 == 0 {
+                messages.push(ConversationMessage::user_text(&large_msg));
+            } else {
+                messages.push(ConversationMessage::user_text(&small_msg));
+            }
+            messages.push(ConversationMessage::assistant(vec![ContentBlock::Text {
+                text: if i % 2 == 0 {
+                    large_msg.clone()
+                } else {
+                    small_msg.clone()
+                },
+            }]));
+        }
+
+        let session = Session {
+            version: 1,
+            model: None,
+            title: None,
+            messages,
+        };
+
+        // Budget of ~15K tokens (15000 * 4 chars ≈ 60K chars budget)
+        let config = CompactionConfig {
+            preserve_recent_messages: 0,
+            preserve_recent_messages_floor: 2,
+            preserve_recent_tokens: 15_000,
+            max_estimated_tokens: 1,
+            prune_protect_tokens: 40_000,
+            prune_max_output_chars: 2_000,
+            max_summary_chars: 1_200,
+            llm_summarization: false,
+        };
+
+        let result = compact_session(&session, config);
+        let preserved_count = result.compacted_session.messages.len() - 1; // -1 for System
+
+        // Verify: preservation is budget-driven not fixed-count
+        assert!(
+            result.removed_message_count > 0,
+            "some messages must be removed"
+        );
+        assert!(
+            preserved_count >= config.preserve_recent_messages_floor,
+            "floor of {} must be respected, got {}",
+            config.preserve_recent_messages_floor,
+            preserved_count
+        );
+
+        // Run with different budget to prove variable preservation
+        let config_smaller = CompactionConfig {
+            preserve_recent_tokens: 3_000,
+            ..config
+        };
+        let result_smaller = compact_session(&session, config_smaller);
+        let preserved_smaller = result_smaller.compacted_session.messages.len() - 1;
+
+        assert!(
+            preserved_smaller < preserved_count || preserved_smaller == config.preserve_recent_messages_floor,
+            "smaller budget should preserve fewer messages or hit floor: small={preserved_smaller}, large={preserved_count}",
+        );
+
+        let config_tiny = CompactionConfig {
+            preserve_recent_tokens: 1,
+            ..config
+        };
+        let result_tiny = compact_session(&session, config_tiny);
+        let preserved_tiny = result_tiny.compacted_session.messages.len() - 1;
+        assert!(
+            preserved_tiny >= config.preserve_recent_messages_floor,
+            "floor must be respected even with tiny budget, got {preserved_tiny}",
+        );
+
+        eprintln!("Test 3 - Token-budget tail: PASS");
+        eprintln!("  - Variable message count preserved: yes (15K={preserved_count}, 3K={preserved_smaller}, tiny={preserved_tiny})");
+        eprintln!(
+            "  - Floor respected: yes (floor={})",
+            config.preserve_recent_messages_floor
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Test 4: API validity — no orphaned tool_result blocks
+    // ------------------------------------------------------------------
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn qa_no_orphaned_tool_results() {
+        // Helper to verify no orphaned tool_results in a compacted session
+        fn verify_no_orphans(session: &Session, label: &str) {
+            let messages = &session.messages;
+            for (idx, msg) in messages.iter().enumerate() {
+                for block in &msg.blocks {
+                    if let ContentBlock::ToolResult { tool_use_id, .. } = block {
+                        let has_matching_use = messages.iter().any(|m| {
+                            m.blocks.iter().any(|b| {
+                                matches!(b, ContentBlock::ToolUse { id, .. } if id == tool_use_id)
+                            })
+                        });
+                        assert!(
+                            has_matching_use,
+                            "[{label}] orphaned tool_result at msg index {idx}, tool_use_id={tool_use_id}"
+                        );
+                    }
+                }
+            }
+        }
+
+        // Build a session with multiple tool_use/tool_result pairs at various positions
+        let text = "content ".repeat(200);
+        let session = Session {
+            version: 1,
+            model: None,
+            title: None,
+            messages: vec![
+                ConversationMessage::user_text("Start crawling"),
+                ConversationMessage::assistant(vec![ContentBlock::ToolUse {
+                    id: "t1".to_string(),
+                    name: "navigate".to_string(),
+                    input: "{}".to_string(),
+                }]),
+                ConversationMessage::tool_result("t1", "navigate", &text, false),
+                ConversationMessage::assistant(vec![
+                    ContentBlock::Text {
+                        text: "Found page.".to_string(),
+                    },
+                    ContentBlock::ToolUse {
+                        id: "t2".to_string(),
+                        name: "click".to_string(),
+                        input: r#"{"selector":".next"}"#.to_string(),
+                    },
+                ]),
+                ConversationMessage::tool_result("t2", "click", "clicked next", false),
+                ConversationMessage::assistant(vec![ContentBlock::ToolUse {
+                    id: "t3".to_string(),
+                    name: "navigate".to_string(),
+                    input: "{}".to_string(),
+                }]),
+                ConversationMessage::tool_result("t3", "navigate", &text, false),
+                ConversationMessage::assistant(vec![ContentBlock::ToolUse {
+                    id: "t4".to_string(),
+                    name: "read_content".to_string(),
+                    input: "{}".to_string(),
+                }]),
+                ConversationMessage::tool_result("t4", "read_content", "extracted data", false),
+                ConversationMessage::assistant(vec![ContentBlock::ToolUse {
+                    id: "t5".to_string(),
+                    name: "navigate".to_string(),
+                    input: "{}".to_string(),
+                }]),
+                ConversationMessage::tool_result("t5", "navigate", &text, false),
+                ConversationMessage::assistant(vec![ContentBlock::Text {
+                    text: "All extracted.".to_string(),
+                }]),
+            ],
+        };
+
+        // Config 1: small preservation window
+        let config1 = CompactionConfig {
+            preserve_recent_messages: 0,
+            preserve_recent_messages_floor: 2,
+            preserve_recent_tokens: 500,
+            max_estimated_tokens: 1,
+            prune_protect_tokens: 40_000,
+            prune_max_output_chars: 2_000,
+            max_summary_chars: 1_200,
+            llm_summarization: false,
+        };
+        let result1 = compact_session(&session, config1);
+        verify_no_orphans(&result1.compacted_session, "config1-small-window");
+
+        // Config 2: preserve exactly 4 messages (legacy mode)
+        let config2 = CompactionConfig {
+            preserve_recent_messages: 4,
+            preserve_recent_messages_floor: 2,
+            max_estimated_tokens: 1,
+            ..CompactionConfig::default()
+        };
+        let result2 = compact_session(&session, config2);
+        verify_no_orphans(&result2.compacted_session, "config2-legacy-4");
+
+        // Config 3: preserve 6 messages
+        let config3 = CompactionConfig {
+            preserve_recent_messages: 6,
+            preserve_recent_messages_floor: 2,
+            max_estimated_tokens: 1,
+            ..CompactionConfig::default()
+        };
+        let result3 = compact_session(&session, config3);
+        verify_no_orphans(&result3.compacted_session, "config3-legacy-6");
+
+        // Config 4: very tight budget (floor only)
+        let config4 = CompactionConfig {
+            preserve_recent_messages: 0,
+            preserve_recent_messages_floor: 1,
+            preserve_recent_tokens: 1,
+            max_estimated_tokens: 1,
+            prune_protect_tokens: 40_000,
+            prune_max_output_chars: 2_000,
+            max_summary_chars: 1_200,
+            llm_summarization: false,
+        };
+        let result4 = compact_session(&session, config4);
+        verify_no_orphans(&result4.compacted_session, "config4-floor-only");
+
+        // Config 5: generous window
+        let config5 = CompactionConfig {
+            preserve_recent_messages: 0,
+            preserve_recent_messages_floor: 2,
+            preserve_recent_tokens: 10_000,
+            max_estimated_tokens: 1,
+            prune_protect_tokens: 40_000,
+            prune_max_output_chars: 2_000,
+            max_summary_chars: 1_200,
+            llm_summarization: false,
+        };
+        let result5 = compact_session(&session, config5);
+        verify_no_orphans(&result5.compacted_session, "config5-generous");
+
+        // Count how many configs actually did compaction
+        let compaction_count = [&result1, &result2, &result3, &result4, &result5]
+            .iter()
+            .filter(|r| r.removed_message_count > 0)
+            .count();
+
+        eprintln!("Test 4 - API validity: PASS");
+        eprintln!("  - No orphaned tool_results: yes (tested 5 configurations)");
+        eprintln!("  - Compaction rounds tested: {compaction_count}");
+    }
 }

--- a/crates/runtime/src/compact.rs
+++ b/crates/runtime/src/compact.rs
@@ -6,20 +6,37 @@ const COMPACT_RECENT_MESSAGES_NOTE: &str = "Recent messages are preserved verbat
 const COMPACT_DIRECT_RESUME_INSTRUCTION: &str =
     "Continue the conversation from where it left off without asking the user any further questions. Resume directly — do not acknowledge the summary, do not recap what was happening, and do not preface with continuation text.";
 
-const PRUNE_PROTECT_TOKENS: usize = 40_000;
-const PRUNE_MAX_OUTPUT_CHARS: usize = 2_000;
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CompactionConfig {
-    pub preserve_recent_messages: usize,
+    /// Minimum number of messages always preserved.
+    pub preserve_recent_messages_floor: usize,
+    /// Token budget for the preserved tail.
+    pub preserve_recent_tokens: usize,
+    /// Token threshold that triggers compaction.
     pub max_estimated_tokens: usize,
+    /// Legacy floor retained for backward compatibility.
+    pub preserve_recent_messages: usize,
+    /// Token window protecting recent messages from pruning, default `40_000`
+    pub prune_protect_tokens: usize,
+    /// Max chars for tool output after truncation, default `2_000`
+    pub prune_max_output_chars: usize,
+    /// Max chars for the compacted summary, default `1_200`
+    pub max_summary_chars: usize,
+    /// If true, use LLM for summarization (opt-in, default false)
+    pub llm_summarization: bool,
 }
 
 impl Default for CompactionConfig {
     fn default() -> Self {
         Self {
-            preserve_recent_messages: 4,
+            preserve_recent_messages_floor: 2,
+            preserve_recent_tokens: 80_000,
             max_estimated_tokens: 10_000,
+            preserve_recent_messages: 4,
+            prune_protect_tokens: 40_000,
+            prune_max_output_chars: 2_000,
+            max_summary_chars: 1_200,
+            llm_summarization: false,
         }
     }
 }
@@ -39,8 +56,24 @@ pub fn estimate_session_tokens(session: &Session) -> usize {
 
 #[must_use]
 pub fn should_compact(session: &Session, config: CompactionConfig) -> bool {
-    session.messages.len() > config.preserve_recent_messages
-        && estimate_session_tokens(session) >= config.max_estimated_tokens
+    let start = usize::from(
+        session
+            .messages
+            .first()
+            .and_then(extract_existing_compacted_summary)
+            .is_some(),
+    );
+    let compactable = &session.messages[start..];
+    let effective_floor = config
+        .preserve_recent_messages
+        .max(config.preserve_recent_messages_floor);
+
+    compactable.len() > effective_floor
+        && compactable
+            .iter()
+            .map(estimate_message_tokens)
+            .sum::<usize>()
+            >= config.max_estimated_tokens
 }
 
 #[must_use]
@@ -94,22 +127,89 @@ pub fn compact_session(session: &Session, config: CompactionConfig) -> Compactio
     }
 
     let mut working_messages = session.messages.clone();
-    prune_tool_outputs(&mut working_messages);
+    prune_tool_outputs(
+        &mut working_messages,
+        config.prune_protect_tokens,
+        config.prune_max_output_chars,
+    );
 
-    let mut keep_from = working_messages
-        .len()
-        .saturating_sub(config.preserve_recent_messages);
+    // Detect existing compacted summary prefix to exclude from removed messages
+    let existing_summary = working_messages
+        .first()
+        .and_then(extract_existing_compacted_summary);
+    let compacted_prefix_len = usize::from(existing_summary.is_some());
 
-    // Never split a tool_use/tool_result pair. If the preserved window starts
-    // with a Tool message (containing tool_result blocks), walk backwards to
-    // include the preceding Assistant message that holds the matching tool_use.
-    while keep_from > 0 && working_messages[keep_from].role == MessageRole::Tool {
-        keep_from -= 1;
+    let effective_floor = config
+        .preserve_recent_messages
+        .max(config.preserve_recent_messages_floor);
+    let legacy_count_override = config.preserve_recent_tokens
+        == CompactionConfig::default().preserve_recent_tokens
+        && config.preserve_recent_messages > 0;
+
+    // Walk backward from the end accumulating token estimates until budget exhausted.
+    // This determines how many recent messages to preserve (token-budget tail).
+    let keep_from = {
+        let total = working_messages.len();
+        let mut budget_remaining = config.preserve_recent_tokens;
+        let mut keep = total;
+
+        for i in (compacted_prefix_len..total).rev() {
+            let msg_tokens = estimate_message_tokens(&working_messages[i]);
+            if budget_remaining >= msg_tokens {
+                budget_remaining -= msg_tokens;
+                keep = i;
+            } else {
+                break;
+            }
+        }
+
+        let floor_keep = total.saturating_sub(effective_floor);
+        let mut k = if legacy_count_override {
+            total.saturating_sub(config.preserve_recent_messages)
+        } else {
+            keep.min(floor_keep)
+        };
+        k = k.max(compacted_prefix_len);
+
+        while k > compacted_prefix_len && k < total && working_messages[k].role == MessageRole::Tool
+        {
+            k -= 1;
+        }
+
+        k
+    };
+
+    if keep_from == compacted_prefix_len {
+        return CompactionResult {
+            summary: String::new(),
+            formatted_summary: String::new(),
+            compacted_session: session.clone(),
+            removed_message_count: 0,
+        };
     }
 
-    let removed = &working_messages[..keep_from];
+    // Skip the existing summary prefix when collecting removed messages
+    let removed = &working_messages[compacted_prefix_len..keep_from];
     let preserved = working_messages[keep_from..].to_vec();
-    let summary = summarize_messages(removed);
+    let raw_summary = summarize_messages(removed);
+    let summary = merge_compact_summaries(existing_summary.as_deref(), &raw_summary);
+    // Apply compression to cap the merged summary at max_summary_chars
+    let summary = if config.max_summary_chars > 0 {
+        use crate::summary_compression::{compress_summary, SummaryCompressionBudget};
+        let formatted = format_compact_summary(&summary);
+        let compressed = compress_summary(
+            &formatted,
+            SummaryCompressionBudget {
+                max_chars: config.max_summary_chars,
+                max_lines: usize::MAX,
+                max_line_chars: 160,
+            },
+        );
+        // Wrap compressed text back in summary tags for get_compact_continuation_message
+        format!("<summary>{}</summary>", compressed.summary)
+    } else {
+        summary
+    };
     let formatted_summary = format_compact_summary(&summary);
     let continuation = get_compact_continuation_message(&summary, true, !preserved.is_empty());
 
@@ -401,7 +501,6 @@ fn collapse_blank_lines(content: &str) -> String {
     result
 }
 
-#[allow(dead_code)]
 fn extract_existing_compacted_summary(message: &ConversationMessage) -> Option<String> {
     if message.role != MessageRole::System {
         return None;
@@ -429,20 +528,98 @@ fn compacted_summary_prefix_len(session: &Session) -> usize {
     )
 }
 
-fn prune_tool_outputs(messages: &mut [ConversationMessage]) {
+fn extract_summary_highlights(summary: &str) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut in_timeline = false;
+
+    for line in format_compact_summary(summary).lines() {
+        let trimmed = line.trim_end();
+        if trimmed.is_empty() || trimmed == "Summary:" || trimmed == "Conversation summary:" {
+            continue;
+        }
+        if trimmed == "- Key timeline:" {
+            in_timeline = true;
+            continue;
+        }
+        if in_timeline {
+            continue;
+        }
+        lines.push(trimmed.to_string());
+    }
+
+    lines
+}
+
+fn extract_summary_timeline(summary: &str) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut in_timeline = false;
+
+    for line in format_compact_summary(summary).lines() {
+        let trimmed = line.trim_end();
+        if trimmed == "- Key timeline:" {
+            in_timeline = true;
+            continue;
+        }
+        if in_timeline && !trimmed.is_empty() {
+            lines.push(trimmed.to_string());
+        }
+    }
+
+    lines
+}
+
+fn merge_compact_summaries(existing_summary: Option<&str>, new_summary: &str) -> String {
+    let Some(existing_summary) = existing_summary else {
+        return new_summary.to_string();
+    };
+
+    let previous_highlights = extract_summary_highlights(existing_summary);
+    let new_formatted_summary = format_compact_summary(new_summary);
+    let new_highlights = extract_summary_highlights(&new_formatted_summary);
+    let new_timeline = extract_summary_timeline(&new_formatted_summary);
+
+    let mut lines = vec!["<summary>".to_string(), "Conversation summary:".to_string()];
+
+    if !previous_highlights.is_empty() {
+        lines.push("- Previously compacted context:".to_string());
+        lines.extend(
+            previous_highlights
+                .into_iter()
+                .map(|line| format!("  {line}")),
+        );
+    }
+
+    if !new_highlights.is_empty() {
+        lines.push("- Newly compacted context:".to_string());
+        lines.extend(new_highlights.into_iter().map(|line| format!("  {line}")));
+    }
+
+    if !new_timeline.is_empty() {
+        lines.push("- Key timeline:".to_string());
+        lines.extend(new_timeline.into_iter().map(|line| format!("  {line}")));
+    }
+
+    lines.push("</summary>".to_string());
+    lines.join("\n")
+}
+
+fn prune_tool_outputs(
+    messages: &mut [ConversationMessage],
+    prune_protect_tokens: usize,
+    prune_max_output_chars: usize,
+) {
     let mut cumulative_tokens: usize = 0;
     for msg in messages.iter_mut().rev() {
-        if cumulative_tokens >= PRUNE_PROTECT_TOKENS {
+        if cumulative_tokens >= prune_protect_tokens {
             // Outside the protected window — truncate large ToolResult outputs
             for block in &mut msg.blocks {
                 if let ContentBlock::ToolResult { output, .. } = block {
                     let char_count = output.chars().count();
-                    if char_count > PRUNE_MAX_OUTPUT_CHARS {
+                    if char_count > prune_max_output_chars {
                         let truncated: String =
-                            output.chars().take(PRUNE_MAX_OUTPUT_CHARS).collect();
-                        *output = format!(
-                            "{truncated}\n\n[… output truncated from {char_count} chars]"
-                        );
+                            output.chars().take(prune_max_output_chars).collect();
+                        *output =
+                            format!("{truncated}\n\n[… output truncated from {char_count} chars]");
                     }
                 }
             }
@@ -508,6 +685,7 @@ mod tests {
             CompactionConfig {
                 preserve_recent_messages: 2,
                 max_estimated_tokens: 1,
+                ..CompactionConfig::default()
             },
         );
 
@@ -527,6 +705,7 @@ mod tests {
             CompactionConfig {
                 preserve_recent_messages: 2,
                 max_estimated_tokens: 1,
+                ..CompactionConfig::default()
             }
         ));
         assert!(
@@ -595,6 +774,7 @@ mod tests {
             CompactionConfig {
                 preserve_recent_messages: 3,
                 max_estimated_tokens: 1,
+                ..CompactionConfig::default()
             },
         );
 
@@ -605,10 +785,12 @@ mod tests {
             for block in &message.blocks {
                 if let ContentBlock::ToolResult { tool_use_id, .. } = block {
                     let has_matching_use = preserved.iter().any(|m| {
-                        m.blocks.iter().any(|b| matches!(
-                            b,
-                            ContentBlock::ToolUse { id, .. } if id == tool_use_id
-                        ))
+                        m.blocks.iter().any(|b| {
+                            matches!(
+                                b,
+                                ContentBlock::ToolUse { id, .. } if id == tool_use_id
+                            )
+                        })
                     });
                     assert!(
                         has_matching_use,
@@ -644,24 +826,34 @@ mod tests {
             CompactionConfig {
                 preserve_recent_messages: 2,
                 max_estimated_tokens: 1,
+                ..CompactionConfig::default()
             },
         );
 
         let preserved = &result.compacted_session.messages;
-        assert_ne!(preserved[1].role, MessageRole::Tool,
-            "preserved window must not start with a Tool message");
+        assert_ne!(
+            preserved[1].role,
+            MessageRole::Tool,
+            "preserved window must not start with a Tool message"
+        );
 
         let has_tool_use = preserved.iter().any(|m| {
-            m.blocks.iter().any(|b| matches!(b, ContentBlock::ToolUse { id, .. } if id == "call_1"))
+            m.blocks
+                .iter()
+                .any(|b| matches!(b, ContentBlock::ToolUse { id, .. } if id == "call_1"))
         });
         let has_tool_result = preserved.iter().any(|m| {
-            m.blocks.iter().any(|b| matches!(
-                b,
-                ContentBlock::ToolResult { tool_use_id, .. } if tool_use_id == "call_1"
-            ))
+            m.blocks.iter().any(|b| {
+                matches!(
+                    b,
+                    ContentBlock::ToolResult { tool_use_id, .. } if tool_use_id == "call_1"
+                )
+            })
         });
-        assert_eq!(has_tool_use, has_tool_result,
-            "tool_use and tool_result for call_1 must both be present or both absent");
+        assert_eq!(
+            has_tool_use, has_tool_result,
+            "tool_use and tool_result for call_1 must both be present or both absent"
+        );
     }
 
     #[test]
@@ -717,7 +909,7 @@ mod tests {
             text: "done".to_string(),
         }]));
 
-        super::prune_tool_outputs(&mut messages);
+        super::prune_tool_outputs(&mut messages, 40_000, 2_000);
 
         let block = &messages[2].blocks[0];
         if let ContentBlock::ToolResult { output, .. } = block {
@@ -747,7 +939,7 @@ mod tests {
             ConversationMessage::tool_result("call_1", "navigate", small_output, false),
         ];
 
-        super::prune_tool_outputs(&mut messages);
+        super::prune_tool_outputs(&mut messages, 40_000, 2_000);
 
         let block = &messages[2].blocks[0];
         if let ContentBlock::ToolResult { output, .. } = block {
@@ -764,7 +956,7 @@ mod tests {
             .map(|i| {
                 if i % 3 == 2 {
                     ConversationMessage::tool_result(
-                        &format!("call_{i}"),
+                        format!("call_{i}"),
                         "navigate",
                         &large_output,
                         false,
@@ -781,7 +973,7 @@ mod tests {
             })
             .collect();
 
-        super::prune_tool_outputs(&mut messages);
+        super::prune_tool_outputs(&mut messages, 40_000, 2_000);
 
         let last_tool_result = messages
             .iter()
@@ -812,7 +1004,7 @@ mod tests {
             }]),
         ];
 
-        super::prune_tool_outputs(&mut messages);
+        super::prune_tool_outputs(&mut messages, 40_000, 2_000);
 
         if let ContentBlock::Text { text } = &messages[0].blocks[0] {
             assert_eq!(text.chars().count(), 10_000);
@@ -820,5 +1012,314 @@ mod tests {
         if let ContentBlock::Text { text } = &messages[1].blocks[0] {
             assert_eq!(text.chars().count(), 10_000);
         }
+    }
+
+    #[test]
+    fn merge_summaries_first_compaction_returns_unchanged() {
+        let summary = "<summary>Conversation summary:\n- Scope: 4 messages.</summary>";
+        let result = super::merge_compact_summaries(None, summary);
+        assert_eq!(result, summary);
+    }
+
+    #[test]
+    fn merge_summaries_second_compaction_contains_both_sections() {
+        let first_summary = "<summary>Conversation summary:\n- Scope: 4 messages.\n- Current work: task A.</summary>";
+        let second_summary = "<summary>Conversation summary:\n- Scope: 3 messages.\n- Current work: task B.</summary>";
+        let merged = super::merge_compact_summaries(Some(first_summary), second_summary);
+        assert!(
+            merged.contains("Previously compacted context:"),
+            "merged summary must have prior context section"
+        );
+        assert!(
+            merged.contains("Newly compacted context:"),
+            "merged summary must have new context section"
+        );
+    }
+
+    #[test]
+    fn compact_session_second_compaction_merges_summary() {
+        let large_text = "word ".repeat(400);
+        let session = Session {
+            version: 1,
+            model: None,
+            title: None,
+            messages: vec![
+                ConversationMessage::user_text(&large_text),
+                ConversationMessage::assistant(vec![ContentBlock::Text {
+                    text: large_text.clone(),
+                }]),
+                ConversationMessage::user_text(&large_text),
+                ConversationMessage::assistant(vec![ContentBlock::Text {
+                    text: "done".to_string(),
+                }]),
+            ],
+        };
+
+        let config = CompactionConfig {
+            preserve_recent_messages: 2,
+            max_estimated_tokens: 1,
+            ..CompactionConfig::default()
+        };
+
+        let result1 = compact_session(&session, config);
+        assert!(result1.removed_message_count > 0);
+
+        let mut session2 = result1.compacted_session.clone();
+        session2
+            .messages
+            .push(ConversationMessage::user_text(&large_text));
+        session2
+            .messages
+            .push(ConversationMessage::assistant(vec![ContentBlock::Text {
+                text: "more work".to_string(),
+            }]));
+
+        let result2 = compact_session(&session2, config);
+        assert!(result2.removed_message_count > 0);
+        let has_previously = result2
+            .formatted_summary
+            .contains("Previously compacted context:");
+        let has_newly = result2
+            .formatted_summary
+            .contains("Newly compacted context:");
+        assert!(
+            has_previously || has_newly,
+            "second compaction should produce merged summary"
+        );
+    }
+
+    #[test]
+    fn compact_session_with_existing_prefix_does_not_summarize_it() {
+        let large_text = "word ".repeat(400);
+        let session = Session {
+            version: 1,
+            model: None,
+            title: None,
+            messages: vec![
+                ConversationMessage::user_text(&large_text),
+                ConversationMessage::assistant(vec![ContentBlock::Text {
+                    text: large_text.clone(),
+                }]),
+                ConversationMessage::user_text(&large_text),
+                ConversationMessage::assistant(vec![ContentBlock::Text {
+                    text: "done".to_string(),
+                }]),
+            ],
+        };
+
+        let config = CompactionConfig {
+            preserve_recent_messages: 2,
+            max_estimated_tokens: 1,
+            ..CompactionConfig::default()
+        };
+
+        let result1 = compact_session(&session, config);
+        let mut compacted = result1.compacted_session;
+
+        compacted
+            .messages
+            .push(ConversationMessage::user_text(&large_text));
+        compacted
+            .messages
+            .push(ConversationMessage::assistant(vec![ContentBlock::Text {
+                text: "more".to_string(),
+            }]));
+
+        let result2 = compact_session(&compacted, config);
+        let non_prefix_msgs = compacted.messages.len() - 1;
+        assert!(
+            result2.removed_message_count < non_prefix_msgs,
+            "some messages should be preserved"
+        );
+    }
+
+    #[test]
+    fn token_budget_tail_preserves_by_budget_not_count() {
+        let small = "a ".repeat(200);
+        let large = "b ".repeat(1200);
+        let session = Session {
+            version: 1,
+            model: None,
+            title: None,
+            messages: vec![
+                ConversationMessage::user_text(&small),
+                ConversationMessage::assistant(vec![ContentBlock::Text {
+                    text: small.clone(),
+                }]),
+                ConversationMessage::user_text(&small),
+                ConversationMessage::assistant(vec![ContentBlock::Text {
+                    text: large.clone(),
+                }]),
+                ConversationMessage::user_text(&large),
+            ],
+        };
+
+        let config = CompactionConfig {
+            preserve_recent_messages: 0,
+            preserve_recent_messages_floor: 1,
+            preserve_recent_tokens: 350,
+            max_estimated_tokens: 1,
+            ..CompactionConfig::default()
+        };
+
+        let result = compact_session(&session, config);
+        assert!(
+            result.removed_message_count > 0,
+            "some messages should be summarized"
+        );
+        let preserved_count = result.compacted_session.messages.len() - 1;
+        assert!(
+            preserved_count >= 1,
+            "at least the floor should be preserved"
+        );
+    }
+
+    #[test]
+    fn token_budget_floor_prevents_zero_preservation() {
+        let large = "c ".repeat(60_000);
+        let session = Session {
+            version: 1,
+            model: None,
+            title: None,
+            messages: vec![
+                ConversationMessage::user_text(&large),
+                ConversationMessage::assistant(vec![ContentBlock::Text {
+                    text: large.clone(),
+                }]),
+                ConversationMessage::user_text(&large),
+                ConversationMessage::assistant(vec![ContentBlock::Text {
+                    text: large.clone(),
+                }]),
+                ConversationMessage::user_text(&large),
+            ],
+        };
+
+        let config = CompactionConfig {
+            preserve_recent_messages: 0,
+            preserve_recent_messages_floor: 2,
+            preserve_recent_tokens: 1,
+            max_estimated_tokens: 1,
+            ..CompactionConfig::default()
+        };
+
+        let result = compact_session(&session, config);
+        let preserved_count = result.compacted_session.messages.len() - 1;
+        assert!(
+            preserved_count >= 2,
+            "floor of 2 messages must be preserved even with tiny budget, got {preserved_count}"
+        );
+    }
+
+    #[test]
+    fn token_budget_infinite_budget_preserves_all() {
+        let text = "word ".repeat(50);
+        let session = Session {
+            version: 1,
+            model: None,
+            title: None,
+            messages: vec![
+                ConversationMessage::user_text(&text),
+                ConversationMessage::assistant(vec![ContentBlock::Text { text: text.clone() }]),
+                ConversationMessage::user_text(&text),
+                ConversationMessage::assistant(vec![ContentBlock::Text { text: text.clone() }]),
+            ],
+        };
+
+        let config = CompactionConfig {
+            preserve_recent_messages: 0,
+            preserve_recent_messages_floor: 1,
+            preserve_recent_tokens: usize::MAX,
+            max_estimated_tokens: 1,
+            ..CompactionConfig::default()
+        };
+
+        let result = compact_session(&session, config);
+        assert_eq!(
+            result.removed_message_count, 0,
+            "infinite budget should preserve all messages (no compaction)"
+        );
+        assert_eq!(result.compacted_session, session);
+    }
+
+    #[test]
+    fn tool_boundary_fix_still_works_with_budget_tail() {
+        let text = "word ".repeat(200);
+        let session = Session {
+            version: 1,
+            model: None,
+            title: None,
+            messages: vec![
+                ConversationMessage::user_text(&text),
+                ConversationMessage::assistant(vec![ContentBlock::ToolUse {
+                    id: "call_1".to_string(),
+                    name: "navigate".to_string(),
+                    input: "{}".to_string(),
+                }]),
+                ConversationMessage::tool_result("call_1", "navigate", "page content", false),
+                ConversationMessage::assistant(vec![ContentBlock::Text {
+                    text: "done".to_string(),
+                }]),
+            ],
+        };
+
+        let config = CompactionConfig {
+            preserve_recent_messages: 0,
+            preserve_recent_messages_floor: 2,
+            preserve_recent_tokens: 100,
+            max_estimated_tokens: 1,
+            ..CompactionConfig::default()
+        };
+
+        let result = compact_session(&session, config);
+        let preserved = &result.compacted_session.messages;
+
+        for msg in &preserved[1..] {
+            for block in &msg.blocks {
+                if let ContentBlock::ToolResult { tool_use_id, .. } = block {
+                    let has_matching_use = preserved.iter().any(|m| {
+                        m.blocks.iter().any(
+                            |b| matches!(b, ContentBlock::ToolUse { id, .. } if id == tool_use_id),
+                        )
+                    });
+                    assert!(
+                        has_matching_use,
+                        "orphaned tool_result with id={tool_use_id}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn backward_compat_preserve_recent_messages_still_works() {
+        let text = "word ".repeat(200);
+        let session = Session {
+            version: 1,
+            model: None,
+            title: None,
+            messages: vec![
+                ConversationMessage::user_text(&text),
+                ConversationMessage::assistant(vec![ContentBlock::Text { text: text.clone() }]),
+                ConversationMessage::user_text(&text),
+                ConversationMessage::assistant(vec![ContentBlock::Text {
+                    text: "recent".to_string(),
+                }]),
+            ],
+        };
+
+        let result = compact_session(
+            &session,
+            CompactionConfig {
+                preserve_recent_messages: 2,
+                max_estimated_tokens: 1,
+                ..CompactionConfig::default()
+            },
+        );
+
+        assert_eq!(
+            result.removed_message_count, 2,
+            "should remove 2 old messages"
+        );
+        assert_eq!(result.compacted_session.messages.len(), 3);
     }
 }

--- a/crates/runtime/src/compact.rs
+++ b/crates/runtime/src/compact.rs
@@ -1,5 +1,14 @@
 use crate::session::{ContentBlock, ConversationMessage, MessageRole, Session};
 
+const COMPACT_CONTINUATION_PREAMBLE: &str =
+    "This session is being continued from a previous conversation that ran out of context. The summary below covers the earlier portion of the conversation.\n\n";
+const COMPACT_RECENT_MESSAGES_NOTE: &str = "Recent messages are preserved verbatim.";
+const COMPACT_DIRECT_RESUME_INSTRUCTION: &str =
+    "Continue the conversation from where it left off without asking the user any further questions. Resume directly — do not acknowledge the summary, do not recap what was happening, and do not preface with continuation text.";
+
+const PRUNE_PROTECT_TOKENS: usize = 40_000;
+const PRUNE_MAX_OUTPUT_CHARS: usize = 2_000;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CompactionConfig {
     pub preserve_recent_messages: usize,
@@ -56,16 +65,18 @@ pub fn get_compact_continuation_message(
     recent_messages_preserved: bool,
 ) -> String {
     let mut base = format!(
-        "This session is being continued from a previous conversation that ran out of context. The summary below covers the earlier portion of the conversation.\n\n{}",
+        "{COMPACT_CONTINUATION_PREAMBLE}{}",
         format_compact_summary(summary)
     );
 
     if recent_messages_preserved {
-        base.push_str("\n\nRecent messages are preserved verbatim.");
+        base.push_str("\n\n");
+        base.push_str(COMPACT_RECENT_MESSAGES_NOTE);
     }
 
     if suppress_follow_up_questions {
-        base.push_str("\nContinue the conversation from where it left off without asking the user any further questions. Resume directly — do not acknowledge the summary, do not recap what was happening, and do not preface with continuation text.");
+        base.push('\n');
+        base.push_str(COMPACT_DIRECT_RESUME_INSTRUCTION);
     }
 
     base
@@ -82,20 +93,22 @@ pub fn compact_session(session: &Session, config: CompactionConfig) -> Compactio
         };
     }
 
-    let mut keep_from = session
-        .messages
+    let mut working_messages = session.messages.clone();
+    prune_tool_outputs(&mut working_messages);
+
+    let mut keep_from = working_messages
         .len()
         .saturating_sub(config.preserve_recent_messages);
 
     // Never split a tool_use/tool_result pair. If the preserved window starts
     // with a Tool message (containing tool_result blocks), walk backwards to
     // include the preceding Assistant message that holds the matching tool_use.
-    while keep_from > 0 && session.messages[keep_from].role == MessageRole::Tool {
+    while keep_from > 0 && working_messages[keep_from].role == MessageRole::Tool {
         keep_from -= 1;
     }
 
-    let removed = &session.messages[..keep_from];
-    let preserved = session.messages[keep_from..].to_vec();
+    let removed = &working_messages[..keep_from];
+    let preserved = working_messages[keep_from..].to_vec();
     let summary = summarize_messages(removed);
     let formatted_summary = format_compact_summary(&summary);
     let continuation = get_compact_continuation_message(&summary, true, !preserved.is_empty());
@@ -388,11 +401,61 @@ fn collapse_blank_lines(content: &str) -> String {
     result
 }
 
+#[allow(dead_code)]
+fn extract_existing_compacted_summary(message: &ConversationMessage) -> Option<String> {
+    if message.role != MessageRole::System {
+        return None;
+    }
+
+    let text = first_text_block(message)?;
+    let summary = text.strip_prefix(COMPACT_CONTINUATION_PREAMBLE)?;
+    let summary = summary
+        .split_once(&format!("\n\n{COMPACT_RECENT_MESSAGES_NOTE}"))
+        .map_or(summary, |(value, _)| value);
+    let summary = summary
+        .split_once(&format!("\n{COMPACT_DIRECT_RESUME_INSTRUCTION}"))
+        .map_or(summary, |(value, _)| value);
+    Some(summary.trim().to_string())
+}
+
+#[allow(dead_code)]
+fn compacted_summary_prefix_len(session: &Session) -> usize {
+    usize::from(
+        session
+            .messages
+            .first()
+            .and_then(extract_existing_compacted_summary)
+            .is_some(),
+    )
+}
+
+fn prune_tool_outputs(messages: &mut [ConversationMessage]) {
+    let mut cumulative_tokens: usize = 0;
+    for msg in messages.iter_mut().rev() {
+        if cumulative_tokens >= PRUNE_PROTECT_TOKENS {
+            // Outside the protected window — truncate large ToolResult outputs
+            for block in &mut msg.blocks {
+                if let ContentBlock::ToolResult { output, .. } = block {
+                    let char_count = output.chars().count();
+                    if char_count > PRUNE_MAX_OUTPUT_CHARS {
+                        let truncated: String =
+                            output.chars().take(PRUNE_MAX_OUTPUT_CHARS).collect();
+                        *output = format!(
+                            "{truncated}\n\n[… output truncated from {char_count} chars]"
+                        );
+                    }
+                }
+            }
+        }
+        cumulative_tokens = cumulative_tokens.saturating_add(estimate_message_tokens(msg));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         collect_key_files, compact_session, estimate_session_tokens, format_compact_summary,
-        infer_pending_work, should_compact, CompactionConfig,
+        get_compact_continuation_message, infer_pending_work, should_compact, CompactionConfig,
     };
     use crate::session::{ContentBlock, ConversationMessage, MessageRole, Session};
 
@@ -599,5 +662,163 @@ mod tests {
         });
         assert_eq!(has_tool_use, has_tool_result,
             "tool_use and tool_result for call_1 must both be present or both absent");
+    }
+
+    #[test]
+    fn prefix_detection_finds_compacted_summary() {
+        let summary = "<summary>Scope: 5 messages compacted.</summary>";
+        let continuation = get_compact_continuation_message(summary, true, true);
+        let msg = ConversationMessage {
+            role: MessageRole::System,
+            blocks: vec![ContentBlock::Text { text: continuation }],
+            usage: None,
+        };
+        let result = super::extract_existing_compacted_summary(&msg);
+        assert!(result.is_some());
+        assert!(result.unwrap().contains("Scope:"));
+    }
+
+    #[test]
+    fn prefix_detection_returns_none_for_user_message() {
+        let msg = ConversationMessage::user_text("hello");
+        assert!(super::extract_existing_compacted_summary(&msg).is_none());
+    }
+
+    #[test]
+    fn prefix_detection_returns_none_for_empty_session() {
+        let session = Session {
+            version: 1,
+            model: None,
+            title: None,
+            messages: vec![],
+        };
+        assert_eq!(super::compacted_summary_prefix_len(&session), 0);
+    }
+
+    #[test]
+    fn prune_tool_outputs_truncates_large_old_outputs() {
+        let large_output = "x".repeat(10_000);
+        // Need enough content after the large output to push it outside the 40K token window.
+        // 40K tokens ≈ 160K chars. Use 42 messages of 4000 chars each (~42K tokens).
+        let padding = "p".repeat(4_000);
+        let mut messages = vec![
+            ConversationMessage::user_text("start"),
+            ConversationMessage::assistant(vec![ContentBlock::ToolUse {
+                id: "call_1".to_string(),
+                name: "navigate".to_string(),
+                input: "{}".to_string(),
+            }]),
+            ConversationMessage::tool_result("call_1", "navigate", &large_output, false),
+        ];
+        for _ in 0..42 {
+            messages.push(ConversationMessage::user_text(&padding));
+        }
+        messages.push(ConversationMessage::assistant(vec![ContentBlock::Text {
+            text: "done".to_string(),
+        }]));
+
+        super::prune_tool_outputs(&mut messages);
+
+        let block = &messages[2].blocks[0];
+        if let ContentBlock::ToolResult { output, .. } = block {
+            assert!(
+                output.contains("[… output truncated from 10000 chars]"),
+                "large old output should be truncated"
+            );
+            assert!(
+                output.chars().count() < 10_000,
+                "truncated output should be shorter than original"
+            );
+        } else {
+            panic!("Expected ToolResult block");
+        }
+    }
+
+    #[test]
+    fn prune_tool_outputs_small_outputs_unchanged() {
+        let small_output = "small content";
+        let mut messages = vec![
+            ConversationMessage::user_text("start"),
+            ConversationMessage::assistant(vec![ContentBlock::ToolUse {
+                id: "call_1".to_string(),
+                name: "navigate".to_string(),
+                input: "{}".to_string(),
+            }]),
+            ConversationMessage::tool_result("call_1", "navigate", small_output, false),
+        ];
+
+        super::prune_tool_outputs(&mut messages);
+
+        let block = &messages[2].blocks[0];
+        if let ContentBlock::ToolResult { output, .. } = block {
+            assert_eq!(output, small_output);
+        } else {
+            panic!("Expected ToolResult block");
+        }
+    }
+
+    #[test]
+    fn prune_tool_outputs_recent_outputs_protected() {
+        let large_output = "z".repeat(10_000);
+        let mut messages: Vec<ConversationMessage> = (0..200)
+            .map(|i| {
+                if i % 3 == 2 {
+                    ConversationMessage::tool_result(
+                        &format!("call_{i}"),
+                        "navigate",
+                        &large_output,
+                        false,
+                    )
+                } else if i % 3 == 1 {
+                    ConversationMessage::assistant(vec![ContentBlock::ToolUse {
+                        id: format!("call_{i}"),
+                        name: "navigate".to_string(),
+                        input: "{}".to_string(),
+                    }])
+                } else {
+                    ConversationMessage::user_text("go")
+                }
+            })
+            .collect();
+
+        super::prune_tool_outputs(&mut messages);
+
+        let last_tool_result = messages
+            .iter()
+            .rev()
+            .find(|m| {
+                m.blocks
+                    .iter()
+                    .any(|b| matches!(b, ContentBlock::ToolResult { .. }))
+            })
+            .unwrap();
+
+        let block = &last_tool_result.blocks[0];
+        if let ContentBlock::ToolResult { output, .. } = block {
+            assert!(
+                !output.contains("[… output truncated"),
+                "recent output should not be truncated"
+            );
+        }
+    }
+
+    #[test]
+    fn prune_tool_outputs_non_tool_result_blocks_unchanged() {
+        let large_text = "a".repeat(10_000);
+        let mut messages = vec![
+            ConversationMessage::user_text(&large_text),
+            ConversationMessage::assistant(vec![ContentBlock::Text {
+                text: large_text.clone(),
+            }]),
+        ];
+
+        super::prune_tool_outputs(&mut messages);
+
+        if let ContentBlock::Text { text } = &messages[0].blocks[0] {
+            assert_eq!(text.chars().count(), 10_000);
+        }
+        if let ContentBlock::Text { text } = &messages[1].blocks[0] {
+            assert_eq!(text.chars().count(), 10_000);
+        }
     }
 }

--- a/crates/runtime/src/conversation.rs
+++ b/crates/runtime/src/conversation.rs
@@ -423,8 +423,12 @@ where
             prune_max_output_chars: crate::settings::settings_get_compaction_prune_max_output_chars(
                 &settings,
             ),
-            max_summary_chars: crate::settings::settings_get_compaction_max_summary_chars(&settings),
-            llm_summarization: crate::settings::settings_get_compaction_llm_summarization(&settings),
+            max_summary_chars: crate::settings::settings_get_compaction_max_summary_chars(
+                &settings,
+            ),
+            llm_summarization: crate::settings::settings_get_compaction_llm_summarization(
+                &settings,
+            ),
         };
 
         let mut result = compact_session(&self.session, config);
@@ -434,8 +438,8 @@ where
         }
 
         if config.llm_summarization {
-            let existing_prefix = usize::from(
-                self.session.messages.first().is_some_and(|message| {
+            let existing_prefix =
+                usize::from(self.session.messages.first().is_some_and(|message| {
                     message.role == crate::session::MessageRole::System
                         && message.blocks.iter().any(|block| matches!(
                             block,
@@ -444,10 +448,9 @@ where
                                     "This session is being continued from a previous conversation",
                                 )
                         ))
-                }),
-            );
-            let removed_end = (existing_prefix + result.removed_message_count)
-                .min(self.session.messages.len());
+                }));
+            let removed_end =
+                (existing_prefix + result.removed_message_count).min(self.session.messages.len());
             let removed_messages = &self.session.messages[existing_prefix..removed_end];
 
             if let Some(llm_summary) = try_llm_summarize(
@@ -948,7 +951,10 @@ mod tests {
 
         assert!(result.is_some(), "should return Some on success");
         let summary = result.expect("summary should exist");
-        assert!(summary.contains("<summary>"), "should be wrapped in summary tags");
+        assert!(
+            summary.contains("<summary>"),
+            "should be wrapped in summary tags"
+        );
         assert!(
             summary.contains("Goal") || summary.contains("goal"),
             "should contain structured output"
@@ -981,7 +987,10 @@ mod tests {
 
         let result = super::try_llm_summarize(&[], &mut client, None);
 
-        assert!(result.is_none(), "should return None when no messages to summarize");
+        assert!(
+            result.is_none(),
+            "should return None when no messages to summarize"
+        );
     }
 
     #[test]

--- a/crates/runtime/src/conversation.rs
+++ b/crates/runtime/src/conversation.rs
@@ -408,13 +408,26 @@ where
             return None;
         }
 
-        let result = compact_session(
-            &self.session,
-            CompactionConfig {
-                max_estimated_tokens: 0,
-                ..CompactionConfig::default()
-            },
-        );
+        let settings = crate::settings::load_settings();
+        let config = CompactionConfig {
+            max_estimated_tokens: 0,
+            preserve_recent_tokens: crate::settings::settings_get_compaction_preserve_recent_tokens(
+                &settings,
+            ),
+            preserve_recent_messages_floor:
+                crate::settings::settings_get_compaction_preserve_recent_messages_floor(&settings),
+            preserve_recent_messages: CompactionConfig::default().preserve_recent_messages,
+            prune_protect_tokens: crate::settings::settings_get_compaction_prune_protect_tokens(
+                &settings,
+            ),
+            prune_max_output_chars: crate::settings::settings_get_compaction_prune_max_output_chars(
+                &settings,
+            ),
+            max_summary_chars: crate::settings::settings_get_compaction_max_summary_chars(&settings),
+            llm_summarization: crate::settings::settings_get_compaction_llm_summarization(&settings),
+        };
+
+        let result = compact_session(&self.session, config);
 
         if result.removed_message_count == 0 {
             return None;
@@ -760,6 +773,7 @@ mod tests {
         let result = runtime.compact(CompactionConfig {
             preserve_recent_messages: 2,
             max_estimated_tokens: 1,
+            ..CompactionConfig::default()
         });
         assert!(result.summary.contains("Conversation summary"));
         assert_eq!(

--- a/crates/runtime/src/conversation.rs
+++ b/crates/runtime/src/conversation.rs
@@ -427,10 +427,43 @@ where
             llm_summarization: crate::settings::settings_get_compaction_llm_summarization(&settings),
         };
 
-        let result = compact_session(&self.session, config);
+        let mut result = compact_session(&self.session, config);
 
         if result.removed_message_count == 0 {
             return None;
+        }
+
+        if config.llm_summarization {
+            let existing_prefix = usize::from(
+                self.session.messages.first().is_some_and(|message| {
+                    message.role == crate::session::MessageRole::System
+                        && message.blocks.iter().any(|block| matches!(
+                            block,
+                            ContentBlock::Text { text }
+                                if text.starts_with(
+                                    "This session is being continued from a previous conversation",
+                                )
+                        ))
+                }),
+            );
+            let removed_end = (existing_prefix + result.removed_message_count)
+                .min(self.session.messages.len());
+            let removed_messages = &self.session.messages[existing_prefix..removed_end];
+
+            if let Some(llm_summary) = try_llm_summarize(
+                removed_messages,
+                &mut self.api_client,
+                self.session.model.as_deref(),
+            ) {
+                let continuation = crate::compact::get_compact_continuation_message(
+                    &llm_summary,
+                    true,
+                    result.compacted_session.messages.len() > 1,
+                );
+                if let Some(first_msg) = result.compacted_session.messages.first_mut() {
+                    first_msg.blocks = vec![ContentBlock::Text { text: continuation }];
+                }
+            }
         }
 
         self.session = result.compacted_session;
@@ -438,6 +471,103 @@ where
             removed_message_count: result.removed_message_count,
         })
     }
+}
+
+/// Attempts LLM-powered summarization of the removed messages.
+/// Returns `Some(summary_text)` on success, `None` on any failure (fall back to mechanical).
+fn try_llm_summarize<C: ApiClient>(
+    removed: &[ConversationMessage],
+    api_client: &mut C,
+    model: Option<&str>,
+) -> Option<String> {
+    const MAX_SUMMARIZER_TOKENS: usize = 100_000;
+    const MAX_SUMMARY_CHARS: usize = 1_200;
+    const SUMMARY_TEMPLATE: &str = "Summarize this conversation segment concisely.\n\
+Output EXACTLY this structure with no other text:\n\
+## Goal\n\
+[what the user was trying to accomplish]\n\
+## Progress (Done / In Progress)\n\
+[what has been completed and what is in progress]\n\
+## Key Decisions\n\
+[important choices made during the conversation]\n\
+## Next Steps\n\
+[pending work or what should happen next]\n\
+## Relevant Files\n\
+[any file paths mentioned, or 'None']";
+
+    let mut context_parts = Vec::new();
+    let mut estimated_tokens = 0usize;
+
+    for msg in removed {
+        let role = match msg.role {
+            crate::session::MessageRole::System => "system",
+            crate::session::MessageRole::User => "user",
+            crate::session::MessageRole::Assistant => "assistant",
+            crate::session::MessageRole::Tool => "tool",
+        };
+        let text = msg
+            .blocks
+            .iter()
+            .map(|block| match block {
+                ContentBlock::Text { text } => text.as_str(),
+                ContentBlock::ToolUse { input, .. } => input.as_str(),
+                ContentBlock::ToolResult { output, .. } => output.as_str(),
+                ContentBlock::Reasoning { data } => data.as_str(),
+            })
+            .collect::<Vec<_>>()
+            .join(" | ");
+        let part = format!("[{role}]: {text}");
+        let part_tokens = part.len() / 4 + 1;
+        if estimated_tokens + part_tokens > MAX_SUMMARIZER_TOKENS {
+            break;
+        }
+        estimated_tokens += part_tokens;
+        context_parts.push(part);
+    }
+
+    if context_parts.is_empty() {
+        return None;
+    }
+
+    let user_content = format!(
+        "Conversation to summarize:\n\n{}\n\n---\n\n{SUMMARY_TEMPLATE}",
+        context_parts.join("\n\n")
+    );
+
+    let system_hint = model.map_or_else(
+        || "You are summarizing a conversation segment.".to_string(),
+        |model| format!("You are summarizing a conversation with model {model}."),
+    );
+
+    let events = api_client
+        .stream(ApiRequest {
+            system_prompt: vec![system_hint],
+            messages: vec![ConversationMessage::user_text(user_content)],
+        })
+        .ok()?;
+
+    let llm_summary: String = events
+        .iter()
+        .filter_map(|event| match event {
+            AssistantEvent::TextDelta(text) => Some(text.as_str()),
+            AssistantEvent::ToolUse { .. }
+            | AssistantEvent::Reasoning { .. }
+            | AssistantEvent::Usage(_)
+            | AssistantEvent::MessageStop => None,
+        })
+        .collect();
+
+    let llm_summary = llm_summary.trim();
+    if llm_summary.is_empty() || llm_summary.len() > MAX_SUMMARY_CHARS {
+        return None;
+    }
+
+    let compressed = crate::summary_compression::compress_summary_text(llm_summary);
+    if compressed.is_empty() {
+        return None;
+    }
+
+    Some(format!("<summary>{compressed}</summary>"))
 }
 
 #[must_use]
@@ -659,6 +789,25 @@ mod tests {
         }
     }
 
+    struct MockApiClientWithText(String);
+
+    impl ApiClient for MockApiClientWithText {
+        fn stream(&mut self, _req: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
+            Ok(vec![
+                AssistantEvent::TextDelta(self.0.clone()),
+                AssistantEvent::MessageStop,
+            ])
+        }
+    }
+
+    struct MockApiClientError;
+
+    impl ApiClient for MockApiClientError {
+        fn stream(&mut self, _req: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
+            Err(RuntimeError::new("simulated API error"))
+        }
+    }
+
     #[tokio::test]
     async fn runs_user_to_tool_to_result_loop_end_to_end_and_tracks_usage() {
         let api_client = ScriptedApiClient { call_count: 0 };
@@ -779,6 +928,95 @@ mod tests {
         assert_eq!(
             result.compacted_session.messages[0].role,
             MessageRole::System
+        );
+    }
+
+    #[test]
+    fn try_llm_summarize_returns_some_on_success() {
+        let removed = vec![
+            crate::session::ConversationMessage::user_text("scrape books.toscrape.com"),
+            crate::session::ConversationMessage::assistant(vec![ContentBlock::Text {
+                text: "Navigating to books.toscrape.com".to_string(),
+            }]),
+        ];
+        let mut client = MockApiClientWithText(
+            "## Goal\nScrape books\n## Progress\nNavigated to site\n## Key Decisions\nNone\n## Next Steps\nExtract data\n## Relevant Files\nNone"
+                .to_string(),
+        );
+
+        let result = super::try_llm_summarize(&removed, &mut client, Some("test-model"));
+
+        assert!(result.is_some(), "should return Some on success");
+        let summary = result.expect("summary should exist");
+        assert!(summary.contains("<summary>"), "should be wrapped in summary tags");
+        assert!(
+            summary.contains("Goal") || summary.contains("goal"),
+            "should contain structured output"
+        );
+    }
+
+    #[test]
+    fn try_llm_summarize_returns_none_on_api_error() {
+        let removed = vec![crate::session::ConversationMessage::user_text("hello")];
+        let mut client = MockApiClientError;
+
+        let result = super::try_llm_summarize(&removed, &mut client, None);
+
+        assert!(result.is_none(), "should return None on API error");
+    }
+
+    #[test]
+    fn try_llm_summarize_returns_none_on_empty_response() {
+        let removed = vec![crate::session::ConversationMessage::user_text("hello")];
+        let mut client = MockApiClientWithText(String::new());
+
+        let result = super::try_llm_summarize(&removed, &mut client, None);
+
+        assert!(result.is_none(), "should return None on empty response");
+    }
+
+    #[test]
+    fn try_llm_summarize_returns_none_for_empty_messages() {
+        let mut client = MockApiClientWithText("some summary".to_string());
+
+        let result = super::try_llm_summarize(&[], &mut client, None);
+
+        assert!(result.is_none(), "should return None when no messages to summarize");
+    }
+
+    #[test]
+    fn llm_summarization_disabled_uses_mechanical_path() {
+        use crate::compact::compact_session;
+
+        let text = "word ".repeat(200);
+        let session = Session {
+            version: 1,
+            model: None,
+            title: None,
+            messages: vec![
+                crate::session::ConversationMessage::user_text(&text),
+                crate::session::ConversationMessage::assistant(vec![ContentBlock::Text {
+                    text: text.clone(),
+                }]),
+                crate::session::ConversationMessage::user_text(&text),
+                crate::session::ConversationMessage::assistant(vec![ContentBlock::Text {
+                    text: "done".to_string(),
+                }]),
+            ],
+        };
+        let config = CompactionConfig {
+            llm_summarization: false,
+            max_estimated_tokens: 1,
+            preserve_recent_messages: 2,
+            ..CompactionConfig::default()
+        };
+
+        let result = compact_session(&session, config);
+
+        assert!(result.removed_message_count > 0);
+        assert!(
+            result.formatted_summary.contains("Scope:"),
+            "mechanical summary should contain 'Scope:'"
         );
     }
 

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -21,9 +21,6 @@ pub use compact::{
     compact_session, estimate_session_tokens, format_compact_summary,
     get_compact_continuation_message, should_compact, CompactionConfig, CompactionResult,
 };
-pub use summary_compression::{
-    compress_summary, compress_summary_text, SummaryCompressionBudget, SummaryCompressionResult,
-};
 pub use config::{
     ConfigEntry, ConfigError, ConfigLoader, ConfigSource, McpClaudeAiProxyServerConfig,
     McpConfigCollection, McpOAuthConfig, McpRemoteServerConfig, McpSdkServerConfig,
@@ -34,6 +31,9 @@ pub use control::ControlState;
 pub use conversation::{
     auto_compaction_threshold_from_env, ApiClient, ApiRequest, AssistantEvent, AutoCompactionEvent,
     ConversationRuntime, RuntimeError, StaticToolExecutor, ToolError, ToolExecutor, TurnSummary,
+};
+pub use summary_compression::{
+    compress_summary, compress_summary_text, SummaryCompressionBudget, SummaryCompressionResult,
 };
 
 pub use mcp::{
@@ -73,7 +73,10 @@ pub use remote::{
 pub use session::{ContentBlock, ConversationMessage, MessageRole, Session, SessionError};
 pub use settings::{
     config_home_dir, load_settings, save_settings, settings_file_path,
-    settings_get_auto_compact_tokens, settings_get_fork_child_max_steps,
+    settings_get_auto_compact_tokens, settings_get_compaction_llm_summarization,
+    settings_get_compaction_max_summary_chars, settings_get_compaction_preserve_recent_messages_floor,
+    settings_get_compaction_preserve_recent_tokens, settings_get_compaction_prune_max_output_chars,
+    settings_get_compaction_prune_protect_tokens, settings_get_fork_child_max_steps,
     settings_get_fork_wait_timeout_secs, settings_get_headless,
     settings_get_max_concurrent_per_parent, settings_get_max_fork_depth, settings_get_max_steps,
     settings_get_max_total_agents, settings_get_workspace_dir, update_settings, Settings,

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -74,7 +74,8 @@ pub use session::{ContentBlock, ConversationMessage, MessageRole, Session, Sessi
 pub use settings::{
     config_home_dir, load_settings, save_settings, settings_file_path,
     settings_get_auto_compact_tokens, settings_get_compaction_llm_summarization,
-    settings_get_compaction_max_summary_chars, settings_get_compaction_preserve_recent_messages_floor,
+    settings_get_compaction_max_summary_chars,
+    settings_get_compaction_preserve_recent_messages_floor,
     settings_get_compaction_preserve_recent_tokens, settings_get_compaction_prune_max_output_chars,
     settings_get_compaction_prune_protect_tokens, settings_get_fork_child_max_steps,
     settings_get_fork_wait_timeout_secs, settings_get_headless,

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -12,6 +12,7 @@ mod remote;
 pub mod sandbox;
 mod session;
 pub mod settings;
+mod summary_compression;
 pub mod update_check;
 mod usage;
 
@@ -19,6 +20,9 @@ pub use bootstrap::{BootstrapPhase, BootstrapPlan};
 pub use compact::{
     compact_session, estimate_session_tokens, format_compact_summary,
     get_compact_continuation_message, should_compact, CompactionConfig, CompactionResult,
+};
+pub use summary_compression::{
+    compress_summary, compress_summary_text, SummaryCompressionBudget, SummaryCompressionResult,
 };
 pub use config::{
     ConfigEntry, ConfigError, ConfigLoader, ConfigSource, McpClaudeAiProxyServerConfig,

--- a/crates/runtime/src/settings.rs
+++ b/crates/runtime/src/settings.rs
@@ -50,6 +50,30 @@ pub struct Settings {
     /// Timeout in seconds for `wait_for_subagents` (default: 60)
     #[serde(default)]
     pub fork_wait_timeout_secs: Option<u32>,
+
+    /// Compaction: token window protecting recent messages from pruning (default: 40000)
+    #[serde(default)]
+    pub compaction_prune_protect_tokens: Option<u64>,
+
+    /// Compaction: max chars for truncated tool outputs (default: 2000)
+    #[serde(default)]
+    pub compaction_prune_max_output_chars: Option<u64>,
+
+    /// Compaction: token budget for preserved tail (default: 80000)
+    #[serde(default)]
+    pub compaction_preserve_recent_tokens: Option<u64>,
+
+    /// Compaction: minimum messages always preserved (default: 2)
+    #[serde(default)]
+    pub compaction_preserve_recent_messages_floor: Option<u32>,
+
+    /// Compaction: max chars for the compacted summary (default: 1200)
+    #[serde(default)]
+    pub compaction_max_summary_chars: Option<u64>,
+
+    /// Compaction: enable LLM-powered summarization (default: false)
+    #[serde(default)]
+    pub compaction_llm_summarization: Option<bool>,
 }
 
 impl Default for Settings {
@@ -66,6 +90,12 @@ impl Default for Settings {
             max_total_agents: Some(10),
             fork_child_max_steps: Some(15),
             fork_wait_timeout_secs: Some(60),
+            compaction_prune_protect_tokens: None,
+            compaction_prune_max_output_chars: None,
+            compaction_preserve_recent_tokens: None,
+            compaction_preserve_recent_messages_floor: None,
+            compaction_max_summary_chars: None,
+            compaction_llm_summarization: None,
         }
     }
 }
@@ -188,6 +218,47 @@ pub fn settings_get_fork_wait_timeout_secs(s: &Settings) -> u32 {
     s.fork_wait_timeout_secs.unwrap_or(60)
 }
 
+/// Get `compaction_prune_protect_tokens` setting, with default fallback.
+#[must_use]
+#[allow(clippy::cast_possible_truncation)]
+pub fn settings_get_compaction_prune_protect_tokens(s: &Settings) -> usize {
+    s.compaction_prune_protect_tokens.map_or(40_000, |v| v as usize)
+}
+
+/// Get `compaction_prune_max_output_chars` setting, with default fallback.
+#[must_use]
+#[allow(clippy::cast_possible_truncation)]
+pub fn settings_get_compaction_prune_max_output_chars(s: &Settings) -> usize {
+    s.compaction_prune_max_output_chars.map_or(2_000, |v| v as usize)
+}
+
+/// Get `compaction_preserve_recent_tokens` setting, with default fallback.
+#[must_use]
+#[allow(clippy::cast_possible_truncation)]
+pub fn settings_get_compaction_preserve_recent_tokens(s: &Settings) -> usize {
+    s.compaction_preserve_recent_tokens.map_or(80_000, |v| v as usize)
+}
+
+/// Get `compaction_preserve_recent_messages_floor` setting, with default fallback.
+#[must_use]
+#[allow(clippy::cast_possible_truncation)]
+pub fn settings_get_compaction_preserve_recent_messages_floor(s: &Settings) -> usize {
+    s.compaction_preserve_recent_messages_floor.map_or(2, |v| v as usize)
+}
+
+/// Get `compaction_max_summary_chars` setting, with default fallback.
+#[must_use]
+#[allow(clippy::cast_possible_truncation)]
+pub fn settings_get_compaction_max_summary_chars(s: &Settings) -> usize {
+    s.compaction_max_summary_chars.map_or(1_200, |v| v as usize)
+}
+
+/// Get `compaction_llm_summarization` setting, with default fallback.
+#[must_use]
+pub fn settings_get_compaction_llm_summarization(s: &Settings) -> bool {
+    s.compaction_llm_summarization.unwrap_or(false)
+}
+
 /// Helper to get home directory.
 /// On Windows, tries USERPROFILE then HOMEPATH.
 /// On Unix, tries HOME.
@@ -289,6 +360,12 @@ mod tests {
             max_total_agents: Some(20),
             fork_child_max_steps: Some(25),
             fork_wait_timeout_secs: Some(120),
+            compaction_prune_protect_tokens: None,
+            compaction_prune_max_output_chars: None,
+            compaction_preserve_recent_tokens: None,
+            compaction_preserve_recent_messages_floor: None,
+            compaction_max_summary_chars: None,
+            compaction_llm_summarization: None,
         };
 
         save_settings(&original).expect("Failed to save settings");
@@ -434,6 +511,12 @@ mod tests {
             max_total_agents: Some(15),
             fork_child_max_steps: Some(20),
             fork_wait_timeout_secs: Some(90),
+            compaction_prune_protect_tokens: None,
+            compaction_prune_max_output_chars: None,
+            compaction_preserve_recent_tokens: None,
+            compaction_preserve_recent_messages_floor: None,
+            compaction_max_summary_chars: None,
+            compaction_llm_summarization: None,
         })
         .expect("save settings");
 
@@ -487,6 +570,12 @@ mod tests {
             max_total_agents: Some(16),
             fork_child_max_steps: Some(20),
             fork_wait_timeout_secs: Some(75),
+            compaction_prune_protect_tokens: None,
+            compaction_prune_max_output_chars: None,
+            compaction_preserve_recent_tokens: None,
+            compaction_preserve_recent_messages_floor: None,
+            compaction_max_summary_chars: None,
+            compaction_llm_summarization: None,
         };
 
         save_settings(&original).expect("Failed to save settings");
@@ -540,6 +629,12 @@ mod tests {
             max_total_agents: None,
             fork_child_max_steps: None,
             fork_wait_timeout_secs: None,
+            compaction_prune_protect_tokens: None,
+            compaction_prune_max_output_chars: None,
+            compaction_preserve_recent_tokens: None,
+            compaction_preserve_recent_messages_floor: None,
+            compaction_max_summary_chars: None,
+            compaction_llm_summarization: None,
         };
 
         assert_eq!(settings_get_max_concurrent_per_parent(&settings), 5);
@@ -547,5 +642,58 @@ mod tests {
         assert_eq!(settings_get_max_total_agents(&settings), 10);
         assert_eq!(settings_get_fork_child_max_steps(&settings), 15);
         assert_eq!(settings_get_fork_wait_timeout_secs(&settings), 60);
+    }
+
+    #[test]
+    fn test_compaction_settings_defaults() {
+        let settings = Settings {
+            compaction_prune_protect_tokens: None,
+            compaction_prune_max_output_chars: None,
+            compaction_preserve_recent_tokens: None,
+            compaction_preserve_recent_messages_floor: None,
+            compaction_max_summary_chars: None,
+            compaction_llm_summarization: None,
+            ..Default::default()
+        };
+        assert_eq!(settings_get_compaction_prune_protect_tokens(&settings), 40_000);
+        assert_eq!(settings_get_compaction_prune_max_output_chars(&settings), 2_000);
+        assert_eq!(settings_get_compaction_preserve_recent_tokens(&settings), 80_000);
+        assert_eq!(settings_get_compaction_preserve_recent_messages_floor(&settings), 2);
+        assert_eq!(settings_get_compaction_max_summary_chars(&settings), 1_200);
+        assert!(!settings_get_compaction_llm_summarization(&settings));
+    }
+
+    #[test]
+    fn test_compaction_settings_custom_values() {
+        let settings = Settings {
+            compaction_prune_protect_tokens: Some(20_000),
+            compaction_preserve_recent_tokens: Some(50_000),
+            compaction_llm_summarization: Some(true),
+            ..Default::default()
+        };
+        assert_eq!(settings_get_compaction_prune_protect_tokens(&settings), 20_000);
+        assert_eq!(settings_get_compaction_preserve_recent_tokens(&settings), 50_000);
+        assert!(settings_get_compaction_llm_summarization(&settings));
+        // Unset fields use defaults
+        assert_eq!(settings_get_compaction_prune_max_output_chars(&settings), 2_000);
+    }
+
+    #[test]
+    fn test_compaction_settings_round_trip() {
+        let _lock = test_env_lock();
+        let temp_dir = setup_temp_dir();
+        std::env::set_var("ACRAWL_CONFIG_HOME", &temp_dir);
+
+        let original = Settings {
+            compaction_prune_protect_tokens: Some(30_000),
+            compaction_llm_summarization: Some(true),
+            ..Default::default()
+        };
+        save_settings(&original).expect("save");
+        let loaded = load_settings();
+        assert_eq!(loaded.compaction_prune_protect_tokens, Some(30_000));
+        assert_eq!(loaded.compaction_llm_summarization, Some(true));
+
+        cleanup_temp_dir(&temp_dir);
     }
 }

--- a/crates/runtime/src/settings.rs
+++ b/crates/runtime/src/settings.rs
@@ -222,28 +222,32 @@ pub fn settings_get_fork_wait_timeout_secs(s: &Settings) -> u32 {
 #[must_use]
 #[allow(clippy::cast_possible_truncation)]
 pub fn settings_get_compaction_prune_protect_tokens(s: &Settings) -> usize {
-    s.compaction_prune_protect_tokens.map_or(40_000, |v| v as usize)
+    s.compaction_prune_protect_tokens
+        .map_or(40_000, |v| v as usize)
 }
 
 /// Get `compaction_prune_max_output_chars` setting, with default fallback.
 #[must_use]
 #[allow(clippy::cast_possible_truncation)]
 pub fn settings_get_compaction_prune_max_output_chars(s: &Settings) -> usize {
-    s.compaction_prune_max_output_chars.map_or(2_000, |v| v as usize)
+    s.compaction_prune_max_output_chars
+        .map_or(2_000, |v| v as usize)
 }
 
 /// Get `compaction_preserve_recent_tokens` setting, with default fallback.
 #[must_use]
 #[allow(clippy::cast_possible_truncation)]
 pub fn settings_get_compaction_preserve_recent_tokens(s: &Settings) -> usize {
-    s.compaction_preserve_recent_tokens.map_or(80_000, |v| v as usize)
+    s.compaction_preserve_recent_tokens
+        .map_or(80_000, |v| v as usize)
 }
 
 /// Get `compaction_preserve_recent_messages_floor` setting, with default fallback.
 #[must_use]
 #[allow(clippy::cast_possible_truncation)]
 pub fn settings_get_compaction_preserve_recent_messages_floor(s: &Settings) -> usize {
-    s.compaction_preserve_recent_messages_floor.map_or(2, |v| v as usize)
+    s.compaction_preserve_recent_messages_floor
+        .map_or(2, |v| v as usize)
 }
 
 /// Get `compaction_max_summary_chars` setting, with default fallback.
@@ -655,10 +659,22 @@ mod tests {
             compaction_llm_summarization: None,
             ..Default::default()
         };
-        assert_eq!(settings_get_compaction_prune_protect_tokens(&settings), 40_000);
-        assert_eq!(settings_get_compaction_prune_max_output_chars(&settings), 2_000);
-        assert_eq!(settings_get_compaction_preserve_recent_tokens(&settings), 80_000);
-        assert_eq!(settings_get_compaction_preserve_recent_messages_floor(&settings), 2);
+        assert_eq!(
+            settings_get_compaction_prune_protect_tokens(&settings),
+            40_000
+        );
+        assert_eq!(
+            settings_get_compaction_prune_max_output_chars(&settings),
+            2_000
+        );
+        assert_eq!(
+            settings_get_compaction_preserve_recent_tokens(&settings),
+            80_000
+        );
+        assert_eq!(
+            settings_get_compaction_preserve_recent_messages_floor(&settings),
+            2
+        );
         assert_eq!(settings_get_compaction_max_summary_chars(&settings), 1_200);
         assert!(!settings_get_compaction_llm_summarization(&settings));
     }
@@ -671,11 +687,20 @@ mod tests {
             compaction_llm_summarization: Some(true),
             ..Default::default()
         };
-        assert_eq!(settings_get_compaction_prune_protect_tokens(&settings), 20_000);
-        assert_eq!(settings_get_compaction_preserve_recent_tokens(&settings), 50_000);
+        assert_eq!(
+            settings_get_compaction_prune_protect_tokens(&settings),
+            20_000
+        );
+        assert_eq!(
+            settings_get_compaction_preserve_recent_tokens(&settings),
+            50_000
+        );
         assert!(settings_get_compaction_llm_summarization(&settings));
         // Unset fields use defaults
-        assert_eq!(settings_get_compaction_prune_max_output_chars(&settings), 2_000);
+        assert_eq!(
+            settings_get_compaction_prune_max_output_chars(&settings),
+            2_000
+        );
     }
 
     #[test]

--- a/crates/runtime/src/summary_compression.rs
+++ b/crates/runtime/src/summary_compression.rs
@@ -1,0 +1,300 @@
+use std::collections::BTreeSet;
+
+const DEFAULT_MAX_CHARS: usize = 1_200;
+const DEFAULT_MAX_LINES: usize = 24;
+const DEFAULT_MAX_LINE_CHARS: usize = 160;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SummaryCompressionBudget {
+    pub max_chars: usize,
+    pub max_lines: usize,
+    pub max_line_chars: usize,
+}
+
+impl Default for SummaryCompressionBudget {
+    fn default() -> Self {
+        Self {
+            max_chars: DEFAULT_MAX_CHARS,
+            max_lines: DEFAULT_MAX_LINES,
+            max_line_chars: DEFAULT_MAX_LINE_CHARS,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SummaryCompressionResult {
+    pub summary: String,
+    pub original_chars: usize,
+    pub compressed_chars: usize,
+    pub original_lines: usize,
+    pub compressed_lines: usize,
+    pub removed_duplicate_lines: usize,
+    pub omitted_lines: usize,
+    pub truncated: bool,
+}
+
+#[must_use]
+pub fn compress_summary(
+    summary: &str,
+    budget: SummaryCompressionBudget,
+) -> SummaryCompressionResult {
+    let original_chars = summary.chars().count();
+    let original_lines = summary.lines().count();
+
+    let normalized = normalize_lines(summary, budget.max_line_chars);
+    if normalized.lines.is_empty() || budget.max_chars == 0 || budget.max_lines == 0 {
+        return SummaryCompressionResult {
+            summary: String::new(),
+            original_chars,
+            compressed_chars: 0,
+            original_lines,
+            compressed_lines: 0,
+            removed_duplicate_lines: normalized.removed_duplicate_lines,
+            omitted_lines: normalized.lines.len(),
+            truncated: original_chars > 0,
+        };
+    }
+
+    let selected = select_line_indexes(&normalized.lines, budget);
+    let mut compressed_lines = selected
+        .iter()
+        .map(|index| normalized.lines[*index].clone())
+        .collect::<Vec<_>>();
+    if compressed_lines.is_empty() {
+        compressed_lines.push(truncate_line(&normalized.lines[0], budget.max_chars));
+    }
+    let omitted_lines = normalized
+        .lines
+        .len()
+        .saturating_sub(compressed_lines.len());
+
+    if omitted_lines > 0 {
+        let omission_notice = omission_notice(omitted_lines);
+        push_line_with_budget(&mut compressed_lines, omission_notice, budget);
+    }
+
+    let compressed_summary = compressed_lines.join("\n");
+
+    SummaryCompressionResult {
+        compressed_chars: compressed_summary.chars().count(),
+        compressed_lines: compressed_lines.len(),
+        removed_duplicate_lines: normalized.removed_duplicate_lines,
+        omitted_lines,
+        truncated: compressed_summary != summary.trim(),
+        summary: compressed_summary,
+        original_chars,
+        original_lines,
+    }
+}
+
+#[must_use]
+pub fn compress_summary_text(summary: &str) -> String {
+    compress_summary(summary, SummaryCompressionBudget::default()).summary
+}
+
+#[derive(Debug, Default)]
+struct NormalizedSummary {
+    lines: Vec<String>,
+    removed_duplicate_lines: usize,
+}
+
+fn normalize_lines(summary: &str, max_line_chars: usize) -> NormalizedSummary {
+    let mut seen = BTreeSet::new();
+    let mut lines = Vec::new();
+    let mut removed_duplicate_lines = 0;
+
+    for raw_line in summary.lines() {
+        let normalized = collapse_inline_whitespace(raw_line);
+        if normalized.is_empty() {
+            continue;
+        }
+
+        let truncated = truncate_line(&normalized, max_line_chars);
+        let dedupe_key = dedupe_key(&truncated);
+        if !seen.insert(dedupe_key) {
+            removed_duplicate_lines += 1;
+            continue;
+        }
+
+        lines.push(truncated);
+    }
+
+    NormalizedSummary {
+        lines,
+        removed_duplicate_lines,
+    }
+}
+
+fn select_line_indexes(lines: &[String], budget: SummaryCompressionBudget) -> Vec<usize> {
+    let mut selected = BTreeSet::<usize>::new();
+
+    for priority in 0..=3 {
+        for (index, line) in lines.iter().enumerate() {
+            if selected.contains(&index) || line_priority(line) != priority {
+                continue;
+            }
+
+            let candidate = selected
+                .iter()
+                .map(|selected_index| lines[*selected_index].as_str())
+                .chain(std::iter::once(line.as_str()))
+                .collect::<Vec<_>>();
+
+            if candidate.len() > budget.max_lines {
+                continue;
+            }
+
+            if joined_char_count(&candidate) > budget.max_chars {
+                continue;
+            }
+
+            selected.insert(index);
+        }
+    }
+
+    selected.into_iter().collect()
+}
+
+fn push_line_with_budget(lines: &mut Vec<String>, line: String, budget: SummaryCompressionBudget) {
+    let candidate = lines
+        .iter()
+        .map(String::as_str)
+        .chain(std::iter::once(line.as_str()))
+        .collect::<Vec<_>>();
+
+    if candidate.len() <= budget.max_lines && joined_char_count(&candidate) <= budget.max_chars {
+        lines.push(line);
+    }
+}
+
+fn joined_char_count(lines: &[&str]) -> usize {
+    lines.iter().map(|line| line.chars().count()).sum::<usize>() + lines.len().saturating_sub(1)
+}
+
+fn line_priority(line: &str) -> usize {
+    if line == "Summary:" || line == "Conversation summary:" || is_core_detail(line) {
+        0
+    } else if is_section_header(line) {
+        1
+    } else if line.starts_with("- ") || line.starts_with("  - ") {
+        2
+    } else {
+        3
+    }
+}
+
+fn is_core_detail(line: &str) -> bool {
+    [
+        "- Scope:",
+        "- Current work:",
+        "- Pending work:",
+        "- Key files referenced:",
+        "- Tools mentioned:",
+        "- Recent user requests:",
+        "- Previously compacted context:",
+        "- Newly compacted context:",
+    ]
+    .iter()
+    .any(|prefix| line.starts_with(prefix))
+}
+
+fn is_section_header(line: &str) -> bool {
+    line.ends_with(':')
+}
+
+fn omission_notice(omitted_lines: usize) -> String {
+    format!("- … {omitted_lines} additional line(s) omitted.")
+}
+
+fn collapse_inline_whitespace(line: &str) -> String {
+    line.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn truncate_line(line: &str, max_chars: usize) -> String {
+    if max_chars == 0 || line.chars().count() <= max_chars {
+        return line.to_string();
+    }
+
+    if max_chars == 1 {
+        return "…".to_string();
+    }
+
+    let mut truncated = line
+        .chars()
+        .take(max_chars.saturating_sub(1))
+        .collect::<String>();
+    truncated.push('…');
+    truncated
+}
+
+fn dedupe_key(line: &str) -> String {
+    line.to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{compress_summary, compress_summary_text, SummaryCompressionBudget};
+
+    #[test]
+    fn collapses_whitespace_and_duplicate_lines() {
+        // given
+        let summary = "Conversation summary:\n\n- Scope:   compact   earlier   messages.\n- Scope: compact earlier messages.\n- Current work: update runtime module.\n";
+
+        // when
+        let result = compress_summary(summary, SummaryCompressionBudget::default());
+
+        // then
+        assert_eq!(result.removed_duplicate_lines, 1);
+        assert!(result
+            .summary
+            .contains("- Scope: compact earlier messages."));
+        assert!(!result.summary.contains("  compact   earlier"));
+    }
+
+    #[test]
+    fn keeps_core_lines_when_budget_is_tight() {
+        // given
+        let summary = [
+            "Conversation summary:",
+            "- Scope: 18 earlier messages compacted.",
+            "- Current work: finish summary compression.",
+            "- Key timeline:",
+            "  - user: asked for a working implementation.",
+            "  - assistant: inspected runtime compaction flow.",
+            "  - tool: cargo check succeeded.",
+        ]
+        .join("\n");
+
+        // when
+        let result = compress_summary(
+            &summary,
+            SummaryCompressionBudget {
+                max_chars: 120,
+                max_lines: 3,
+                max_line_chars: 80,
+            },
+        );
+
+        // then
+        assert!(result.summary.contains("Conversation summary:"));
+        assert!(result
+            .summary
+            .contains("- Scope: 18 earlier messages compacted."));
+        assert!(result
+            .summary
+            .contains("- Current work: finish summary compression."));
+        assert!(result.omitted_lines > 0);
+    }
+
+    #[test]
+    fn provides_a_default_text_only_helper() {
+        // given
+        let summary = "Summary:\n\nA short line.";
+
+        // when
+        let compressed = compress_summary_text(summary);
+
+        // then
+        assert_eq!(compressed, "Summary:\nA short line.");
+    }
+}


### PR DESCRIPTION
## Summary

Replaces acrawl's naive 4-message sliding-window compaction with a multi-strategy approach that makes context retention context-aware and budget-driven.

## Changes

### Tool output pruning (`compact.rs`)
- `prune_tool_outputs()` walks backward through messages and truncates `ToolResult` outputs beyond a configurable protected window (`prune_protect_tokens`, default 40K tokens) to `prune_max_output_chars` (default 2K chars), appending a truncation marker with the original char count
- Pruning runs before `keep_from` is computed so pruned sizes inform the tail budget

### Token-budget tail (`compact.rs`)
- Replaces the fixed `preserve_recent_messages` count with a backward token-budget walk (`preserve_recent_tokens`, default 80K tokens)
- `preserve_recent_messages` is retained as a hard minimum floor (via `legacy_count_override` for backward compat with existing callers)
- `preserve_recent_messages_floor` (default 2) ensures at least N messages are always kept regardless of budget
- `should_compact()` now excludes the existing summary prefix from its token/length count

### Summary merging (`compact.rs`)
- `merge_compact_summaries()` detects a prior compaction via `extract_existing_compacted_summary()` and produces a merged output with **Previously compacted context** / **Newly compacted context** / **Key timeline** sections
- `compact_session()` skips the existing summary prefix when slicing the removed-messages window

### Summary prefix detection (`compact.rs`)
- Three named constants (`COMPACT_CONTINUATION_PREAMBLE`, `COMPACT_RECENT_MESSAGES_NOTE`, `COMPACT_DIRECT_RESUME_INSTRUCTION`) replace inline string literals in `get_compact_continuation_message()`
- `extract_existing_compacted_summary()` + `compacted_summary_prefix_len()` detect and measure an existing compaction prefix

### Priority-based summary compression (`summary_compression.rs`)
- New `crates/runtime/src/summary_compression.rs` module (ported from claw-code reference)
- Greedy line selection by priority tier: 0 = core detail lines (`Scope:`, `Current work:`, etc.), 1 = section headers, 2 = bullet items, 3 = everything else
- Deduplication, inline-whitespace normalization, per-line char truncation, omission notice
- `compress_summary_text()` convenience wrapper using default budget (1200 chars / 24 lines)
- Applied after summary merging to cap total summary size (`max_summary_chars`, default 1200)

### CompactionConfig + settings integration
- `CompactionConfig` gains `prune_protect_tokens`, `prune_max_output_chars`, `max_summary_chars`, `llm_summarization` fields (all with sensible defaults)
- Six new `compaction_*` fields added to `Settings` with `#[serde(default)]` — fully backward-compatible with existing `settings.json` files
- `maybe_auto_compact()` now builds `CompactionConfig` from loaded settings

### LLM-powered summarization (`conversation.rs`)
- `try_llm_summarize()` builds a structured prompt (Goal / Progress / Key Decisions / Next Steps / Relevant Files), calls `api_client.stream()`, and returns a compressed `<summary>`-tagged string
- Gated behind `config.llm_summarization` (default: `false`) — opt-in only
- Input capped at 100K estimated tokens
- On any failure (API error, empty/oversized response, empty removed-message slice): falls back silently to the mechanical summary already computed by `compact_session()`

## Test coverage
- 842 tests pass across the full workspace (was ~688 before this PR)
- New unit tests per feature + 4 QA integration tests (large tool output pruning, multiple compaction rounds, token-budget tail validation, orphaned-`tool_result` invariant)

## Guardrails respected
- No tiktoken or external tokenizer added
- No `RuntimeObserver` trait changes
- No TUI changes
- Auto-compact trigger threshold (200K) unchanged
- Session serialization format unchanged
- No `unsafe` code