### PR TITLE
fix(installer): install playwright-core alongside cloakbrowser

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -150,16 +150,17 @@ try {
 # --- 10. CloakBrowser install ---
 if ($nodeAvailable) {
     $cloakbrowserDir = Join-Path $ConfigHome "node_modules\cloakbrowser"
-    if (Test-Path $cloakbrowserDir) {
+    $playwrightCoreDir = Join-Path $ConfigHome "node_modules\playwright-core"
+    if ((Test-Path $cloakbrowserDir) -and (Test-Path $playwrightCoreDir)) {
         Write-Host "  CloakBrowser already installed." -ForegroundColor Gray
     } else {
         Write-Host "Installing CloakBrowser..." -ForegroundColor Gray
         try {
-            & npm install --prefix $ConfigHome cloakbrowser 2>&1 | Out-Null
+            & npm install --prefix $ConfigHome cloakbrowser playwright-core 2>&1 | Out-Null
             Write-Host "  CloakBrowser installed." -ForegroundColor Green
         } catch {
             Write-Warning "CloakBrowser installation failed: $_"
-            Write-Warning "You can install it manually later: npm install --prefix `"$ConfigHome`" cloakbrowser"
+            Write-Warning "You can install it manually later: npm install --prefix `"$ConfigHome`" cloakbrowser playwright-core"
         }
     }
 

--- a/install.sh
+++ b/install.sh
@@ -138,15 +138,15 @@ fi
 
 # --- 10. CloakBrowser install ---
 if [ -n "$node_major" ] && [ "$node_major" -ge 20 ]; then
-    if [ -d "${CONFIG_HOME}/node_modules/cloakbrowser" ]; then
+    if [ -d "${CONFIG_HOME}/node_modules/cloakbrowser" ] && [ -d "${CONFIG_HOME}/node_modules/playwright-core" ]; then
         echo "CloakBrowser already installed at ${CONFIG_HOME}/node_modules/cloakbrowser (skipping)"
     else
         echo "Installing CloakBrowser..."
         mkdir -p "$CONFIG_HOME"
-        if npm install --prefix "$CONFIG_HOME" cloakbrowser; then
+        if npm install --prefix "$CONFIG_HOME" cloakbrowser playwright-core; then
             echo "CloakBrowser installed."
         else
-            echo "WARNING: CloakBrowser install failed. Run manually: npm install --prefix \"$CONFIG_HOME\" cloakbrowser"
+            echo "WARNING: CloakBrowser install failed. Run manually: npm install --prefix \"$CONFIG_HOME\" cloakbrowser playwright-core"
         fi
     fi
 


### PR DESCRIPTION
## Summary

- `playwright-core` is an optional peer dependency of `cloakbrowser`, so npm skips it by default — causing the bridge to fail at runtime with `ERR_MODULE_NOT_FOUND`
- Both `install.ps1` and `install.sh` now install `playwright-core` explicitly alongside `cloakbrowser`
- The "already installed" skip check now requires **both** packages to be present, so re-running the installer auto-repairs broken existing installs

## Test plan

- [ ] Fresh install → verify `acrawl` can navigate without the `playwright-core` bridge error
- [ ] Re-run installer on a broken install (cloakbrowser present, playwright-core missing) → verify it reinstalls both
- [ ] Re-run installer on a healthy install → verify it skips with "already installed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)