### PR TITLE
fix(tui): auth provider routing, resume parser, and Cloudflare Turnstile bypass

### DIFF
--- a/crates/acrawl-cli/src/main.rs
+++ b/crates/acrawl-cli/src/main.rs
@@ -398,10 +398,8 @@ fn parse_resume_args(args: &[String]) -> Result<CliAction, String> {
     let mut commands = Vec::new();
     let mut current = String::new();
     for arg in raw_args {
-        if arg.trim_start().starts_with('/') {
-            if !current.is_empty() {
-                commands.push(std::mem::take(&mut current));
-            }
+        if arg.trim_start().starts_with('/') && !current.is_empty() {
+            commands.push(std::mem::take(&mut current));
         }
         if !current.is_empty() {
             current.push(' ');

--- a/crates/acrawl-cli/src/main.rs
+++ b/crates/acrawl-cli/src/main.rs
@@ -412,6 +412,11 @@ fn parse_resume_args(args: &[String]) -> Result<CliAction, String> {
     if commands.is_empty() {
         return Err("--resume requires at least one slash command".to_string());
     }
+    if let Some(bad) = commands.iter().find(|c| !c.trim_start().starts_with('/')) {
+        return Err(format!(
+            "--resume trailing arguments must be slash commands (got '{bad}')"
+        ));
+    }
     Ok(CliAction::ResumeSession {
         session_path,
         commands,

--- a/crates/acrawl-cli/src/main.rs
+++ b/crates/acrawl-cli/src/main.rs
@@ -391,12 +391,28 @@ fn parse_resume_args(args: &[String]) -> Result<CliAction, String> {
         .first()
         .ok_or_else(|| "missing session path for --resume".to_string())
         .map(PathBuf::from)?;
-    let commands = args[1..].to_vec();
-    if commands
-        .iter()
-        .any(|command| !command.trim_start().starts_with('/'))
-    {
-        return Err("--resume trailing arguments must be slash commands".to_string());
+    let raw_args = &args[1..];
+    // Re-join arguments into slash commands, splitting on leading '/' tokens.
+    // This allows commands like `/clear --confirm` or `/config env`
+    // where arguments don't start with '/'.
+    let mut commands = Vec::new();
+    let mut current = String::new();
+    for arg in raw_args {
+        if arg.trim_start().starts_with('/') {
+            if !current.is_empty() {
+                commands.push(std::mem::take(&mut current));
+            }
+        }
+        if !current.is_empty() {
+            current.push(' ');
+        }
+        current.push_str(arg);
+    }
+    if !current.is_empty() {
+        commands.push(current);
+    }
+    if commands.is_empty() {
+        return Err("--resume requires at least one slash command".to_string());
     }
     Ok(CliAction::ResumeSession {
         session_path,
@@ -795,6 +811,23 @@ mod tests {
                     "/compact".to_string(),
                     "/cost".to_string(),
                 ],
+            }
+        );
+    }
+
+    #[test]
+    fn parses_resume_flag_with_command_arguments() {
+        let args = vec![
+            "--resume".to_string(),
+            "session.json".to_string(),
+            "/clear".to_string(),
+            "--confirm".to_string(),
+        ];
+        assert_eq!(
+            parse_args(&args).expect("args should parse"),
+            CliAction::ResumeSession {
+                session_path: PathBuf::from("session.json"),
+                commands: vec!["/clear --confirm".to_string()],
             }
         );
     }

--- a/crates/acrawl-cli/src/tui/auth_modal.rs
+++ b/crates/acrawl-cli/src/tui/auth_modal.rs
@@ -1129,11 +1129,22 @@ impl Modal for AuthModal {
                             error: None,
                         };
                     } else if let ProviderKind::Preset(p) = provider {
-                        let idx = flat_preset_list()
-                            .iter()
-                            .position(|pp| pp.id == p.id)
-                            .unwrap_or(0);
-                        self.step = AuthModalStep::ProviderSelect { selected: idx };
+                        if base_url.is_some() {
+                            let previous = base_url.clone().unwrap_or_default();
+                            let previous_len = Self::char_len(&previous);
+                            self.step = AuthModalStep::BaseUrlInput {
+                                provider: ProviderKind::Preset(*p),
+                                input: previous,
+                                cursor: previous_len,
+                                error: None,
+                            };
+                        } else {
+                            let idx = flat_preset_list()
+                                .iter()
+                                .position(|pp| pp.id == p.id)
+                                .unwrap_or(0);
+                            self.step = AuthModalStep::ProviderSelect { selected: idx };
+                        }
                     } else {
                         self.step = AuthModalStep::AuthMethodSelect {
                             provider: *provider,

--- a/crates/acrawl-cli/src/tui/auth_modal.rs
+++ b/crates/acrawl-cli/src/tui/auth_modal.rs
@@ -7,6 +7,7 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph, Wrap};
 
+use crate::auth::ProviderChoice;
 use crate::display_width::{prefix_display_width, text_display_width};
 use crate::tui::modal::{draw_modal_frame, should_passthrough_key, Modal, ModalAction};
 use crate::tui::ReplTuiEvent;
@@ -69,6 +70,7 @@ pub(crate) enum AuthModalStep {
         selected: usize,
     },
     BaseUrlInput {
+        provider: ProviderKind,
         input: String,
         cursor: usize,
         error: Option<String>,
@@ -147,27 +149,69 @@ impl AuthModal {
     }
 
     pub(crate) fn new(ui_tx: Sender<ReplTuiEvent>, provider: Option<crate::app::Provider>) -> Self {
-        let step = if let Some(p) = provider {
-            match p {
-                crate::app::Provider::OpenAi => AuthModalStep::ApiKeyInput {
-                    provider: ProviderKind::OpenAi,
-                    base_url: None,
-                    key_buffer: String::new(),
-                    cursor: 0,
-                    masked: true,
-                    error: None,
+        Self::new_with_choice(ui_tx, provider.map(ProviderChoice::Legacy))
+    }
+
+    pub(crate) fn new_with_choice(
+        ui_tx: Sender<ReplTuiEvent>,
+        choice: Option<ProviderChoice>,
+    ) -> Self {
+        let step = if let Some(c) = choice {
+            match c {
+                ProviderChoice::Legacy(p) => match p {
+                    crate::app::Provider::OpenAi => AuthModalStep::ApiKeyInput {
+                        provider: ProviderKind::OpenAi,
+                        base_url: None,
+                        key_buffer: String::new(),
+                        cursor: 0,
+                        masked: true,
+                        error: None,
+                    },
+                    crate::app::Provider::Anthropic => AuthModalStep::OAuthWaiting {
+                        provider: ProviderKind::Anthropic,
+                        status: "Preparing OAuth flow...".to_string(),
+                        cancel_tx: None,
+                        tick: 0,
+                    },
+                    crate::app::Provider::Other => AuthModalStep::BaseUrlInput {
+                        provider: ProviderKind::Other,
+                        input: String::new(),
+                        cursor: 0,
+                        error: None,
+                    },
                 },
-                crate::app::Provider::Anthropic => AuthModalStep::OAuthWaiting {
-                    provider: ProviderKind::Anthropic,
-                    status: "Preparing OAuth flow...".to_string(),
-                    cancel_tx: None,
-                    tick: 0,
-                },
-                crate::app::Provider::Other => AuthModalStep::BaseUrlInput {
-                    input: String::new(),
-                    cursor: 0,
-                    error: None,
-                },
+                ProviderChoice::Preset(preset) => {
+                    // Route preset providers with placeholder base URLs to the
+                    // BaseUrlInput step so the user can fill in required fields.
+                    // Copilot needs device-code OAuth, not an API key.
+                    if preset.id == "copilot" {
+                        AuthModalStep::OAuthWaiting {
+                            provider: ProviderKind::Preset(preset),
+                            status: "Preparing device code flow...".to_string(),
+                            cancel_tx: None,
+                            tick: 0,
+                        }
+                    } else if preset.base_url.contains('{') {
+                        AuthModalStep::BaseUrlInput {
+                            provider: ProviderKind::Preset(preset),
+                            input: preset.base_url.to_string(),
+                            cursor: preset.base_url.chars().count(),
+                            error: Some(
+                                "Replace {placeholders} with your values, then press Enter"
+                                    .to_string(),
+                            ),
+                        }
+                    } else {
+                        AuthModalStep::ApiKeyInput {
+                            provider: ProviderKind::Preset(preset),
+                            base_url: None,
+                            key_buffer: String::new(),
+                            cursor: 0,
+                            masked: true,
+                            error: None,
+                        }
+                    }
+                }
             }
         } else {
             AuthModalStep::ProviderSelect { selected: 0 }
@@ -536,12 +580,18 @@ impl Modal for AuthModal {
                 )
             }
             AuthModalStep::BaseUrlInput {
+                provider,
                 input,
                 cursor,
                 error,
             } => {
+                let header = if matches!(provider, ProviderKind::Other) {
+                    "Enter base URL for Other provider:"
+                } else {
+                    "Base URL (replace placeholders):"
+                };
                 let mut lines = vec![
-                    Line::from("Enter base URL for Other provider:"),
+                    Line::from(header),
                     Line::default(),
                     Line::from(format!("  > {input}")),
                     Line::default(),
@@ -567,23 +617,37 @@ impl Modal for AuthModal {
                 )
             }
             AuthModalStep::ApiKeyInput {
+                provider,
+                base_url,
                 key_buffer,
                 cursor,
                 masked,
                 error,
-                ..
             } => {
                 let display_key = if *masked {
                     "*".repeat(key_buffer.chars().count())
                 } else {
                     key_buffer.clone()
                 };
+                let preset_url = match provider {
+                    ProviderKind::Preset(p) => Some(p.base_url),
+                    _ => None,
+                };
+                let effective_url = base_url.as_deref().or(preset_url);
                 let mut lines = vec![
                     Line::from("Paste your API key:"),
                     Line::default(),
                     Line::from(format!("  [{display_key}]")),
                     Line::default(),
                 ];
+                if let Some(url) = effective_url {
+                    lines.push(Line::from(Span::styled(
+                        format!("  URL: {url}"),
+                        Style::default()
+                            .fg(Color::Rgb(130, 136, 145))
+                            .add_modifier(Modifier::DIM),
+                    )));
+                }
                 if let Some(message) = error {
                     lines.push(Line::from(Span::styled(
                         message.clone(),
@@ -831,6 +895,7 @@ impl Modal for AuthModal {
                             }
                             "other" => {
                                 self.step = AuthModalStep::BaseUrlInput {
+                                    provider: ProviderKind::Other,
                                     input: String::new(),
                                     cursor: 0,
                                     error: None,
@@ -920,6 +985,7 @@ impl Modal for AuthModal {
                 }
             }
             AuthModalStep::BaseUrlInput {
+                provider,
                 input,
                 cursor,
                 error,
@@ -958,7 +1024,7 @@ impl Modal for AuthModal {
                         *error = Some("Base URL cannot be empty".to_string());
                     } else {
                         self.step = AuthModalStep::ApiKeyInput {
-                            provider: ProviderKind::Other,
+                            provider: *provider,
                             base_url: Some(input.clone()),
                             key_buffer: String::new(),
                             cursor: 0,
@@ -969,11 +1035,19 @@ impl Modal for AuthModal {
                     ModalAction::Consumed
                 }
                 KeyCode::Esc => {
-                    let idx = flat_preset_list()
-                        .iter()
-                        .position(|p| p.id == "other")
-                        .unwrap_or(0);
-                    self.step = AuthModalStep::ProviderSelect { selected: idx };
+                    if let ProviderKind::Preset(p) = provider {
+                        let idx = flat_preset_list()
+                            .iter()
+                            .position(|pp| pp.id == p.id)
+                            .unwrap_or(0);
+                        self.step = AuthModalStep::ProviderSelect { selected: idx };
+                    } else {
+                        let idx = flat_preset_list()
+                            .iter()
+                            .position(|p| p.id == "other")
+                            .unwrap_or(0);
+                        self.step = AuthModalStep::ProviderSelect { selected: idx };
+                    }
                     ModalAction::Consumed
                 }
                 _ => ModalAction::Consumed,
@@ -1040,6 +1114,7 @@ impl Modal for AuthModal {
                         let previous = base_url.clone().unwrap_or_default();
                         let previous_len = Self::char_len(&previous);
                         self.step = AuthModalStep::BaseUrlInput {
+                            provider: ProviderKind::Other,
                             input: previous,
                             cursor: previous_len,
                             error: None,

--- a/crates/acrawl-cli/src/tui/auth_modal.rs
+++ b/crates/acrawl-cli/src/tui/auth_modal.rs
@@ -648,6 +648,15 @@ impl Modal for AuthModal {
                             .add_modifier(Modifier::DIM),
                     )));
                 }
+                let key_len = key_buffer.chars().count();
+                if key_len > 0 {
+                    lines.push(Line::from(Span::styled(
+                        format!("  {key_len} characters"),
+                        Style::default()
+                            .fg(Color::Rgb(130, 136, 145))
+                            .add_modifier(Modifier::DIM),
+                    )));
+                }
                 if let Some(message) = error {
                     lines.push(Line::from(Span::styled(
                         message.clone(),
@@ -657,7 +666,7 @@ impl Modal for AuthModal {
                 (
                     Color::Yellow,
                     lines,
-                    Some(hint_line("←/→ move  Enter confirm  Esc back")),
+                    Some(hint_line("←/→ move  Ctrl+V paste  Enter confirm  Esc back")),
                     Some((
                         3u16,
                         u16::try_from(

--- a/crates/acrawl-cli/src/tui/model_modal.rs
+++ b/crates/acrawl-cli/src/tui/model_modal.rs
@@ -363,7 +363,7 @@ impl Modal for ModelModal {
             .add_modifier(Modifier::DIM);
         let source_tag = Self::catalog_source_tag(self.catalog_source);
         let hint_text =
-            format!("↑↓ Navigate  Enter Select  Esc Cancel  Type to filter{source_tag}");
+            format!("↑↓ Navigate  Enter Select  Esc Cancel  Type to filter  (unconfigured → auth prompt){source_tag}");
         frame.render_widget(Paragraph::new(hint_text).style(hint_style), hint_area);
     }
 

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -9,6 +9,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::app::{slash_command_completion_candidates, AllowedToolSet, LiveCli};
+use crate::auth::ProviderChoice;
 use crate::display_width::{char_count_for_display_col, char_display_width, text_display_width};
 use crate::format::render_repl_help;
 use crate::markdown::{drain_safe_boundary, render_lines};
@@ -1334,12 +1335,16 @@ fn handle_slash_command_tui(
             }
             let parsed_provider = provider
                 .as_deref()
-                .and_then(|p| crate::app::parse_provider_arg(p).ok());
-            state.active_modal = Some(ActiveModal::Auth(AuthModal::new(
+                .and_then(|p| crate::auth::resolve_provider_arg(p).ok());
+            let is_anthropic_legacy = matches!(
+                parsed_provider,
+                Some(ProviderChoice::Legacy(crate::app::Provider::Anthropic))
+            );
+            state.active_modal = Some(ActiveModal::Auth(AuthModal::new_with_choice(
                 ui_tx.clone(),
                 parsed_provider,
             )));
-            if let Some(crate::app::Provider::Anthropic) = parsed_provider {
+            if is_anthropic_legacy {
                 spawn_anthropic_oauth_thread(ui_tx.clone(), &mut state.active_modal);
             }
         }
@@ -2310,8 +2315,13 @@ fn run_loop(
 
                 if key.code == KeyCode::Char('t') && key.modifiers.contains(KeyModifiers::CONTROL) {
                     let mut g = cli.lock().expect("cli lock");
-                    g.cycle_reasoning_effort();
+                    let new_effort = g.cycle_reasoning_effort();
                     state.cached_header = build_header_snapshot(&g);
+                    if let Some(effort) = new_effort {
+                        state.push_system(&format!("Reasoning effort → {}", effort));
+                    } else {
+                        state.push_system("Reasoning effort → off");
+                    }
                     continue;
                 }
 

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -2318,7 +2318,7 @@ fn run_loop(
                     let new_effort = g.cycle_reasoning_effort();
                     state.cached_header = build_header_snapshot(&g);
                     if let Some(effort) = new_effort {
-                        state.push_system(&format!("Reasoning effort → {}", effort));
+                        state.push_system(&format!("Reasoning effort → {effort}"));
                     } else {
                         state.push_system("Reasoning effort → off");
                     }

--- a/crates/crawler/src/playwright.rs
+++ b/crates/crawler/src/playwright.rs
@@ -92,6 +92,23 @@ async function bootstrap() {
   });
   process.stdout.write(JSON.stringify({ event: 'bridge_bootstrap', ok: true }) + '\n');
 
+  async function bypassTurnstileIfPresent(pg) {
+    let html = await pg.content();
+    if (!html.includes('Checking your browser') && !html.includes('challenge-platform')) {
+      return html;
+    }
+    await pg.mouse.move(120 + Math.random() * 200, 180 + Math.random() * 150);
+    await new Promise(r => setTimeout(r, 500 + Math.random() * 800));
+    await pg.mouse.move(350 + Math.random() * 250, 280 + Math.random() * 180);
+    await new Promise(r => setTimeout(r, 400 + Math.random() * 600));
+    for (let i = 0; i < 16; i++) {
+      await new Promise(r => setTimeout(r, 500));
+      html = await pg.content();
+      if (!html.includes('Checking your browser')) break;
+    }
+    return html;
+  }
+
   const wire = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
   for await (const line of wire) {
     let command;
@@ -109,28 +126,7 @@ async function bootstrap() {
     if (command.action === 'navigate') {
       try {
         await page.goto(command.url, { waitUntil: 'domcontentloaded', timeout: 30000 });
-        let html = await page.content();
-
-        // ── Cloudflare Turnstile bypass ──────────────────────────────
-        // When humanize:true is enabled, page.mouse.move uses Bezier
-        // curves and page interactions are human-like.  CF Turnstile
-        // checks require behavioural signals — scan the page for a
-        // challenge, then simulate idle reading (mouse sweeps) to
-        // satisfy the behavioural model.
-        if (html.includes('Checking your browser') || html.includes('challenge-platform')) {
-          // idle sweep: move cursor like someone skimming the page
-          await page.mouse.move(120 + Math.random() * 200, 180 + Math.random() * 150);
-          await new Promise(r => setTimeout(r, 500 + Math.random() * 800));
-          await page.mouse.move(350 + Math.random() * 250, 280 + Math.random() * 180);
-          await new Promise(r => setTimeout(r, 400 + Math.random() * 600));
-          // poll until turnstile clears (max 8 s)
-          for (let i = 0; i < 16; i++) {
-            await new Promise(r => setTimeout(r, 500));
-            html = await page.content();
-            if (!html.includes('Checking your browser')) break;
-          }
-        }
-        // ─────────────────────────────────────────────────────────────
+        let html = await bypassTurnstileIfPresent(page);
 
         const title = await page.title();
         html = await page.content();
@@ -168,20 +164,7 @@ async function bootstrap() {
         if (command.url) {
           await newPage.goto(command.url, { waitUntil: 'domcontentloaded', timeout: 30000 });
           currentUrl = newPage.url();
-          // ── Cloudflare Turnstile bypass ──
-          let newHtml = await newPage.content();
-          if (newHtml.includes('Checking your browser') || newHtml.includes('challenge-platform')) {
-            await newPage.mouse.move(120 + Math.random() * 200, 180 + Math.random() * 150);
-            await new Promise(r => setTimeout(r, 500 + Math.random() * 800));
-            await newPage.mouse.move(350 + Math.random() * 250, 280 + Math.random() * 180);
-            await new Promise(r => setTimeout(r, 400 + Math.random() * 600));
-            for (let i = 0; i < 16; i++) {
-              await new Promise(r => setTimeout(r, 500));
-              newHtml = await newPage.content();
-              if (!newHtml.includes('Checking your browser')) break;
-            }
-          }
-          // ────────────────────────────────
+          await bypassTurnstileIfPresent(newPage);
         }
         await newPage.bringToFront();
         process.stdout.write(JSON.stringify({

--- a/crates/crawler/src/playwright.rs
+++ b/crates/crawler/src/playwright.rs
@@ -109,8 +109,31 @@ async function bootstrap() {
     if (command.action === 'navigate') {
       try {
         await page.goto(command.url, { waitUntil: 'domcontentloaded', timeout: 30000 });
+        let html = await page.content();
+
+        // ── Cloudflare Turnstile bypass ──────────────────────────────
+        // When humanize:true is enabled, page.mouse.move uses Bezier
+        // curves and page interactions are human-like.  CF Turnstile
+        // checks require behavioural signals — scan the page for a
+        // challenge, then simulate idle reading (mouse sweeps) to
+        // satisfy the behavioural model.
+        if (html.includes('Checking your browser') || html.includes('challenge-platform')) {
+          // idle sweep: move cursor like someone skimming the page
+          await page.mouse.move(120 + Math.random() * 200, 180 + Math.random() * 150);
+          await new Promise(r => setTimeout(r, 500 + Math.random() * 800));
+          await page.mouse.move(350 + Math.random() * 250, 280 + Math.random() * 180);
+          await new Promise(r => setTimeout(r, 400 + Math.random() * 600));
+          // poll until turnstile clears (max 8 s)
+          for (let i = 0; i < 16; i++) {
+            await new Promise(r => setTimeout(r, 500));
+            html = await page.content();
+            if (!html.includes('Checking your browser')) break;
+          }
+        }
+        // ─────────────────────────────────────────────────────────────
+
         const title = await page.title();
-        const html = await page.content();
+        html = await page.content();
         process.stdout.write(JSON.stringify({
           event: 'bridge_response',
           ok: true,
@@ -145,6 +168,20 @@ async function bootstrap() {
         if (command.url) {
           await newPage.goto(command.url, { waitUntil: 'domcontentloaded', timeout: 30000 });
           currentUrl = newPage.url();
+          // ── Cloudflare Turnstile bypass ──
+          let newHtml = await newPage.content();
+          if (newHtml.includes('Checking your browser') || newHtml.includes('challenge-platform')) {
+            await newPage.mouse.move(120 + Math.random() * 200, 180 + Math.random() * 150);
+            await new Promise(r => setTimeout(r, 500 + Math.random() * 800));
+            await newPage.mouse.move(350 + Math.random() * 250, 280 + Math.random() * 180);
+            await new Promise(r => setTimeout(r, 400 + Math.random() * 600));
+            for (let i = 0; i < 16; i++) {
+              await new Promise(r => setTimeout(r, 500));
+              newHtml = await newPage.content();
+              if (!newHtml.includes('Checking your browser')) break;
+            }
+          }
+          // ────────────────────────────────
         }
         await newPage.bringToFront();
         process.stdout.write(JSON.stringify({


### PR DESCRIPTION
## Summary

3 fixes covering TUI auth flow, CLI resume parsing, and Cloudflare anti-bot bypass.

### 655c4ad fix(tui): preserve preset provider context through auth flow
**Problem**: \AuthModal::new()\ accepted \Provider\ (old 3-category enum), losing \ProviderPreset\ info (base_url, provider identity) when user did \/auth deepseek\.
**Fix**: Changed to \AuthModal::new_with_choice()\ accepting \ProviderChoice\ (Legacy/Preset), preserving the full provider context through the auth flow. Also added:
- Base URL display as dimmed hint line in API key input screen (P1)
- \Ctrl+V paste\ hint + character count display in key input (P5)
- Model modal auth guidance tip when provider is unconfigured (P9)

### b7344d6 fix: resume parser rejects slash commands with arguments
**Problem**: \--resume\ with slash commands that take arguments failed (e.g., \--resume session.json /status /compact\). Parser required every trailing arg to start with \/\.
**Fix**: Split by \/\ prefix; non-prefixed args get merged into the preceding command. Only the first residual arg must be a slash command. Added regression test.

### f6fd0a1 feat(crawler): Cloudflare Turnstile bypass via human-like mouse sweeps
**Problem**: \page.goto({ waitUntil: 'domcontentloaded' })\ returned before Cloudflare Turnstile JS challenges resolved. CloakBrowser's \humanize: true\ layer patches \page.mouse.move\ with Bezier curves but \
avigate\ never called interaction methods.
**Fix**: After \page.goto\, detect CF challenge patterns in content → perform idle cursor sweeps via humanized mouse movements → poll every 500ms (max 8s) until challenge clears. Applied to both \
avigate\ and \
ew_page\ handlers.
**Verified**: steamdb.info Cloudflare Turnstile bypassed successfully.

## Test Results
- 424 tests passed, 0 failed, 0 regressions
- Real crawl tests: 6 scenarios all passed