### PR TITLE
feat: add acrawl uninstall subcommand

### DIFF
--- a/crates/acrawl-cli/src/main.rs
+++ b/crates/acrawl-cli/src/main.rs
@@ -8,9 +8,9 @@ mod markdown;
 mod output_sink;
 mod self_update;
 mod session_mgr;
-mod uninstall;
 mod tool_format;
 mod tui;
+mod uninstall;
 
 use std::collections::BTreeMap;
 use std::env;
@@ -953,7 +953,8 @@ mod tests {
     #[test]
     fn parses_uninstall_with_purge_flag() {
         assert_eq!(
-            parse_args(&["uninstall".to_string(), "--purge".to_string()]).expect("uninstall --purge"),
+            parse_args(&["uninstall".to_string(), "--purge".to_string()])
+                .expect("uninstall --purge"),
             CliAction::Uninstall { purge: true }
         );
     }

--- a/crates/acrawl-cli/src/main.rs
+++ b/crates/acrawl-cli/src/main.rs
@@ -8,6 +8,7 @@ mod markdown;
 mod output_sink;
 mod self_update;
 mod session_mgr;
+mod uninstall;
 mod tool_format;
 mod tui;
 
@@ -101,6 +102,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             let rt = TOKIO_RUNTIME.get().expect("tokio runtime not initialized");
             rt.block_on(self_update::run_self_update())?;
         }
+        CliAction::Uninstall { purge } => uninstall::run_uninstall(purge)?,
         CliAction::Repl {
             model,
             allowed_tools,
@@ -137,6 +139,9 @@ enum CliAction {
     },
     Init,
     Update,
+    Uninstall {
+        purge: bool,
+    },
     Repl {
         model: Option<String>,
         allowed_tools: Option<AllowedToolSet>,
@@ -287,6 +292,9 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
         }
         "init" => Ok(CliAction::Init),
         "update" => Ok(CliAction::Update),
+        "uninstall" => Ok(CliAction::Uninstall {
+            purge: rest.iter().any(|a| a == "--purge"),
+        }),
         "prompt" => {
             let prompt = rest[1..].join(" ");
             if prompt.trim().is_empty() {
@@ -512,6 +520,12 @@ fn print_help_to(out: &mut impl Write) -> io::Result<()> {
         "      Configure credentials for a provider interactively"
     )?;
     writeln!(out, "  acrawl init")?;
+    writeln!(out, "  acrawl update")?;
+    writeln!(out, "  acrawl uninstall [--purge]")?;
+    writeln!(
+        out,
+        "      Remove acrawl. --purge also deletes settings, credentials, and sessions"
+    )?;
     writeln!(out)?;
     writeln!(out, "Flags:")?;
     writeln!(
@@ -926,5 +940,30 @@ mod tests {
                 provider: Some("openai".to_string())
             }
         );
+    }
+
+    #[test]
+    fn parses_uninstall_subcommand() {
+        assert_eq!(
+            parse_args(&["uninstall".to_string()]).expect("uninstall"),
+            CliAction::Uninstall { purge: false }
+        );
+    }
+
+    #[test]
+    fn parses_uninstall_with_purge_flag() {
+        assert_eq!(
+            parse_args(&["uninstall".to_string(), "--purge".to_string()]).expect("uninstall --purge"),
+            CliAction::Uninstall { purge: true }
+        );
+    }
+
+    #[test]
+    fn uninstall_help_mentions_purge() {
+        let mut help = Vec::new();
+        print_help_to(&mut help).expect("help should render");
+        let help = String::from_utf8(help).expect("help should be utf8");
+        assert!(help.contains("acrawl uninstall"));
+        assert!(help.contains("--purge"));
     }
 }

--- a/crates/acrawl-cli/src/uninstall.rs
+++ b/crates/acrawl-cli/src/uninstall.rs
@@ -48,7 +48,7 @@ pub fn run_uninstall(purge: bool) -> Result<(), Box<dyn std::error::Error>> {
         remove_dir_if_exists(&config_home.join("sessions"), "sessions")?;
     }
 
-    remove_binary(&current_exe)?;
+    remove_binary(&current_exe);
 
     #[cfg(target_os = "windows")]
     if let Some(bin_dir) = current_exe.parent() {
@@ -77,7 +77,7 @@ pub fn run_uninstall(purge: bool) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn remove_binary(current_exe: &Path) -> Result<(), Box<dyn std::error::Error>> {
+fn remove_binary(current_exe: &Path) {
     if cfg!(target_os = "windows") {
         let old_path = current_exe.with_extension("exe.old");
         if fs::rename(current_exe, &old_path).is_ok() {
@@ -105,7 +105,6 @@ fn remove_binary(current_exe: &Path) -> Result<(), Box<dyn std::error::Error>> {
             ),
         }
     }
-    Ok(())
 }
 
 fn remove_file_if_exists(path: &Path, label: &str) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/acrawl-cli/src/uninstall.rs
+++ b/crates/acrawl-cli/src/uninstall.rs
@@ -16,8 +16,14 @@ pub fn run_uninstall(purge: bool) -> Result<(), Box<dyn std::error::Error>> {
         println!("  node_modules: {}", node_modules.display());
     }
     if purge {
-        println!("  Settings:     {}", config_home.join("settings.json").display());
-        println!("  Credentials:  {}", config_home.join("credentials.json").display());
+        println!(
+            "  Settings:     {}",
+            config_home.join("settings.json").display()
+        );
+        println!(
+            "  Credentials:  {}",
+            config_home.join("credentials.json").display()
+        );
         println!("  Sessions:     {}", config_home.join("sessions").display());
     }
     println!();

--- a/crates/acrawl-cli/src/uninstall.rs
+++ b/crates/acrawl-cli/src/uninstall.rs
@@ -1,0 +1,139 @@
+use std::env;
+use std::fs;
+use std::io::{self, Write};
+use std::path::Path;
+
+use runtime::config_home_dir;
+
+pub fn run_uninstall(purge: bool) -> Result<(), Box<dyn std::error::Error>> {
+    let config_home = config_home_dir();
+    let current_exe = env::current_exe()?;
+
+    println!("This will remove:");
+    println!("  Binary:       {}", current_exe.display());
+    let node_modules = config_home.join("node_modules");
+    if node_modules.exists() {
+        println!("  node_modules: {}", node_modules.display());
+    }
+    if purge {
+        println!("  Settings:     {}", config_home.join("settings.json").display());
+        println!("  Credentials:  {}", config_home.join("credentials.json").display());
+        println!("  Sessions:     {}", config_home.join("sessions").display());
+    }
+    println!();
+
+    print!("Uninstall acrawl? (y/N): ");
+    io::stdout().flush()?;
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+    if !matches!(input.trim(), "y" | "Y") {
+        println!("Aborted.");
+        return Ok(());
+    }
+
+    if node_modules.exists() {
+        fs::remove_dir_all(&node_modules)?;
+        println!("Removed node_modules.");
+    }
+
+    if purge {
+        remove_file_if_exists(&config_home.join("settings.json"), "settings")?;
+        remove_file_if_exists(&config_home.join("credentials.json"), "credentials")?;
+        remove_dir_if_exists(&config_home.join("sessions"), "sessions")?;
+    }
+
+    remove_binary(&current_exe)?;
+
+    #[cfg(target_os = "windows")]
+    if let Some(bin_dir) = current_exe.parent() {
+        remove_from_windows_path(bin_dir);
+    }
+
+    if let Some(bin_dir) = current_exe.parent() {
+        let _ = fs::remove_dir(bin_dir);
+    }
+    if purge {
+        match fs::remove_dir_all(&config_home) {
+            Ok(()) => println!("Removed config directory: {}", config_home.display()),
+            Err(_) => {
+                let _ = fs::remove_dir(&config_home);
+            }
+        }
+    } else {
+        let _ = fs::remove_dir(&config_home);
+    }
+
+    println!("\nacrawl uninstalled successfully.");
+    if cfg!(target_os = "windows") {
+        println!("Restart your terminal for PATH changes to take effect.");
+    }
+
+    Ok(())
+}
+
+fn remove_binary(current_exe: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    if cfg!(target_os = "windows") {
+        let old_path = current_exe.with_extension("exe.old");
+        if fs::rename(current_exe, &old_path).is_ok() {
+            let _ = fs::remove_file(&old_path);
+            if old_path.exists() {
+                println!(
+                    "Binary renamed to {} — delete it after this process exits.",
+                    old_path.display()
+                );
+            } else {
+                println!("Removed binary: {}", current_exe.display());
+            }
+        } else {
+            println!(
+                "Warning: could not remove binary {} — delete it manually after this process exits.",
+                current_exe.display()
+            );
+        }
+    } else {
+        match fs::remove_file(current_exe) {
+            Ok(()) => println!("Removed binary: {}", current_exe.display()),
+            Err(e) => println!(
+                "Warning: could not remove binary {}: {e}",
+                current_exe.display()
+            ),
+        }
+    }
+    Ok(())
+}
+
+fn remove_file_if_exists(path: &Path, label: &str) -> Result<(), Box<dyn std::error::Error>> {
+    if path.exists() {
+        fs::remove_file(path)?;
+        println!("Removed {label}.");
+    }
+    Ok(())
+}
+
+fn remove_dir_if_exists(path: &Path, label: &str) -> Result<(), Box<dyn std::error::Error>> {
+    if path.exists() {
+        fs::remove_dir_all(path)?;
+        println!("Removed {label}.");
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn remove_from_windows_path(bin_dir: &Path) {
+    let bin_str = bin_dir.to_string_lossy();
+    let script = format!(
+        "$p = [Environment]::GetEnvironmentVariable('Path','User'); \
+         $new = ($p -split ';' | Where-Object {{ $_ -ne '{bin_str}' }}) -join ';'; \
+         [Environment]::SetEnvironmentVariable('Path',$new,'User')"
+    );
+    let ok = std::process::Command::new("powershell")
+        .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+        .status()
+        .is_ok_and(|s| s.success());
+    if ok {
+        println!("Removed from PATH.");
+    } else {
+        println!("Warning: could not remove {bin_str} from PATH automatically.");
+        println!("  Remove it manually from your user environment variables.");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `acrawl uninstall` as a first-class CLI subcommand
- `acrawl uninstall` prompts for confirmation, then removes the binary, `node_modules` (browser automation), PATH entry (Windows), and the config home dir if empty
- `acrawl uninstall --purge` also deletes `settings.json`, `credentials.json`, and `sessions/` for a complete wipe
- Workspace files (`./workspace/`) and project-level `.acrawl/` dirs are never touched
- On Windows, the running binary is renamed to `.old` (deleted if possible) and the User PATH entry is removed via PowerShell

## Test plan

- [ ] `acrawl uninstall` → confirm with `y` → binary, node_modules, and PATH entry removed
- [ ] `acrawl uninstall --purge` → entire `~/.acrawl/` dir removed
- [ ] `acrawl uninstall` → answer `n` → nothing deleted
- [ ] Run when acrawl not installed → graceful warnings, exits cleanly
- [ ] `acrawl --help` → shows `acrawl uninstall [--purge]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)