### PR TITLE
Security and correctness pass from code review

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,8 +107,16 @@ jobs:
         id: notes
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          # Extract the section between ## [VERSION] and the next ## [
-          NOTES=$(awk "/^## \\[${VERSION}\\]/{found=1; next} /^## \\[/{if(found) exit} found{print}" CHANGELOG.md)
+          # Extract the section between `## [VERSION]` and the next `## [...]`.
+          # Pass VERSION via -v so its characters are treated literally — embedding
+          # it inside the awk pattern would let regex metacharacters in a tag
+          # name break or silently broaden the match.
+          NOTES=$(awk -v ver="$VERSION" '
+            BEGIN { header = "## [" ver "]" }
+            index($0, header) == 1 { found=1; next }
+            /^## \[/ { if (found) exit }
+            found { print }
+          ' CHANGELOG.md)
           if [ -z "$NOTES" ]; then
             NOTES="Release ${GITHUB_REF_NAME}"
           fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,7 @@ dependencies = [
  "textwrap",
  "tokio",
  "unicode-width",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/acrawl-cli/Cargo.toml
+++ b/crates/acrawl-cli/Cargo.toml
@@ -23,6 +23,7 @@ ratatui = "0.30.0"
 textwrap = "0.16"
 pulldown-cmark = "0.13"
 unicode-width = "0.2"
+zeroize = "1"
 
 [lints]
 workspace = true

--- a/crates/acrawl-cli/src/app/api_client.rs
+++ b/crates/acrawl-cli/src/app/api_client.rs
@@ -282,11 +282,20 @@ pub(super) fn convert_messages(messages: &[ConversationMessage]) -> Vec<InputMes
                         InputContentBlock::Text { text: text.clone() }
                     }
                     runtime::ContentBlock::ToolUse { id, name, input } => {
+                        // If the model handed us non-JSON tool input we still
+                        // forward it (wrapped in {"raw": ...}) so the request
+                        // continues, but log to stderr so the parse failure
+                        // doesn't disappear into the void.
+                        let parsed_input = serde_json::from_str(input).unwrap_or_else(|err| {
+                            eprintln!(
+                                "warning: tool-use input for `{name}` (id `{id}`) was not valid JSON ({err}); forwarding as {{\"raw\": ...}}"
+                            );
+                            json!({ "raw": input })
+                        });
                         InputContentBlock::ToolUse {
                             id: id.clone(),
                             name: name.clone(),
-                            input: serde_json::from_str(input)
-                                .unwrap_or_else(|_| json!({ "raw": input })),
+                            input: parsed_input,
                         }
                     }
                     runtime::ContentBlock::ToolResult {

--- a/crates/acrawl-cli/src/app/mod.rs
+++ b/crates/acrawl-cli/src/app/mod.rs
@@ -514,10 +514,14 @@ impl LiveCli {
 
     pub(crate) fn persist_session(&mut self) -> Result<(), CliError> {
         if self.runtime.session().title.is_none() {
-            if let Ok(mut guard) = self.pending_title.lock() {
-                if let Some(title) = guard.take() {
-                    self.runtime.session_mut().title = Some(title);
-                }
+            // Recover from a poisoned mutex (e.g. title-generation thread
+            // panicked) instead of silently dropping the pending title.
+            let mut guard = self
+                .pending_title
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if let Some(title) = guard.take() {
+                self.runtime.session_mut().title = Some(title);
             }
         }
         self.runtime.session().save_to_path(&self.session.path)?;

--- a/crates/acrawl-cli/src/auth/anthropic.rs
+++ b/crates/acrawl-cli/src/auth/anthropic.rs
@@ -102,8 +102,12 @@ pub(crate) fn run_login() -> Result<(), Box<dyn std::error::Error>> {
     let client = AnthropicClient::from_auth(AuthSource::None);
     let exchange_request =
         OAuthTokenExchangeRequest::from_config(oauth, code, state, pkce.verifier, redirect_uri);
-    let rt = tokio::runtime::Runtime::new()?;
-    let token_set = rt.block_on(client.exchange_oauth_code(oauth, &exchange_request))?;
+    // Reuse the process-wide tokio runtime instead of spinning up a fresh
+    // one per OAuth attempt (which leaks threads on repeated retries).
+    let runtime = crate::TOKIO_RUNTIME
+        .get()
+        .ok_or_else(|| io::Error::other("tokio runtime not initialised"))?;
+    let token_set = runtime.block_on(client.exchange_oauth_code(oauth, &exchange_request))?;
     save_oauth_credentials(&runtime::OAuthTokenSet {
         access_token: token_set.access_token,
         refresh_token: token_set.refresh_token,

--- a/crates/acrawl-cli/src/auth/mod.rs
+++ b/crates/acrawl-cli/src/auth/mod.rs
@@ -13,6 +13,21 @@ use super::Provider;
 
 pub(crate) use anthropic::default_oauth_config;
 
+/// Load the credentials store, warning to stderr if the file existed but
+/// failed to parse so users notice a corrupted credentials file instead of
+/// silently getting an empty store and a fresh re-auth prompt.
+pub(crate) fn load_credentials_or_warn() -> api::CredentialStore {
+    match api::load_credentials() {
+        Ok(store) => store,
+        Err(err) => {
+            eprintln!(
+                "warning: failed to load credentials ({err}); starting from an empty store"
+            );
+            api::CredentialStore::default()
+        }
+    }
+}
+
 /// Bind a TCP listener for the OAuth callback on `preferred_port`.
 /// Retries briefly in case the port is stuck in `TIME_WAIT` from a prior
 /// session, then returns a clear error if still occupied.
@@ -72,7 +87,7 @@ pub(crate) fn persist_provider_credentials(
     provider: Provider,
     mut config: api::StoredProviderConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let mut store = api::load_credentials().unwrap_or_default();
+    let mut store = load_credentials_or_warn();
     let provider_name = provider_label(provider).to_string();
     if config.default_model.is_none() {
         config.default_model = store
@@ -90,7 +105,7 @@ pub(crate) fn persist_preset_credentials(
     preset_id: &str,
     mut config: api::StoredProviderConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let mut store = api::load_credentials().unwrap_or_default();
+    let mut store = load_credentials_or_warn();
     let key = preset_id.to_string();
     if config.default_model.is_none() {
         config.default_model = store

--- a/crates/acrawl-cli/src/auth/mod.rs
+++ b/crates/acrawl-cli/src/auth/mod.rs
@@ -501,12 +501,26 @@ pub(crate) fn wait_for_oauth_callback_cancellable(
         .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send>)?;
 
     let deadline = std::time::Instant::now() + std::time::Duration::from_mins(5);
+    // Emit a progress line every 30s so a slow network or IdP doesn't look
+    // like a hang. Track when we last printed instead of dividing remaining
+    // time, so the first message lands ~30s in rather than at startup.
+    let mut last_status = std::time::Instant::now();
+    let status_interval = std::time::Duration::from_secs(30);
     loop {
-        if std::time::Instant::now() >= deadline {
+        let now = std::time::Instant::now();
+        if now >= deadline {
             return Err(Box::new(io::Error::new(
                 io::ErrorKind::TimedOut,
                 "OAuth callback timed out after 5 minutes",
             )));
+        }
+        if now.duration_since(last_status) >= status_interval {
+            let remaining = deadline.saturating_duration_since(now);
+            eprintln!(
+                "Waiting for OAuth callback ({}s remaining; press Ctrl+C to cancel)...",
+                remaining.as_secs()
+            );
+            last_status = now;
         }
         if cancel_rx.try_recv().is_ok() {
             return Err(Box::new(io::Error::new(

--- a/crates/acrawl-cli/src/auth/mod.rs
+++ b/crates/acrawl-cli/src/auth/mod.rs
@@ -20,9 +20,7 @@ pub(crate) fn load_credentials_or_warn() -> api::CredentialStore {
     match api::load_credentials() {
         Ok(store) => store,
         Err(err) => {
-            eprintln!(
-                "warning: failed to load credentials ({err}); starting from an empty store"
-            );
+            eprintln!("warning: failed to load credentials ({err}); starting from an empty store");
             api::CredentialStore::default()
         }
     }

--- a/crates/acrawl-cli/src/auth/openai.rs
+++ b/crates/acrawl-cli/src/auth/openai.rs
@@ -73,9 +73,13 @@ pub(super) fn run_openai_login() -> Result<(), Box<dyn std::error::Error>> {
         login_req.pkce.verifier,
         login_req.redirect_uri,
     );
-    let rt = tokio::runtime::Runtime::new()?;
+    // Reuse the process-wide tokio runtime instead of spinning up a fresh
+    // one per OAuth attempt (which leaks threads on repeated retries).
+    let runtime = crate::TOKIO_RUNTIME
+        .get()
+        .ok_or_else(|| std::io::Error::other("tokio runtime not initialised"))?;
     let token_set =
-        rt.block_on(client.exchange_oauth_code(&login_req.config, &exchange_request))?;
+        runtime.block_on(client.exchange_oauth_code(&login_req.config, &exchange_request))?;
     persist_provider_credentials(
         Provider::OpenAi,
         api::StoredProviderConfig {

--- a/crates/acrawl-cli/src/main.rs
+++ b/crates/acrawl-cli/src/main.rs
@@ -417,6 +417,37 @@ fn parse_resume_args(args: &[String]) -> Result<CliAction, String> {
             "--resume trailing arguments must be slash commands (got '{bad}')"
         ));
     }
+    // Validate the head of each grouped command against the resume-safe
+    // command set. The previous parser only checked that each token started
+    // with '/', so `--resume session.json /not-a-command` would parse
+    // successfully and then fail at runtime with a confusing error.
+    let resume_supported: Vec<&'static str> = resume_supported_slash_commands()
+        .iter()
+        .map(|spec| spec.name)
+        .collect();
+    for command in &commands {
+        let head = command
+            .trim_start()
+            .trim_start_matches('/')
+            .split_whitespace()
+            .next()
+            .unwrap_or("");
+        if head.is_empty() {
+            return Err(format!("--resume command is missing a name (got '{command}')"));
+        }
+        let head_lower = head.to_ascii_lowercase();
+        if !resume_supported.iter().any(|name| *name == head_lower) {
+            return Err(format!(
+                "--resume command '/{head}' is not a recognised resume-safe slash command \
+                 (supported: {})",
+                resume_supported
+                    .iter()
+                    .map(|n| format!("/{n}"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+    }
     Ok(CliAction::ResumeSession {
         session_path,
         commands,
@@ -815,6 +846,40 @@ mod tests {
                     "/cost".to_string(),
                 ],
             }
+        );
+    }
+
+    #[test]
+    fn rejects_resume_unknown_slash_command() {
+        // Previously, anything starting with `/` was accepted by the resume
+        // parser and the failure only surfaced at runtime with a confusing
+        // error. Validate eagerly against the resume-safe spec list.
+        let args = vec![
+            "--resume".to_string(),
+            "session.json".to_string(),
+            "/not-a-command".to_string(),
+        ];
+        let err = parse_args(&args).expect_err("unknown command must be rejected");
+        assert!(
+            err.contains("not a recognised resume-safe slash command"),
+            "{err}"
+        );
+        assert!(err.contains("/not-a-command"), "{err}");
+    }
+
+    #[test]
+    fn rejects_resume_command_known_but_not_resume_safe() {
+        // `/model` exists but is not in resume_supported_slash_commands(); it
+        // mutates session-level config in a way that's not safe at replay.
+        let args = vec![
+            "--resume".to_string(),
+            "session.json".to_string(),
+            "/auth".to_string(),
+        ];
+        let err = parse_args(&args).expect_err("non-resume-safe command must be rejected");
+        assert!(
+            err.contains("not a recognised resume-safe slash command"),
+            "{err}"
         );
     }
 

--- a/crates/acrawl-cli/src/main.rs
+++ b/crates/acrawl-cli/src/main.rs
@@ -433,7 +433,9 @@ fn parse_resume_args(args: &[String]) -> Result<CliAction, String> {
             .next()
             .unwrap_or("");
         if head.is_empty() {
-            return Err(format!("--resume command is missing a name (got '{command}')"));
+            return Err(format!(
+                "--resume command is missing a name (got '{command}')"
+            ));
         }
         let head_lower = head.to_ascii_lowercase();
         if !resume_supported.iter().any(|name| *name == head_lower) {

--- a/crates/acrawl-cli/src/tui/active_modal.rs
+++ b/crates/acrawl-cli/src/tui/active_modal.rs
@@ -76,7 +76,7 @@ impl ActiveModal {
         }
     }
 
-    pub fn as_model(&self) -> Option<&ModelModal> {
+    pub fn as_model_mut(&mut self) -> Option<&mut ModelModal> {
         match self {
             Self::Model(modal) => Some(modal),
             _ => None,

--- a/crates/acrawl-cli/src/tui/auth_modal.rs
+++ b/crates/acrawl-cli/src/tui/auth_modal.rs
@@ -299,7 +299,7 @@ impl AuthModal {
                 (p.id, url)
             }
         };
-        let mut store = api::credentials::load_credentials().unwrap_or_default();
+        let mut store = crate::auth::load_credentials_or_warn();
         let mut config = store
             .providers
             .get(provider_str)
@@ -324,7 +324,7 @@ impl AuthModal {
         if model_id.trim().is_empty() {
             return;
         }
-        let mut store = api::credentials::load_credentials().unwrap_or_default();
+        let mut store = crate::auth::load_credentials_or_warn();
         let provider_str = match provider {
             ProviderKind::Anthropic => "anthropic",
             ProviderKind::OpenAi => "openai",

--- a/crates/acrawl-cli/src/tui/auth_modal.rs
+++ b/crates/acrawl-cli/src/tui/auth_modal.rs
@@ -2,11 +2,11 @@ use std::sync::mpsc::Sender;
 use std::thread;
 
 use crossterm::event::{KeyCode, KeyEvent};
-use zeroize::Zeroizing;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph, Wrap};
+use zeroize::Zeroizing;
 
 use crate::display_width::{prefix_display_width, text_display_width};
 use crate::tui::modal::{draw_modal_frame, should_passthrough_key, Modal, ModalAction};

--- a/crates/acrawl-cli/src/tui/auth_modal.rs
+++ b/crates/acrawl-cli/src/tui/auth_modal.rs
@@ -365,13 +365,25 @@ impl AuthModal {
                 "api_key".to_string()
             }
         };
-        // Move the inner String into the config. `key` (Zeroizing<String>) is
-        // dropped at function exit and wipes the local copy. The serialized
-        // JSON written to disk lives only inside save_credentials.
+        // Three heap copies of the API key are in play here:
+        //   1. `key` (Zeroizing<String>): the modal-owned buffer — wiped on
+        //      function exit by `Zeroizing`'s Drop impl.
+        //   2. `config.api_key`: the clone we hand to `set_provider_config`;
+        //      we wipe it via `Zeroize::zeroize` after the disk write so the
+        //      `store` doesn't outlive this function carrying the key bytes.
+        //   3. The serialized JSON inside `save_credentials_to_path`: wrapped
+        //      in `Zeroizing` over there so it's wiped before that function
+        //      returns.
         config.api_key = Some((*key).clone());
         config.base_url = base_url.or(preset_base_url);
         api::credentials::set_provider_config(&mut store, provider_str, config);
         let _ = api::credentials::save_credentials(&store);
+        if let Some(cfg) = store.providers.get_mut(provider_str) {
+            if let Some(saved_key) = cfg.api_key.as_mut() {
+                use zeroize::Zeroize;
+                saved_key.zeroize();
+            }
+        }
     }
 
     fn save_default_model(provider: ProviderKind, model_id: &str) {

--- a/crates/acrawl-cli/src/tui/auth_modal.rs
+++ b/crates/acrawl-cli/src/tui/auth_modal.rs
@@ -2,6 +2,7 @@ use std::sync::mpsc::Sender;
 use std::thread;
 
 use crossterm::event::{KeyCode, KeyEvent};
+use zeroize::Zeroizing;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
@@ -76,7 +77,10 @@ pub(crate) enum AuthModalStep {
     ApiKeyInput {
         provider: ProviderKind,
         base_url: Option<String>,
-        key_buffer: String,
+        // Wrapped so the heap-allocated bytes are zeroed when the modal
+        // transitions out of this step (or is dropped), keeping the API key
+        // out of memory past the moment it's saved.
+        key_buffer: Zeroizing<String>,
         cursor: usize,
         masked: bool,
         error: Option<String>,
@@ -152,7 +156,7 @@ impl AuthModal {
                 crate::app::Provider::OpenAi => AuthModalStep::ApiKeyInput {
                     provider: ProviderKind::OpenAi,
                     base_url: None,
-                    key_buffer: String::new(),
+                    key_buffer: Zeroizing::new(String::new()),
                     cursor: 0,
                     masked: true,
                     error: None,
@@ -281,7 +285,7 @@ impl AuthModal {
         }
     }
 
-    fn save_api_key(provider: ProviderKind, base_url: Option<String>, key: String) {
+    fn save_api_key(provider: ProviderKind, base_url: Option<String>, key: Zeroizing<String>) {
         let (provider_str, preset_base_url): (&str, Option<String>) = match provider {
             ProviderKind::Anthropic => ("anthropic", None),
             ProviderKind::OpenAi => ("openai", None),
@@ -307,7 +311,10 @@ impl AuthModal {
                 "api_key".to_string()
             }
         };
-        config.api_key = Some(key);
+        // Move the inner String into the config. `key` (Zeroizing<String>) is
+        // dropped at function exit and wipes the local copy. The serialized
+        // JSON written to disk lives only inside save_credentials.
+        config.api_key = Some((*key).clone());
         config.base_url = base_url.or(preset_base_url);
         api::credentials::set_provider_config(&mut store, provider_str, config);
         let _ = api::credentials::save_credentials(&store);
@@ -573,10 +580,10 @@ impl Modal for AuthModal {
                 error,
                 ..
             } => {
-                let display_key = if *masked {
+                let display_key: String = if *masked {
                     "*".repeat(key_buffer.chars().count())
                 } else {
-                    key_buffer.clone()
+                    (**key_buffer).clone()
                 };
                 let mut lines = vec![
                     Line::from("Paste your API key:"),
@@ -840,7 +847,7 @@ impl Modal for AuthModal {
                                 self.step = AuthModalStep::ApiKeyInput {
                                     provider: ProviderKind::Preset(preset),
                                     base_url: None,
-                                    key_buffer: String::new(),
+                                    key_buffer: Zeroizing::new(String::new()),
                                     cursor: 0,
                                     masked: true,
                                     error: None,
@@ -882,7 +889,7 @@ impl Modal for AuthModal {
                             self.step = AuthModalStep::ApiKeyInput {
                                 provider: *provider,
                                 base_url: None,
-                                key_buffer: String::new(),
+                                key_buffer: Zeroizing::new(String::new()),
                                 cursor: 0,
                                 masked: true,
                                 error: None,
@@ -960,7 +967,7 @@ impl Modal for AuthModal {
                         self.step = AuthModalStep::ApiKeyInput {
                             provider: ProviderKind::Other,
                             base_url: Some(input.clone()),
-                            key_buffer: String::new(),
+                            key_buffer: Zeroizing::new(String::new()),
                             cursor: 0,
                             masked: true,
                             error: None,
@@ -1383,7 +1390,7 @@ mod tests {
             AuthModalStep::ApiKeyInput {
                 key_buffer, error, ..
             } => {
-                assert_eq!(key_buffer, "sk");
+                assert_eq!(key_buffer.as_str(), "sk");
                 assert_eq!(error, &None);
             }
             _ => panic!("expected api key input step"),
@@ -1402,7 +1409,9 @@ mod tests {
             ModalAction::Consumed
         );
         match &modal.step {
-            AuthModalStep::ApiKeyInput { key_buffer, .. } => assert_eq!(key_buffer, "s"),
+            AuthModalStep::ApiKeyInput { key_buffer, .. } => {
+                assert_eq!(key_buffer.as_str(), "s");
+            }
             _ => panic!("expected api key input step"),
         }
     }

--- a/crates/acrawl-cli/src/tui/auth_modal.rs
+++ b/crates/acrawl-cli/src/tui/auth_modal.rs
@@ -203,7 +203,9 @@ impl AuthModal {
         match provider {
             ProviderKind::Anthropic => {
                 let key = config.api_key.unwrap_or_default();
-                let runtime = tokio::runtime::Runtime::new().map_err(|e| e.to_string())?;
+                let runtime = crate::TOKIO_RUNTIME
+                    .get()
+                    .ok_or_else(|| "tokio runtime not initialised".to_string())?;
                 runtime
                     .block_on(api::models::list_anthropic_models(&key))
                     .map(|models| {
@@ -218,7 +220,9 @@ impl AuthModal {
                     .map_err(|e| e.to_string())
             }
             ProviderKind::OpenAi => {
-                let runtime = tokio::runtime::Runtime::new().map_err(|e| e.to_string())?;
+                let runtime = crate::TOKIO_RUNTIME
+                    .get()
+                    .ok_or_else(|| "tokio runtime not initialised".to_string())?;
                 if config.auth_method == "oauth" {
                     runtime
                         .block_on(api::models::list_models_dev("openai"))
@@ -260,7 +264,9 @@ impl AuthModal {
             }
             ProviderKind::Other => Ok(vec![]),
             ProviderKind::Preset(p) => {
-                let runtime = tokio::runtime::Runtime::new().map_err(|e| e.to_string())?;
+                let runtime = crate::TOKIO_RUNTIME
+                    .get()
+                    .ok_or_else(|| "tokio runtime not initialised".to_string())?;
                 let models = runtime
                     .block_on(api::models::list_models_dev(p.id))
                     .unwrap_or_default();

--- a/crates/acrawl-cli/src/tui/auth_modal.rs
+++ b/crates/acrawl-cli/src/tui/auth_modal.rs
@@ -184,6 +184,7 @@ impl AuthModal {
         }
     }
 
+    #[allow(clippy::too_many_lines)]
     fn fetch_models_for_provider(
         provider: ProviderKind,
     ) -> Result<Vec<crate::tui::model_list::ModelInfo>, String> {
@@ -291,6 +292,9 @@ impl AuthModal {
         }
     }
 
+    // Take `key` by value (not by reference) so its heap allocation is dropped
+    // — and zeroed — by the time this function returns.
+    #[allow(clippy::needless_pass_by_value)]
     fn save_api_key(provider: ProviderKind, base_url: Option<String>, key: Zeroizing<String>) {
         let (provider_str, preset_base_url): (&str, Option<String>) = match provider {
             ProviderKind::Anthropic => ("anthropic", None),

--- a/crates/acrawl-cli/src/tui/model_modal.rs
+++ b/crates/acrawl-cli/src/tui/model_modal.rs
@@ -162,8 +162,11 @@ impl ModelModal {
         }
     }
 
-    pub fn outcome(&self) -> &ModelModalOutcome {
-        &self.outcome
+    /// Consume the pending outcome, replacing it with `None`, so a single
+    /// Enter press can't be observed twice (and applied twice) by callers
+    /// that re-inspect the modal on the next event.
+    pub fn take_outcome(&mut self) -> ModelModalOutcome {
+        std::mem::replace(&mut self.outcome, ModelModalOutcome::None)
     }
 
     fn visible_rows(&self) -> (Vec<RowKind<'_>>, usize, usize) {

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -2292,7 +2292,14 @@ fn run_loop(
                     }
                 }
 
-                if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+                if state.active_modal.is_none()
+                    && key.code == KeyCode::Char('c')
+                    && key.modifiers.contains(KeyModifiers::CONTROL)
+                {
+                    // Only honour Ctrl+C as a global cancel/exit when no modal
+                    // is open. Cancelling here while e.g. an AuthModal is mid
+                    // OAuth flow would orphan its callback thread; the modal
+                    // owns its own cancel path (Esc, or its cancel_tx).
                     if state.busy {
                         cancel_flag.request_cancel();
                         if let Some(registry) = &state.child_control_registry {

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -42,7 +42,7 @@ const MAX_INPUT_LINES: usize = 5;
 const MAX_EVENTS_PER_FRAME: usize = 256;
 /// Cap on the typewriter backlog. If the producer overruns this, flush the
 /// queue straight to the transcript (skipping the slow per-char reveal) so the
-/// VecDeque can't grow unbounded.
+/// `VecDeque` can't grow unbounded.
 const MAX_TYPEWRITER_BACKLOG: usize = 64 * 1024;
 pub(super) const WELCOME_BOX_SIDE_GUTTER: u16 = 16;
 pub(super) const WELCOME_BOX_MAX_WIDTH: u16 = 82;

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -37,6 +37,13 @@ use ratatui::DefaultTerminal;
 use runtime::ControlState;
 
 const MAX_INPUT_LINES: usize = 5;
+/// Cap on events processed in a single `drain_events` call so a producer that
+/// emits faster than the typewriter reveals can't starve the render loop.
+const MAX_EVENTS_PER_FRAME: usize = 256;
+/// Cap on the typewriter backlog. If the producer overruns this, flush the
+/// queue straight to the transcript (skipping the slow per-char reveal) so the
+/// VecDeque can't grow unbounded.
+const MAX_TYPEWRITER_BACKLOG: usize = 64 * 1024;
 pub(super) const WELCOME_BOX_SIDE_GUTTER: u16 = 16;
 pub(super) const WELCOME_BOX_MAX_WIDTH: u16 = 82;
 pub(super) const WELCOME_BOX_MIN_WIDTH: u16 = 30;
@@ -849,12 +856,19 @@ impl ReplTuiState {
 
     #[allow(clippy::too_many_lines)]
     fn drain_events(&mut self, rx: &Receiver<ReplTuiEvent>) {
-        while let Ok(ev) = rx.try_recv() {
+        for _ in 0..MAX_EVENTS_PER_FRAME {
+            let Ok(ev) = rx.try_recv() else { break };
             match ev {
                 ReplTuiEvent::StreamText(s) => {
                     // Enqueue raw chars for typewriter reveal.
                     for c in s.chars() {
                         self.typewriter.chars.push_back(c);
+                    }
+                    // If the producer is faster than the reveal can keep up,
+                    // bypass the slow per-char reveal so the queue doesn't
+                    // grow unbounded.
+                    if self.typewriter.chars.len() > MAX_TYPEWRITER_BACKLOG {
+                        self.flush_typewriter();
                     }
                 }
                 ReplTuiEvent::TurnStarting => {

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -950,8 +950,7 @@ impl ReplTuiState {
                                     }
                                 };
 
-                                let mut store =
-                                    api::credentials::load_credentials().unwrap_or_default();
+                                let mut store = crate::auth::load_credentials_or_warn();
                                 let provider_str = match provider_kind {
                                     crate::tui::auth_modal::ProviderKind::Anthropic => "anthropic",
                                     crate::tui::auth_modal::ProviderKind::OpenAi => "openai",
@@ -1529,7 +1528,7 @@ fn spawn_anthropic_oauth_thread(
             let token_set = rt
                 .block_on(client.exchange_oauth_code(&oauth, &exchange))
                 .map_err(|e| Box::new(std::io::Error::other(e.to_string())) as _)?;
-            let mut store = api::credentials::load_credentials().unwrap_or_default();
+            let mut store = crate::auth::load_credentials_or_warn();
             api::credentials::set_provider_config(
                 &mut store,
                 "anthropic",
@@ -1640,7 +1639,7 @@ fn spawn_openai_oauth_thread(ui_tx: Sender<ReplTuiEvent>, active_modal: &mut Opt
                 scopes: token_set.scopes,
                 account_id,
             };
-            let mut store = api::credentials::load_credentials().unwrap_or_default();
+            let mut store = crate::auth::load_credentials_or_warn();
             let mut cfg = store.providers.get("openai").cloned().unwrap_or_default();
             cfg.auth_method = "oauth".to_string();
             cfg.oauth = Some(oauth_tokens);

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -2146,8 +2146,14 @@ fn run_loop(
                         } => Some(*provider),
                         _ => None,
                     });
-                    if let Some(m) = modal.as_model() {
-                        model_outcome = Some(m.outcome().clone());
+                    if let Some(m) = modal.as_model_mut() {
+                        // `take_outcome` swaps the modal's outcome back to
+                        // `None`, so a single Enter press can't be observed
+                        // (and applied) twice on the next key event.
+                        let taken = m.take_outcome();
+                        if !matches!(taken, crate::tui::model_modal::ModelModalOutcome::None) {
+                            model_outcome = Some(taken);
+                        }
                     }
                     if let Some(m) = modal.as_session_mut() {
                         let taken = m.take_outcome();

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -16,6 +16,7 @@ runtime = { path = "../runtime" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread", "time"] }
+zeroize = "1"
 
 [lints]
 workspace = true

--- a/crates/api/src/credentials.rs
+++ b/crates/api/src/credentials.rs
@@ -145,13 +145,17 @@ pub fn save_credentials_to_path(
         std::fs::create_dir_all(parent).map_err(|e| CredentialError::Io(e.to_string()))?;
     }
 
-    // Serialize to JSON
-    let json = serde_json::to_string_pretty(store)
-        .map_err(|e| CredentialError::Json { msg: e.to_string() })?;
+    // Serialize to JSON. Wrap in `Zeroizing` so the in-memory buffer is wiped
+    // before this function returns — even on the error paths below — instead
+    // of being dropped with the secret bytes still resident in the allocator.
+    let json = zeroize::Zeroizing::new(
+        serde_json::to_string_pretty(store)
+            .map_err(|e| CredentialError::Json { msg: e.to_string() })?,
+    );
 
     // Write to temp file first
     let temp_path = path.with_extension("json.tmp");
-    std::fs::write(&temp_path, json).map_err(|e| CredentialError::Io(e.to_string()))?;
+    std::fs::write(&temp_path, json.as_bytes()).map_err(|e| CredentialError::Io(e.to_string()))?;
 
     // Restrict to owner-only before the atomic rename so the final file is never
     // world-readable, even momentarily, on Unix.

--- a/crates/api/src/credentials.rs
+++ b/crates/api/src/credentials.rs
@@ -454,7 +454,10 @@ mod tests {
         save_credentials_to_path(&store, &cred_path).unwrap();
 
         let mode = fs::metadata(&cred_path).unwrap().permissions().mode() & 0o777;
-        assert_eq!(mode, 0o600, "credentials file must be readable only by owner");
+        assert_eq!(
+            mode, 0o600,
+            "credentials file must be readable only by owner"
+        );
 
         let _ = fs::remove_dir_all(&temp_dir);
     }

--- a/crates/api/src/credentials.rs
+++ b/crates/api/src/credentials.rs
@@ -153,6 +153,15 @@ pub fn save_credentials_to_path(
     let temp_path = path.with_extension("json.tmp");
     std::fs::write(&temp_path, json).map_err(|e| CredentialError::Io(e.to_string()))?;
 
+    // Restrict to owner-only before the atomic rename so the final file is never
+    // world-readable, even momentarily, on Unix.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&temp_path, std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| CredentialError::Io(e.to_string()))?;
+    }
+
     // Atomic rename
     std::fs::rename(&temp_path, path).map_err(|e| CredentialError::Io(e.to_string()))?;
 
@@ -429,6 +438,25 @@ mod tests {
     fn test_get_active_config_returns_none_when_no_active_provider() {
         let store = CredentialStore::default();
         assert_eq!(get_active_config(&store), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_save_credentials_sets_owner_only_perms() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = test_temp_dir("perms");
+        let _ = fs::remove_dir_all(&temp_dir);
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        let cred_path = temp_dir.join("credentials.json");
+        let store = CredentialStore::default();
+        save_credentials_to_path(&store, &cred_path).unwrap();
+
+        let mode = fs::metadata(&cred_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "credentials file must be readable only by owner");
+
+        let _ = fs::remove_dir_all(&temp_dir);
     }
 
     #[test]

--- a/crates/api/src/gemini.rs
+++ b/crates/api/src/gemini.rs
@@ -114,13 +114,13 @@ impl GeminiMessageStream {
             }
 
             if let Some(chunk) = self.response.chunk().await? {
-                for frame in self.parser.push_frames(&chunk) {
+                for frame in self.parser.push_frames(&chunk)? {
                     if let Some(response) = parse_gemini_frame(&frame)? {
                         self.pending.extend(self.state.process_response(&response));
                     }
                 }
             } else {
-                for frame in self.parser.finish_frames() {
+                for frame in self.parser.finish_frames()? {
                     if let Some(response) = parse_gemini_frame(&frame)? {
                         self.pending.extend(self.state.process_response(&response));
                     }

--- a/crates/api/src/sse.rs
+++ b/crates/api/src/sse.rs
@@ -15,7 +15,7 @@ impl SseParser {
     pub fn push(&mut self, chunk: &[u8]) -> Result<Vec<StreamEvent>, ApiError> {
         let mut events = Vec::new();
 
-        for frame in self.push_frames(chunk) {
+        for frame in self.push_frames(chunk)? {
             if let Some(event) = parse_frame(&frame)? {
                 events.push(event);
             }
@@ -24,38 +24,41 @@ impl SseParser {
         Ok(events)
     }
 
-    #[must_use]
-    pub fn push_frames(&mut self, chunk: &[u8]) -> Vec<String> {
+    pub fn push_frames(&mut self, chunk: &[u8]) -> Result<Vec<String>, ApiError> {
         self.buffer.extend_from_slice(chunk);
         let mut frames = Vec::new();
 
-        while let Some(frame) = self.next_frame() {
+        while let Some(frame) = self.next_frame()? {
             frames.push(frame);
         }
 
-        frames
+        Ok(frames)
     }
 
     pub fn finish(&mut self) -> Result<Vec<StreamEvent>, ApiError> {
-        self.finish_frames()
+        self.finish_frames()?
             .into_iter()
             .map(|frame| parse_frame(&frame))
             .collect::<Result<Vec<_>, _>>()
             .map(|events| events.into_iter().flatten().collect())
     }
 
-    #[must_use]
-    pub fn finish_frames(&mut self) -> Vec<String> {
+    pub fn finish_frames(&mut self) -> Result<Vec<String>, ApiError> {
         if self.buffer.is_empty() {
-            return Vec::new();
+            return Ok(Vec::new());
         }
 
         let trailing = std::mem::take(&mut self.buffer);
-        vec![String::from_utf8_lossy(&trailing).into_owned()]
+        // Reject invalid UTF-8 instead of silently substituting U+FFFD so
+        // malformed transport bytes can't quietly corrupt the JSON payload
+        // passed downstream (where deserialisation would then succeed-but-wrong).
+        let frame = String::from_utf8(trailing)
+            .map_err(|_| ApiError::InvalidSseFrame("trailing buffer contained invalid utf-8"))?;
+        Ok(vec![frame])
     }
 
-    fn next_frame(&mut self) -> Option<String> {
-        let separator = self
+    fn next_frame(&mut self) -> Result<Option<String>, ApiError> {
+        let Some((position, separator_len)) = self
             .buffer
             .windows(2)
             .position(|window| window == b"\n\n")
@@ -65,15 +68,19 @@ impl SseParser {
                     .windows(4)
                     .position(|window| window == b"\r\n\r\n")
                     .map(|position| (position, 4))
-            })?;
+            })
+        else {
+            return Ok(None);
+        };
 
-        let (position, separator_len) = separator;
         let frame = self
             .buffer
             .drain(..position + separator_len)
             .collect::<Vec<_>>();
         let frame_len = frame.len().saturating_sub(separator_len);
-        Some(String::from_utf8_lossy(&frame[..frame_len]).into_owned())
+        let text = String::from_utf8(frame[..frame_len].to_vec())
+            .map_err(|_| ApiError::InvalidSseFrame("frame contained invalid utf-8"))?;
+        Ok(Some(text))
     }
 }
 
@@ -210,6 +217,33 @@ mod tests {
         let frame = "event: ping\n\n";
         let event = parse_frame(frame).expect("frame without data should be ignored");
         assert_eq!(event, None);
+    }
+
+    #[test]
+    fn invalid_utf8_in_frame_errors_instead_of_silently_lossy() {
+        let mut parser = SseParser::new();
+        // Lone continuation byte 0x80 mid-frame: invalid UTF-8.
+        let chunk = b"event: x\n\xFFdata: {}\n\n";
+
+        let err = parser
+            .push(chunk)
+            .expect_err("invalid utf-8 must produce an error");
+        assert!(
+            matches!(err, crate::error::ApiError::InvalidSseFrame(_)),
+            "expected InvalidSseFrame, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn invalid_utf8_in_trailing_buffer_errors() {
+        let mut parser = SseParser::new();
+        // No frame separator → bytes land in the trailing buffer; that
+        // trailing flush must also reject invalid UTF-8.
+        assert!(parser.push(b"event: x\ndata: \xFF").unwrap().is_empty());
+        let err = parser
+            .finish()
+            .expect_err("trailing invalid utf-8 must error");
+        assert!(matches!(err, crate::error::ApiError::InvalidSseFrame(_)));
     }
 
     #[test]

--- a/crates/api/src/types.rs
+++ b/crates/api/src/types.rs
@@ -241,7 +241,40 @@ pub struct Usage {
 impl Usage {
     #[must_use]
     pub const fn total_tokens(&self) -> u32 {
-        self.input_tokens + self.output_tokens
+        // All four fields count against context spend when prompt caching is
+        // enabled; summing only input + output silently undercounted total
+        // tokens (and therefore reported cost) for cached conversations.
+        self.input_tokens
+            + self.cache_creation_input_tokens
+            + self.cache_read_input_tokens
+            + self.output_tokens
+    }
+}
+
+#[cfg(test)]
+mod usage_tests {
+    use super::Usage;
+
+    #[test]
+    fn total_tokens_sums_all_four_fields() {
+        let usage = Usage {
+            input_tokens: 100,
+            cache_creation_input_tokens: 50,
+            cache_read_input_tokens: 25,
+            output_tokens: 200,
+        };
+        assert_eq!(usage.total_tokens(), 375);
+    }
+
+    #[test]
+    fn total_tokens_zero_when_all_zero() {
+        let usage = Usage {
+            input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            output_tokens: 0,
+        };
+        assert_eq!(usage.total_tokens(), 0);
     }
 }
 

--- a/crates/commands/src/lib.rs
+++ b/crates/commands/src/lib.rs
@@ -436,6 +436,10 @@ mod tests {
 
     #[test]
     fn compacts_sessions_via_slash_command() {
+        // Plain user/assistant turns only — the compactor walks the preserved
+        // window backwards across tool_use/tool_result pairs, so including a
+        // Tool message would change the removal count and obscure what this
+        // test is asserting (that /compact wires the count into the message).
         let session = Session {
             version: 1,
             model: None,
@@ -445,7 +449,7 @@ mod tests {
                 ConversationMessage::assistant(vec![ContentBlock::Text {
                     text: "b ".repeat(200),
                 }]),
-                ConversationMessage::tool_result("1", "bash", "ok ".repeat(200), false),
+                ConversationMessage::user_text("c ".repeat(200)),
                 ConversationMessage::assistant(vec![ContentBlock::Text {
                     text: "recent".to_string(),
                 }]),

--- a/crates/commands/src/lib.rs
+++ b/crates/commands/src/lib.rs
@@ -198,9 +198,18 @@ impl SlashCommand {
             "model" => Self::Model {
                 model: parts.next().map(ToOwned::to_owned),
             },
-            "clear" => Self::Clear {
-                confirm: parts.next() == Some("--confirm"),
-            },
+            "clear" => {
+                // Strict parse so `/clear --comfirm` (or any other trailing
+                // garbage) doesn't silently behave like `/clear` without
+                // confirmation and wipe the session.
+                let next = parts.next();
+                let extra = parts.next();
+                match (next, extra) {
+                    (None, _) => Self::Clear { confirm: false },
+                    (Some("--confirm"), None) => Self::Clear { confirm: true },
+                    _ => Self::Unknown(command_raw.to_string()),
+                }
+            }
             "cost" => Self::Cost,
             "config" => Self::Config {
                 section: parts.next().map(ToOwned::to_owned),
@@ -333,6 +342,16 @@ mod tests {
         assert_eq!(
             SlashCommand::parse("/clear --confirm"),
             Some(SlashCommand::Clear { confirm: true })
+        );
+        // Typo'd flag must not silently behave like `/clear` (no confirm).
+        assert_eq!(
+            SlashCommand::parse("/clear --comfirm"),
+            Some(SlashCommand::Unknown("clear".to_string()))
+        );
+        // Trailing garbage after a real confirm flag is also rejected.
+        assert_eq!(
+            SlashCommand::parse("/clear --confirm extra"),
+            Some(SlashCommand::Unknown("clear".to_string()))
         );
         assert_eq!(SlashCommand::parse("/cost"), Some(SlashCommand::Cost));
         assert_eq!(

--- a/crates/crawler/Cargo.toml
+++ b/crates/crawler/Cargo.toml
@@ -9,7 +9,7 @@ publish.workspace = true
 runtime = { path = "../runtime" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["io-util", "macros", "process", "rt", "time"] }
+tokio = { version = "1", features = ["io-util", "macros", "net", "process", "rt", "time"] }
 csv = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 htmd = "0.5"

--- a/crates/crawler/src/agent/fork.rs
+++ b/crates/crawler/src/agent/fork.rs
@@ -16,11 +16,16 @@ impl<'a> ForkSupervisor<'a> {
     }
 
     fn next_child_id(&self) -> String {
-        format!(
-            "{}-child-{}",
-            self.agent.agent_id,
-            self.agent.child_tasks.len() + 1
-        )
+        // Monotonic per-agent counter: using `child_tasks.len() + 1` reused IDs
+        // once children were drained by `wait_for_subagents`, which then made
+        // every downstream lookup (control registry, manager, child_tasks)
+        // ambiguous between current and prior generations.
+        let n = self
+            .agent
+            .child_id_counter
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            + 1;
+        format!("{}-child-{n}", self.agent.agent_id)
     }
 
     async fn claim_child_slot(&mut self, child_id: &str) -> Result<(), ToolError> {
@@ -634,5 +639,28 @@ mod tests {
                 error: Some(ref error),
             } if error == "timed out"
         ));
+    }
+
+    #[test]
+    fn next_child_id_is_monotonic_across_drains() {
+        // Even after the child_tasks map has been drained (which used to
+        // reset the count to 0), subsequent IDs must keep increasing so that
+        // every child gets a globally unique handle across the agent's life.
+        let mut agent = CrawlerAgent::new_for_testing(ToolRegistry::new());
+
+        let mut ids = std::collections::HashSet::new();
+        for _ in 0..3 {
+            ids.insert(ForkSupervisor::new(&mut agent).next_child_id());
+        }
+        // Simulate `wait_for_subagents` having drained completed children.
+        agent.child_tasks.clear();
+        for _ in 0..3 {
+            ids.insert(ForkSupervisor::new(&mut agent).next_child_id());
+        }
+        assert_eq!(
+            ids.len(),
+            6,
+            "next_child_id must produce unique IDs even after drains: {ids:?}"
+        );
     }
 }

--- a/crates/crawler/src/agent/mod.rs
+++ b/crates/crawler/src/agent/mod.rs
@@ -298,8 +298,10 @@ impl ToolExecutor for CrawlerAgent {
         let tool_effect = if let Some(handler) = self.registry.get(tool_name) {
             match handler(&input_value) {
                 Ok(effect) => effect,
-                Err(error) if crate::tool_registry::is_requires_async_error(&error) => {
+                Err(error) if error.is_requires_async() => {
                     if !Self::supports_async(tool_name) {
+                        // Forward the canonical phrasing to the runtime
+                        // executor (which uses its own `ToolError` type).
                         return Err(ToolError::new(error.to_string()));
                     }
 

--- a/crates/crawler/src/agent/mod.rs
+++ b/crates/crawler/src/agent/mod.rs
@@ -298,11 +298,7 @@ impl ToolExecutor for CrawlerAgent {
         let tool_effect = if let Some(handler) = self.registry.get(tool_name) {
             match handler(&input_value) {
                 Ok(effect) => effect,
-                Err(error)
-                    if error
-                        .to_string()
-                        .contains("requires async execution via execute_async") =>
-                {
+                Err(error) if crate::tool_registry::is_requires_async_error(&error) => {
                     if !Self::supports_async(tool_name) {
                         return Err(ToolError::new(error.to_string()));
                     }

--- a/crates/crawler/src/agent/mod.rs
+++ b/crates/crawler/src/agent/mod.rs
@@ -86,6 +86,10 @@ pub struct CrawlerAgent {
     pub(super) shared_bridge: Option<SharedBridge>,
     pub(super) crawl_state: CrawlState,
     pub(crate) child_tasks: ChildTaskMap,
+    /// Monotonically increasing counter feeding `next_child_id`. Using a
+    /// per-agent counter (rather than `child_tasks.len()`) prevents IDs from
+    /// being reused after children are drained/waited on.
+    pub(super) child_id_counter: std::sync::atomic::AtomicU64,
     pub(super) api_client_arc: Option<SharedApiClient>,
     control_state: Option<Arc<ControlState>>,
     child_event_tx: Option<std::sync::mpsc::Sender<crate::child_events::ChildEvent>>,
@@ -109,6 +113,7 @@ impl CrawlerAgent {
                 ..CrawlState::default()
             },
             child_tasks: HashMap::new(),
+            child_id_counter: std::sync::atomic::AtomicU64::new(0),
             api_client_arc: None,
             control_state: None,
             child_event_tx: None,
@@ -132,6 +137,7 @@ impl CrawlerAgent {
                 ..CrawlState::default()
             },
             child_tasks: HashMap::new(),
+            child_id_counter: std::sync::atomic::AtomicU64::new(0),
             api_client_arc: None,
             control_state: None,
             child_event_tx: None,
@@ -155,6 +161,7 @@ impl CrawlerAgent {
                 ..CrawlState::default()
             },
             child_tasks: HashMap::new(),
+            child_id_counter: std::sync::atomic::AtomicU64::new(0),
             api_client_arc: None,
             control_state: None,
             child_event_tx: None,

--- a/crates/crawler/src/fetcher.rs
+++ b/crates/crawler/src/fetcher.rs
@@ -21,9 +21,15 @@ pub struct FetchedPage {
 pub enum FetchError {
     Http(reqwest::Error),
     Browser(String),
-    StatusError { status: u16, url: String },
+    StatusError {
+        status: u16,
+        url: String,
+    },
     /// Response body exceeded the configured maximum size.
-    BodyTooLarge { url: String, limit: usize },
+    BodyTooLarge {
+        url: String,
+        limit: usize,
+    },
 }
 
 impl fmt::Display for FetchError {

--- a/crates/crawler/src/fetcher.rs
+++ b/crates/crawler/src/fetcher.rs
@@ -22,6 +22,8 @@ pub enum FetchError {
     Http(reqwest::Error),
     Browser(String),
     StatusError { status: u16, url: String },
+    /// Response body exceeded the configured maximum size.
+    BodyTooLarge { url: String, limit: usize },
 }
 
 impl fmt::Display for FetchError {
@@ -32,6 +34,9 @@ impl fmt::Display for FetchError {
             Self::StatusError { status, url } => {
                 write!(f, "HTTP {status} for {url}")
             }
+            Self::BodyTooLarge { url, limit } => {
+                write!(f, "response body for {url} exceeds {limit} bytes")
+            }
         }
     }
 }
@@ -40,7 +45,7 @@ impl std::error::Error for FetchError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Http(e) => Some(e),
-            Self::Browser(_) | Self::StatusError { .. } => None,
+            Self::Browser(_) | Self::StatusError { .. } | Self::BodyTooLarge { .. } => None,
         }
     }
 }
@@ -76,6 +81,12 @@ const AUTH_REDIRECT_PATTERNS: &[&str] = &[
 ];
 
 const MIN_BODY_LENGTH: usize = 500;
+
+/// Hard cap on a single HTTP response body. A page that is much larger than
+/// this is almost never useful to the agent (and is almost certainly a binary
+/// dump, generated content, or an attack) — and without a cap, reqwest's
+/// `.text()` will happily buffer multi-gigabyte responses into memory.
+const MAX_BODY_BYTES: usize = 32 * 1024 * 1024;
 
 fn needs_escalation(status: StatusCode, body: &str) -> bool {
     if ESCALATION_STATUS_CODES.contains(&status.as_u16()) {
@@ -240,10 +251,38 @@ impl HttpFetcher {
     ///
     /// Returns `FetchError::Http` on network or protocol errors.
     pub async fn fetch(&self, url: &str) -> Result<HttpResponse, FetchError> {
-        let resp = self.client.get(url).send().await?;
+        let mut resp = self.client.get(url).send().await?;
         let status = resp.status();
         let final_url = resp.url().to_string();
-        let body = resp.text().await?;
+
+        // Reject up front if the server advertises a body over the limit so we
+        // don't even start downloading the payload.
+        if let Some(declared) = resp.content_length() {
+            if declared > MAX_BODY_BYTES as u64 {
+                return Err(FetchError::BodyTooLarge {
+                    url: final_url,
+                    limit: MAX_BODY_BYTES,
+                });
+            }
+        }
+
+        // Stream the body chunk-by-chunk so a missing or lying Content-Length
+        // header can still be caught mid-transfer.
+        let mut bytes: Vec<u8> = Vec::new();
+        while let Some(chunk) = resp.chunk().await? {
+            if bytes.len() + chunk.len() > MAX_BODY_BYTES {
+                return Err(FetchError::BodyTooLarge {
+                    url: final_url,
+                    limit: MAX_BODY_BYTES,
+                });
+            }
+            bytes.extend_from_slice(&chunk);
+        }
+
+        // Match reqwest's text() in being lossy on invalid UTF-8 — the
+        // downstream HTML/markdown pipelines can tolerate replacement chars,
+        // and erroring here would break legitimately mojibake'd pages.
+        let body = String::from_utf8_lossy(&bytes).into_owned();
 
         Ok(HttpResponse {
             url: final_url,
@@ -671,6 +710,44 @@ mod tests {
             page.markdown.starts_with("```"),
             "non-HTML input should be wrapped in a code block"
         );
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_oversized_content_length() {
+        use tokio::io::AsyncWriteExt;
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+
+        // Serve a single connection that advertises a body well over the cap
+        // and then closes — we expect the client to bail out before reading
+        // anywhere near that many bytes.
+        let server = tokio::spawn(async move {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                let _ = socket
+                    .write_all(
+                        b"HTTP/1.1 200 OK\r\nContent-Length: 999999999\r\nConnection: close\r\n\r\n",
+                    )
+                    .await;
+                let _ = socket.shutdown().await;
+            }
+        });
+
+        let fetcher = HttpFetcher::new().expect("client");
+        let url = format!("http://{addr}/");
+        let err = fetcher
+            .fetch(&url)
+            .await
+            .expect_err("oversized body must be rejected");
+        let _ = server.await;
+
+        match err {
+            FetchError::BodyTooLarge { limit, .. } => {
+                assert_eq!(limit, MAX_BODY_BYTES);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/crawler/src/playwright.rs
+++ b/crates/crawler/src/playwright.rs
@@ -126,10 +126,12 @@ async function bootstrap() {
     if (command.action === 'navigate') {
       try {
         await page.goto(command.url, { waitUntil: 'domcontentloaded', timeout: 30000 });
-        let html = await bypassTurnstileIfPresent(page);
-
+        // `bypassTurnstileIfPresent` already calls `page.content()` after
+        // any nudge it performs, so reuse that html instead of fetching
+        // again — the earlier `html = await page.content()` overwrite was
+        // dead and just doubled the wire-format round-trip.
+        const html = await bypassTurnstileIfPresent(page);
         const title = await page.title();
-        html = await page.content();
         process.stdout.write(JSON.stringify({
           event: 'bridge_response',
           ok: true,

--- a/crates/crawler/src/tool_effect.rs
+++ b/crates/crawler/src/tool_effect.rs
@@ -34,12 +34,50 @@ pub struct WaitSpec {
 }
 
 /// Error type for tool execution failures.
+///
+/// Most failures are `Message(_)`. The `RequiresAsync` variant is a sentinel
+/// emitted by the synchronous handler stub for any tool that actually needs
+/// the async path; the agent loop matches on it via [`ToolError::is_requires_async`]
+/// instead of substring-matching the error text — which used to misclassify
+/// any unrelated error whose message happened to contain the same phrase.
 #[derive(Debug)]
-pub struct ToolError(pub String);
+pub enum ToolError {
+    /// A plain, user-visible error message.
+    Message(String),
+    /// The named tool is registered as async-only and must go through
+    /// `execute_async`. Carries the tool name purely for diagnostics.
+    RequiresAsync { tool_name: String },
+}
+
+impl ToolError {
+    /// Construct a plain message error.
+    pub fn new<S: Into<String>>(message: S) -> Self {
+        Self::Message(message.into())
+    }
+
+    /// Construct the sentinel emitted by the registry stub for async-only tools.
+    pub fn requires_async<S: Into<String>>(tool_name: S) -> Self {
+        Self::RequiresAsync {
+            tool_name: tool_name.into(),
+        }
+    }
+
+    /// True iff this error is the `RequiresAsync` sentinel.
+    #[must_use]
+    pub const fn is_requires_async(&self) -> bool {
+        matches!(self, Self::RequiresAsync { .. })
+    }
+}
 
 impl std::fmt::Display for ToolError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+        match self {
+            Self::Message(s) => write!(f, "{s}"),
+            Self::RequiresAsync { tool_name } => write!(
+                f,
+                "tool `{tool_name}` requires async execution via execute_async"
+            ),
+        }
     }
 }
 
@@ -47,7 +85,7 @@ impl std::error::Error for ToolError {}
 
 impl From<crate::CrawlError> for ToolError {
     fn from(value: crate::CrawlError) -> Self {
-        Self(value.to_string())
+        Self::new(value.to_string())
     }
 }
 
@@ -81,8 +119,9 @@ mod tests {
 
     #[test]
     fn tool_error_display_message() {
-        let err = ToolError("something went wrong".to_string());
+        let err = ToolError::new("something went wrong");
         assert_eq!(err.to_string(), "something went wrong");
+        assert!(!err.is_requires_async());
     }
 
     #[test]
@@ -90,6 +129,33 @@ mod tests {
         let crawl_err = crate::CrawlError::new("crawl failure");
         let tool_err: ToolError = crawl_err.into();
         assert_eq!(tool_err.to_string(), "crawl failure");
+        assert!(!tool_err.is_requires_async());
+    }
+
+    #[test]
+    fn tool_error_requires_async_variant_is_recognised_by_predicate() {
+        let err = ToolError::requires_async("navigate");
+        assert!(err.is_requires_async());
+        // Display still includes the canonical phrasing so log readers stay
+        // oriented even though callers must not substring-match.
+        assert!(err
+            .to_string()
+            .contains("requires async execution via execute_async"));
+    }
+
+    #[test]
+    fn tool_error_message_containing_marker_phrase_is_not_misclassified() {
+        // Pre-refactor, `is_requires_async_error` was a substring-match on
+        // `error.to_string()`, which meant any error message that happened
+        // to mention the canonical phrase would be misclassified. With a
+        // dedicated variant, the predicate is identity-based, not text-based.
+        let err = ToolError::new(
+            "upstream said: tool `foo` requires async execution via execute_async (but it's a Message)",
+        );
+        assert!(
+            !err.is_requires_async(),
+            "Message variant must not be reported as RequiresAsync regardless of its text"
+        );
     }
 
     #[test]

--- a/crates/crawler/src/tool_registry.rs
+++ b/crates/crawler/src/tool_registry.rs
@@ -7,6 +7,19 @@ use crate::{ToolEffect, ToolError};
 
 pub type ToolHandler = Box<dyn Fn(&Value) -> Result<ToolEffect, ToolError> + Send + Sync>;
 
+/// Sentinel embedded in the `ToolError` returned by the synchronous handler
+/// stub for any tool that actually needs the async path. Centralised here so
+/// callers don't have to grep for the literal string — see `is_requires_async`.
+const REQUIRES_ASYNC_MARKER: &str = "requires async execution via execute_async";
+
+/// Returns `true` when `error` is the sentinel emitted by a stub registered
+/// for an async-only tool. Use this instead of substring-matching on the error
+/// message at the call site.
+#[must_use]
+pub fn is_requires_async_error(error: &ToolError) -> bool {
+    error.to_string().contains(REQUIRES_ASYNC_MARKER)
+}
+
 const ASYNC_TOOLS: &[&str] = &[
     "navigate",
     "click",
@@ -53,7 +66,7 @@ impl ToolRegistry {
                 name,
                 Box::new(move |_| {
                     Err(ToolError(format!(
-                        "tool `{tool_name}` requires async execution via execute_async"
+                        "tool `{tool_name}` {REQUIRES_ASYNC_MARKER}"
                     )))
                 }),
             );

--- a/crates/crawler/src/tool_registry.rs
+++ b/crates/crawler/src/tool_registry.rs
@@ -7,19 +7,6 @@ use crate::{ToolEffect, ToolError};
 
 pub type ToolHandler = Box<dyn Fn(&Value) -> Result<ToolEffect, ToolError> + Send + Sync>;
 
-/// Sentinel embedded in the `ToolError` returned by the synchronous handler
-/// stub for any tool that actually needs the async path. Centralised here so
-/// callers don't have to grep for the literal string — see `is_requires_async`.
-const REQUIRES_ASYNC_MARKER: &str = "requires async execution via execute_async";
-
-/// Returns `true` when `error` is the sentinel emitted by a stub registered
-/// for an async-only tool. Use this instead of substring-matching on the error
-/// message at the call site.
-#[must_use]
-pub fn is_requires_async_error(error: &ToolError) -> bool {
-    error.to_string().contains(REQUIRES_ASYNC_MARKER)
-}
-
 const ASYNC_TOOLS: &[&str] = &[
     "navigate",
     "click",
@@ -64,11 +51,7 @@ impl ToolRegistry {
             let tool_name = name.to_string();
             registry.register(
                 name,
-                Box::new(move |_| {
-                    Err(ToolError(format!(
-                        "tool `{tool_name}` {REQUIRES_ASYNC_MARKER}"
-                    )))
-                }),
+                Box::new(move |_| Err(ToolError::requires_async(tool_name.clone()))),
             );
         }
         registry.register("fork", Box::new(crate::tools::fork::execute));
@@ -139,7 +122,7 @@ impl ToolRegistry {
                 if let Some(handler) = self.handlers.get(name) {
                     handler(input)
                 } else {
-                    Err(ToolError(format!("unknown tool: `{name}`")))
+                    Err(ToolError::new(format!("unknown tool: `{name}`")))
                 }
             }
         }

--- a/crates/crawler/src/tools/click.rs
+++ b/crates/crawler/src/tools/click.rs
@@ -28,10 +28,10 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
     browser
         .acquire_bridge()
         .await
-        .map_err(|e| ToolError(e.to_string()))?
+        .map_err(|e| ToolError::new(e.to_string()))?
         .click(&params.selector)
         .await
-        .map_err(|e| ToolError(e.to_string()))?;
+        .map_err(|e| ToolError::new(e.to_string()))?;
 
     let page_state = super::feedback::post_action_page_state(browser).await;
 

--- a/crates/crawler/src/tools/execute_js.rs
+++ b/crates/crawler/src/tools/execute_js.rs
@@ -17,10 +17,10 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
     let result = browser
         .acquire_bridge()
         .await
-        .map_err(|e| ToolError(e.to_string()))?
+        .map_err(|e| ToolError::new(e.to_string()))?
         .evaluate(&script)
         .await
-        .map_err(|e| ToolError(e.to_string()))?;
+        .map_err(|e| ToolError::new(e.to_string()))?;
 
     let value = result.get("value").cloned().unwrap_or(Value::Null);
 

--- a/crates/crawler/src/tools/fill_form.rs
+++ b/crates/crawler/src/tools/fill_form.rs
@@ -58,10 +58,10 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
         browser
             .acquire_bridge()
             .await
-            .map_err(|e| ToolError(e.to_string()))?
+            .map_err(|e| ToolError::new(e.to_string()))?
             .fill(selector, value)
             .await
-            .map_err(|e| ToolError(format!("failed to fill '{selector}': {e}")))?;
+            .map_err(|e| ToolError::new(format!("failed to fill '{selector}': {e}")))?;
     }
 
     if params.submit {
@@ -72,10 +72,10 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
         browser
             .acquire_bridge()
             .await
-            .map_err(|e| ToolError(e.to_string()))?
+            .map_err(|e| ToolError::new(e.to_string()))?
             .evaluate(&js)
             .await
-            .map_err(|e| ToolError(format!("failed to submit form: {e}")))?;
+            .map_err(|e| ToolError::new(format!("failed to submit form: {e}")))?;
     }
 
     let page_state = super::feedback::post_action_page_state(browser).await;

--- a/crates/crawler/src/tools/fork.rs
+++ b/crates/crawler/src/tools/fork.rs
@@ -9,7 +9,7 @@ pub fn execute(input: &Value) -> Result<ToolEffect, ToolError> {
         .map_or("", str::trim)
         .to_string();
     if goal.is_empty() {
-        return Err(ToolError("fork requires non-empty sub_goal".to_string()));
+        return Err(ToolError::new("fork requires non-empty sub_goal".to_string()));
     }
 
     Ok(ToolEffect::Spawn(ForkSpec {

--- a/crates/crawler/src/tools/fork.rs
+++ b/crates/crawler/src/tools/fork.rs
@@ -9,7 +9,9 @@ pub fn execute(input: &Value) -> Result<ToolEffect, ToolError> {
         .map_or("", str::trim)
         .to_string();
     if goal.is_empty() {
-        return Err(ToolError::new("fork requires non-empty sub_goal".to_string()));
+        return Err(ToolError::new(
+            "fork requires non-empty sub_goal".to_string(),
+        ));
     }
 
     Ok(ToolEffect::Spawn(ForkSpec {

--- a/crates/crawler/src/tools/go_back.rs
+++ b/crates/crawler/src/tools/go_back.rs
@@ -9,10 +9,10 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
     let url = browser
         .acquire_bridge()
         .await
-        .map_err(|e| ToolError(e.to_string()))?
+        .map_err(|e| ToolError::new(e.to_string()))?
         .go_back()
         .await
-        .map_err(|e| ToolError(e.to_string()))?;
+        .map_err(|e| ToolError::new(e.to_string()))?;
 
     let page_state = super::feedback::post_action_page_state(browser).await;
 

--- a/crates/crawler/src/tools/hover.rs
+++ b/crates/crawler/src/tools/hover.rs
@@ -17,10 +17,10 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
     browser
         .acquire_bridge()
         .await
-        .map_err(|e| ToolError(e.to_string()))?
+        .map_err(|e| ToolError::new(e.to_string()))?
         .hover(&selector)
         .await
-        .map_err(|e| ToolError(e.to_string()))?;
+        .map_err(|e| ToolError::new(e.to_string()))?;
 
     let page_state = super::feedback::post_action_page_state(browser).await;
 

--- a/crates/crawler/src/tools/list_resources.rs
+++ b/crates/crawler/src/tools/list_resources.rs
@@ -9,10 +9,10 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
     let result = browser
         .acquire_bridge()
         .await
-        .map_err(|e| ToolError(e.to_string()))?
+        .map_err(|e| ToolError::new(e.to_string()))?
         .list_resources()
         .await
-        .map_err(|e| ToolError(e.to_string()))?;
+        .map_err(|e| ToolError::new(e.to_string()))?;
 
     let links = result.get("links").cloned().unwrap_or_else(|| json!([]));
     let images = result.get("images").cloned().unwrap_or_else(|| json!([]));

--- a/crates/crawler/src/tools/navigate.rs
+++ b/crates/crawler/src/tools/navigate.rs
@@ -37,14 +37,12 @@ fn parse_input(input: &Value) -> Result<NavigateInput, CrawlError> {
     // Allowlist http/https only. Without this, the agent could be steered into
     // file://, javascript:, data:, or other schemes that bypass network
     // boundaries (local-file disclosure, SSRF helpers, etc.).
-    let scheme_end = url.find(':').ok_or_else(|| {
-        CrawlError::new("url must include a scheme (http:// or https://)")
-    })?;
+    let scheme_end = url
+        .find(':')
+        .ok_or_else(|| CrawlError::new("url must include a scheme (http:// or https://)"))?;
     let scheme = &url[..scheme_end];
     if !scheme.eq_ignore_ascii_case("http") && !scheme.eq_ignore_ascii_case("https") {
-        return Err(CrawlError::new(
-            "url scheme must be http or https",
-        ));
+        return Err(CrawlError::new("url scheme must be http or https"));
     }
 
     let format = input

--- a/crates/crawler/src/tools/navigate.rs
+++ b/crates/crawler/src/tools/navigate.rs
@@ -34,6 +34,19 @@ fn parse_input(input: &Value) -> Result<NavigateInput, CrawlError> {
         return Err(CrawlError::new("url must not be empty"));
     }
 
+    // Allowlist http/https only. Without this, the agent could be steered into
+    // file://, javascript:, data:, or other schemes that bypass network
+    // boundaries (local-file disclosure, SSRF helpers, etc.).
+    let scheme_end = url.find(':').ok_or_else(|| {
+        CrawlError::new("url must include a scheme (http:// or https://)")
+    })?;
+    let scheme = &url[..scheme_end];
+    if !scheme.eq_ignore_ascii_case("http") && !scheme.eq_ignore_ascii_case("https") {
+        return Err(CrawlError::new(
+            "url scheme must be http or https",
+        ));
+    }
+
     let format = input
         .get("format")
         .and_then(Value::as_str)
@@ -329,6 +342,33 @@ mod tests {
             let input = json!({"url": "https://x.com", "content_depth": val});
             let result = parse_input(&input).unwrap();
             assert_eq!(result.content_depth, expected);
+        }
+    }
+
+    #[test]
+    fn navigate_parse_rejects_non_http_schemes() {
+        for url in [
+            "file:///etc/passwd",
+            "javascript:alert(1)",
+            "data:text/html,<h1>x</h1>",
+            "ftp://example.com/foo",
+            "noscheme",
+        ] {
+            let input = json!({"url": url});
+            let err = parse_input(&input).expect_err(&format!("expected error for {url}"));
+            let msg = err.to_string();
+            assert!(
+                msg.contains("scheme") || msg.contains("http"),
+                "unexpected error for {url}: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn navigate_parse_accepts_http_and_https_case_insensitively() {
+        for url in ["http://example.com", "HTTPS://Example.com/path"] {
+            let input = json!({"url": url});
+            parse_input(&input).unwrap_or_else(|e| panic!("rejected {url}: {e}"));
         }
     }
 

--- a/crates/crawler/src/tools/navigate.rs
+++ b/crates/crawler/src/tools/navigate.rs
@@ -217,11 +217,11 @@ fn resolve_content(
 pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<ToolEffect, ToolError> {
     let params = parse_input(input)?;
 
-    let router = FetchRouter::new().map_err(|e| ToolError(e.to_string()))?;
+    let router = FetchRouter::new().map_err(|e| ToolError::new(e.to_string()))?;
     let page = router
         .fetch(&params.url, Some(browser))
         .await
-        .map_err(|e| ToolError(e.to_string()))?;
+        .map_err(|e| ToolError::new(e.to_string()))?;
 
     let title = page.title.clone().unwrap_or_default();
 

--- a/crates/crawler/src/tools/page_map.rs
+++ b/crates/crawler/src/tools/page_map.rs
@@ -41,10 +41,10 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
     let mut result = browser
         .acquire_bridge()
         .await
-        .map_err(|e| ToolError(e.to_string()))?
+        .map_err(|e| ToolError::new(e.to_string()))?
         .page_map()
         .await
-        .map_err(|e| ToolError(e.to_string()))?;
+        .map_err(|e| ToolError::new(e.to_string()))?;
 
     apply_page_map_caps(&mut result);
 

--- a/crates/crawler/src/tools/press_key.rs
+++ b/crates/crawler/src/tools/press_key.rs
@@ -29,10 +29,10 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
     browser
         .acquire_bridge()
         .await
-        .map_err(|e| ToolError(e.to_string()))?
+        .map_err(|e| ToolError::new(e.to_string()))?
         .press_key(&parsed.key, parsed.selector.as_deref())
         .await
-        .map_err(|e| ToolError(e.to_string()))?;
+        .map_err(|e| ToolError::new(e.to_string()))?;
 
     let page_state = super::feedback::post_action_page_state(browser).await;
 

--- a/crates/crawler/src/tools/read_content.rs
+++ b/crates/crawler/src/tools/read_content.rs
@@ -38,11 +38,11 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
     let mut bridge = browser
         .acquire_bridge()
         .await
-        .map_err(|e| ToolError(e.to_string()))?;
+        .map_err(|e| ToolError::new(e.to_string()))?;
     let result = bridge
         .read_content(heading.as_deref(), selector.as_deref(), offset, max_chars)
         .await
-        .map_err(|e| ToolError(e.to_string()))?;
+        .map_err(|e| ToolError::new(e.to_string()))?;
     Ok(ToolEffect::reply_json(&result))
 }
 

--- a/crates/crawler/src/tools/save_file.rs
+++ b/crates/crawler/src/tools/save_file.rs
@@ -99,10 +99,10 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
     let saved_path = browser
         .acquire_bridge()
         .await
-        .map_err(|e| ToolError(e.to_string()))?
+        .map_err(|e| ToolError::new(e.to_string()))?
         .save_file(&parsed.url, &path_str)
         .await
-        .map_err(|e| ToolError(e.to_string()))?;
+        .map_err(|e| ToolError::new(e.to_string()))?;
 
     Ok(ToolEffect::reply_json(&json!({
         "success": true,

--- a/crates/crawler/src/tools/screenshot.rs
+++ b/crates/crawler/src/tools/screenshot.rs
@@ -9,10 +9,10 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
     let (screenshot_base64, size_bytes) = browser
         .acquire_bridge()
         .await
-        .map_err(|e| ToolError(e.to_string()))?
+        .map_err(|e| ToolError::new(e.to_string()))?
         .screenshot()
         .await
-        .map_err(|e| ToolError(e.to_string()))?;
+        .map_err(|e| ToolError::new(e.to_string()))?;
 
     Ok(ToolEffect::reply_json(&serde_json::json!({
         "screenshot_base64": screenshot_base64,

--- a/crates/crawler/src/tools/scroll.rs
+++ b/crates/crawler/src/tools/scroll.rs
@@ -31,10 +31,10 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
     browser
         .acquire_bridge()
         .await
-        .map_err(|e| ToolError(e.to_string()))?
+        .map_err(|e| ToolError::new(e.to_string()))?
         .scroll(&direction, pixels)
         .await
-        .map_err(|e| ToolError(e.to_string()))?;
+        .map_err(|e| ToolError::new(e.to_string()))?;
 
     let page_state = super::feedback::post_action_page_state(browser).await;
 

--- a/crates/crawler/src/tools/select_option.rs
+++ b/crates/crawler/src/tools/select_option.rs
@@ -31,10 +31,10 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
     browser
         .acquire_bridge()
         .await
-        .map_err(|e| ToolError(e.to_string()))?
+        .map_err(|e| ToolError::new(e.to_string()))?
         .select_option(&parsed.selector, &parsed.value)
         .await
-        .map_err(|e| ToolError(e.to_string()))?;
+        .map_err(|e| ToolError::new(e.to_string()))?;
 
     let page_state = super::feedback::post_action_page_state(browser).await;
 

--- a/crates/crawler/src/tools/switch_tab.rs
+++ b/crates/crawler/src/tools/switch_tab.rs
@@ -20,7 +20,7 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
         .await
         .switch_tab(index)
         .await
-        .map_err(|e| ToolError(e.to_string()))?;
+        .map_err(|e| ToolError::new(e.to_string()))?;
 
     if let Some(page_index) = result
         .get("pageIndex")

--- a/crates/crawler/src/tools/wait.rs
+++ b/crates/crawler/src/tools/wait.rs
@@ -75,10 +75,10 @@ pub async fn execute(input: &Value, browser: &mut BrowserContext) -> Result<Tool
         let found = browser
             .acquire_bridge()
             .await
-            .map_err(|e| ToolError(e.to_string()))?
+            .map_err(|e| ToolError::new(e.to_string()))?
             .wait_for_selector(selector, parsed.timeout_ms)
             .await
-            .map_err(|e| ToolError(e.to_string()))?;
+            .map_err(|e| ToolError::new(e.to_string()))?;
 
         Ok(ToolEffect::reply_json(&json!({
             "success": true,

--- a/crates/crawler/src/tools/wait_for_human.rs
+++ b/crates/crawler/src/tools/wait_for_human.rs
@@ -25,7 +25,7 @@ fn parse_input(input: &Value) -> Result<WaitForHumanInput, crate::CrawlError> {
 
 pub fn execute(input: &Value, is_interactive: bool) -> Result<ToolEffect, ToolError> {
     if !is_interactive {
-        return Err(ToolError(
+        return Err(ToolError::new(
             "wait_for_human is only available in an interactive TUI session \
              (not in `prompt` or `--resume`)."
                 .to_string(),

--- a/crates/crawler/src/tools/wait_for_subagents.rs
+++ b/crates/crawler/src/tools/wait_for_subagents.rs
@@ -9,14 +9,14 @@ pub fn execute(input: &Value) -> Result<ToolEffect, ToolError> {
             value
                 .as_array()
                 .ok_or_else(|| {
-                    ToolError("wait_for_subagents child_ids must be an array".to_string())
+                    ToolError::new("wait_for_subagents child_ids must be an array".to_string())
                 })
                 .and_then(|values| {
                     values
                         .iter()
                         .map(|value| {
                             value.as_str().map(str::to_owned).ok_or_else(|| {
-                                ToolError(
+                                ToolError::new(
                                     "wait_for_subagents child_ids entries must be strings"
                                         .to_string(),
                                 )

--- a/crates/runtime/src/compact.rs
+++ b/crates/runtime/src/compact.rs
@@ -542,10 +542,12 @@ mod tests {
             for block in &message.blocks {
                 if let ContentBlock::ToolResult { tool_use_id, .. } = block {
                     let has_matching_use = preserved.iter().any(|m| {
-                        m.blocks.iter().any(|b| matches!(
-                            b,
-                            ContentBlock::ToolUse { id, .. } if id == tool_use_id
-                        ))
+                        m.blocks.iter().any(|b| {
+                            matches!(
+                                b,
+                                ContentBlock::ToolUse { id, .. } if id == tool_use_id
+                            )
+                        })
                     });
                     assert!(
                         has_matching_use,
@@ -585,19 +587,28 @@ mod tests {
         );
 
         let preserved = &result.compacted_session.messages;
-        assert_ne!(preserved[1].role, MessageRole::Tool,
-            "preserved window must not start with a Tool message");
+        assert_ne!(
+            preserved[1].role,
+            MessageRole::Tool,
+            "preserved window must not start with a Tool message"
+        );
 
         let has_tool_use = preserved.iter().any(|m| {
-            m.blocks.iter().any(|b| matches!(b, ContentBlock::ToolUse { id, .. } if id == "call_1"))
+            m.blocks
+                .iter()
+                .any(|b| matches!(b, ContentBlock::ToolUse { id, .. } if id == "call_1"))
         });
         let has_tool_result = preserved.iter().any(|m| {
-            m.blocks.iter().any(|b| matches!(
-                b,
-                ContentBlock::ToolResult { tool_use_id, .. } if tool_use_id == "call_1"
-            ))
+            m.blocks.iter().any(|b| {
+                matches!(
+                    b,
+                    ContentBlock::ToolResult { tool_use_id, .. } if tool_use_id == "call_1"
+                )
+            })
         });
-        assert_eq!(has_tool_use, has_tool_result,
-            "tool_use and tool_result for call_1 must both be present or both absent");
+        assert_eq!(
+            has_tool_use, has_tool_result,
+            "tool_use and tool_result for call_1 must both be present or both absent"
+        );
     }
 }

--- a/crates/runtime/src/compact.rs
+++ b/crates/runtime/src/compact.rs
@@ -501,6 +501,17 @@ fn collapse_blank_lines(content: &str) -> String {
     result
 }
 
+/// Returns `true` when `message` is the synthetic system message produced by
+/// a prior compaction (i.e. starts with [`COMPACT_CONTINUATION_PREAMBLE`]).
+///
+/// Callers that need to skip the prior compaction prefix when slicing the
+/// removed range should go through this helper instead of substring-matching
+/// the preamble themselves — that keeps the wording in one place.
+#[must_use]
+pub fn is_compact_continuation_message(message: &ConversationMessage) -> bool {
+    extract_existing_compacted_summary(message).is_some()
+}
+
 fn extract_existing_compacted_summary(message: &ConversationMessage) -> Option<String> {
     if message.role != MessageRole::System {
         return None;

--- a/crates/runtime/src/conversation.rs
+++ b/crates/runtime/src/conversation.rs
@@ -483,7 +483,6 @@ fn try_llm_summarize<C: ApiClient>(
     model: Option<&str>,
 ) -> Option<String> {
     const MAX_SUMMARIZER_TOKENS: usize = 100_000;
-    const MAX_SUMMARY_CHARS: usize = 1_200;
     const SUMMARY_TEMPLATE: &str = "Summarize this conversation segment concisely.\n\
 Output EXACTLY this structure with no other text:\n\
 ## Goal\n\
@@ -541,12 +540,18 @@ Output EXACTLY this structure with no other text:\n\
         |model| format!("You are summarizing a conversation with model {model}."),
     );
 
-    let events = api_client
-        .stream(ApiRequest {
-            system_prompt: vec![system_hint],
-            messages: vec![ConversationMessage::user_text(user_content)],
-        })
-        .ok()?;
+    let events = match api_client.stream(ApiRequest {
+        system_prompt: vec![system_hint],
+        messages: vec![ConversationMessage::user_text(user_content)],
+    }) {
+        Ok(events) => events,
+        Err(err) => {
+            eprintln!(
+                "warning: LLM summarization failed ({err}); falling back to mechanical summary"
+            );
+            return None;
+        }
+    };
 
     let llm_summary: String = events
         .iter()
@@ -560,12 +565,24 @@ Output EXACTLY this structure with no other text:\n\
         .collect();
 
     let llm_summary = llm_summary.trim();
-    if llm_summary.is_empty() || llm_summary.len() > MAX_SUMMARY_CHARS {
+    if llm_summary.is_empty() {
+        eprintln!(
+            "warning: LLM summarization returned empty response; falling back to mechanical summary"
+        );
         return None;
     }
 
+    // Always compress: `compress_summary_text` enforces the default budget
+    // (max_chars / max_lines / max_line_chars) and gracefully truncates
+    // oversized output instead of throwing it away. Earlier the function
+    // hard-rejected anything over a byte ceiling, which silently dropped
+    // useful summaries that were just a little long — and used byte length
+    // for a char-counted budget on top of that.
     let compressed = crate::summary_compression::compress_summary_text(llm_summary);
     if compressed.is_empty() {
+        eprintln!(
+            "warning: LLM summary was empty after compression; falling back to mechanical summary"
+        );
         return None;
     }
 
@@ -957,6 +974,32 @@ mod tests {
         assert!(
             summary.contains("Goal") || summary.contains("goal"),
             "should contain structured output"
+        );
+    }
+
+    #[test]
+    fn try_llm_summarize_compresses_oversized_response() {
+        // Previously, a response over the byte ceiling was hard-rejected with
+        // no diagnostic, silently dropping a usable summary on the floor.
+        // It should now flow through summary compression instead.
+        let removed = vec![crate::session::ConversationMessage::user_text("hello")];
+        let oversized = "## Goal\n".to_string() + &"word ".repeat(1_000); // >> 1_200 chars
+        let mut client = MockApiClientWithText(oversized);
+
+        let result = super::try_llm_summarize(&removed, &mut client, None);
+
+        let summary = result.expect("oversized response must be compressed, not dropped");
+        assert!(summary.starts_with("<summary>"));
+        assert!(summary.ends_with("</summary>"));
+        // The inner payload must respect the compression budget (1_200 chars
+        // by default), not silently overflow.
+        let inner = summary
+            .trim_start_matches("<summary>")
+            .trim_end_matches("</summary>");
+        assert!(
+            inner.chars().count() <= 1_200,
+            "compressed inner length must respect default budget; got {}",
+            inner.chars().count()
         );
     }
 

--- a/crates/runtime/src/conversation.rs
+++ b/crates/runtime/src/conversation.rs
@@ -438,17 +438,16 @@ where
         }
 
         if config.llm_summarization {
-            let existing_prefix =
-                usize::from(self.session.messages.first().is_some_and(|message| {
-                    message.role == crate::session::MessageRole::System
-                        && message.blocks.iter().any(|block| matches!(
-                            block,
-                            ContentBlock::Text { text }
-                                if text.starts_with(
-                                    "This session is being continued from a previous conversation",
-                                )
-                        ))
-                }));
+            // Detect (and skip) a prior compaction's continuation message so
+            // the LLM summarizer doesn't re-summarize the previous summary.
+            // Detection lives in `compact::is_compact_continuation_message`
+            // so the preamble wording has a single source of truth.
+            let existing_prefix = usize::from(
+                self.session
+                    .messages
+                    .first()
+                    .is_some_and(crate::compact::is_compact_continuation_message),
+            );
             let removed_end =
                 (existing_prefix + result.removed_message_count).min(self.session.messages.len());
             let removed_messages = &self.session.messages[existing_prefix..removed_end];

--- a/crates/runtime/src/mcp/process.rs
+++ b/crates/runtime/src/mcp/process.rs
@@ -16,6 +16,13 @@ use super::types::{
     McpToolCallParams, McpToolCallResult,
 };
 
+/// Hard cap on a single MCP JSON-RPC frame. A malicious or buggy MCP server can
+/// advertise an arbitrary `Content-Length`; without a ceiling, the subsequent
+/// `vec![0; content_length]` allocation lets it trigger OOM in the host.
+/// 64 MiB is well above any real MCP payload and small enough to refuse with a
+/// clear error before allocating.
+const MAX_MCP_FRAME_BYTES: usize = 64 * 1024 * 1024;
+
 #[derive(Debug)]
 pub struct McpStdioProcess {
     child: Child,
@@ -115,6 +122,14 @@ impl McpStdioProcess {
         let content_length = content_length.ok_or_else(|| {
             io::Error::new(io::ErrorKind::InvalidData, "missing Content-Length header")
         })?;
+        if content_length > MAX_MCP_FRAME_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "MCP frame too large: {content_length} bytes (limit {MAX_MCP_FRAME_BYTES})"
+                ),
+            ));
+        }
         let mut payload = vec![0_u8; content_length];
         self.stdout.read_exact(&mut payload).await?;
         Ok(payload)
@@ -488,6 +503,26 @@ while True:
         script_path
     }
 
+    fn write_huge_content_length_script() -> PathBuf {
+        let root = temp_dir();
+        fs::create_dir_all(&root).expect("temp dir");
+        let script_path = root.join("huge-content-length.py");
+        let script = [
+            "#!/usr/bin/env python3",
+            "import sys",
+            // Advertise ~10 GiB; we never get a chance to write that much.
+            "sys.stdout.buffer.write(b'Content-Length: 10737418240\\r\\n\\r\\n')",
+            "sys.stdout.buffer.flush()",
+            "",
+        ]
+        .join("\n");
+        fs::write(&script_path, script).expect("write script");
+        let mut permissions = fs::metadata(&script_path).expect("metadata").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script_path, permissions).expect("chmod");
+        script_path
+    }
+
     fn write_missing_header_script() -> PathBuf {
         let root = temp_dir();
         fs::create_dir_all(&root).expect("temp dir");
@@ -853,6 +888,33 @@ while True:
             let status = process.wait().await.expect("wait for exit");
             assert!(status.success());
 
+            cleanup_script(&script_path);
+        });
+    }
+
+    #[test]
+    fn rejects_oversized_content_length() {
+        let runtime = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        runtime.block_on(async {
+            let script_path = write_huge_content_length_script();
+            let transport = script_transport(&script_path);
+            let mut process =
+                McpStdioProcess::spawn(&transport).expect("spawn oversized-length server");
+
+            let error = process
+                .read_frame()
+                .await
+                .expect_err("oversized Content-Length should error before allocation");
+            assert_eq!(error.kind(), ErrorKind::InvalidData);
+            assert!(
+                error.to_string().contains("MCP frame too large"),
+                "unexpected error: {error}"
+            );
+
+            let _ = process.wait().await;
             cleanup_script(&script_path);
         });
     }

--- a/crates/runtime/src/mcp/server_manager.rs
+++ b/crates/runtime/src/mcp/server_manager.rs
@@ -103,7 +103,9 @@ impl McpServerManager {
                         McpServerManagerError::InvalidResponse {
                             server_name: server_name.clone(),
                             method: "tools/list",
-                            details: "server process missing after initialization".to_string(),
+                            details: "MCP server process is gone — it likely crashed or was killed; \
+                                      check the server's stderr output above and retry"
+                                .to_string(),
                         }
                     })?;
                     timeout(
@@ -287,7 +289,10 @@ impl McpServerManager {
                     McpServerManagerError::InvalidResponse {
                         server_name: server_name.to_string(),
                         method: "initialize",
-                        details: "server process missing before initialize".to_string(),
+                        details: "MCP server process is gone before initialize — \
+                                  spawn appears to have failed silently; \
+                                  check the server's stderr output above and retry"
+                            .to_string(),
                     }
                 })?;
                 timeout(
@@ -324,7 +329,9 @@ impl McpServerManager {
                     McpServerManagerError::InvalidResponse {
                         server_name: server_name.to_string(),
                         method: "notifications/initialized",
-                        details: "server process missing before initialized notification"
+                        details: "MCP server process is gone after initialize but before \
+                                  the initialized notification — the server probably exited mid-handshake; \
+                                  check the server's stderr output above and retry"
                             .to_string(),
                     }
                 })?;

--- a/crates/runtime/src/mcp/server_manager.rs
+++ b/crates/runtime/src/mcp/server_manager.rs
@@ -103,9 +103,10 @@ impl McpServerManager {
                         McpServerManagerError::InvalidResponse {
                             server_name: server_name.clone(),
                             method: "tools/list",
-                            details: "MCP server process is gone — it likely crashed or was killed; \
+                            details:
+                                "MCP server process is gone — it likely crashed or was killed; \
                                       check the server's stderr output above and retry"
-                                .to_string(),
+                                    .to_string(),
                         }
                     })?;
                     timeout(

--- a/crates/runtime/src/mcp/server_manager.rs
+++ b/crates/runtime/src/mcp/server_manager.rs
@@ -243,8 +243,13 @@ impl McpServerManager {
     }
 
     fn take_request_id(&mut self) -> JsonRpcId {
+        // saturating_add would have pinned every subsequent request at
+        // u64::MAX once the counter reached the ceiling, repeatedly issuing
+        // the same id and breaking JSON-RPC correlation. Wrap to 1 instead;
+        // any in-flight requests will have resolved long before another
+        // 2^64 ids are minted, so reuse-after-wrap is benign.
         let id = self.next_request_id;
-        self.next_request_id = self.next_request_id.saturating_add(1);
+        self.next_request_id = self.next_request_id.checked_add(1).unwrap_or(1);
         JsonRpcId::Number(id)
     }
 

--- a/crates/runtime/src/summary_compression.rs
+++ b/crates/runtime/src/summary_compression.rs
@@ -30,6 +30,11 @@ pub struct SummaryCompressionResult {
     pub compressed_lines: usize,
     pub removed_duplicate_lines: usize,
     pub omitted_lines: usize,
+    /// `true` iff any content from the (trimmed) input was dropped or shortened
+    /// to fit the budget — including the degenerate cases where the input was
+    /// non-empty but the budget was zero, or normalization collapsed every line
+    /// to nothing. `false` iff the compressed output is equivalent to the
+    /// trimmed input.
     pub truncated: bool,
 }
 
@@ -126,7 +131,13 @@ fn normalize_lines(summary: &str, max_line_chars: usize) -> NormalizedSummary {
 }
 
 fn select_line_indexes(lines: &[String], budget: SummaryCompressionBudget) -> Vec<usize> {
+    // Maintain running totals matching `joined_char_count`'s semantic
+    // (sum of chars in selected lines plus `selected.len() - 1` newline
+    // joiners) so each candidate is an O(1) check instead of an O(N)
+    // rescan. Selection used to be O(P · N · S) which became visible once
+    // `max_summary_chars` was made configurable upward of the default.
     let mut selected = BTreeSet::<usize>::new();
+    let mut running_chars = 0usize;
 
     for priority in 0..=3 {
         for (index, line) in lines.iter().enumerate() {
@@ -134,21 +145,20 @@ fn select_line_indexes(lines: &[String], budget: SummaryCompressionBudget) -> Ve
                 continue;
             }
 
-            let candidate = selected
-                .iter()
-                .map(|selected_index| lines[*selected_index].as_str())
-                .chain(std::iter::once(line.as_str()))
-                .collect::<Vec<_>>();
-
-            if candidate.len() > budget.max_lines {
+            let prospective_count = selected.len() + 1;
+            if prospective_count > budget.max_lines {
                 continue;
             }
 
-            if joined_char_count(&candidate) > budget.max_chars {
+            let line_chars = line.chars().count();
+            let joiner = usize::from(!selected.is_empty());
+            let prospective_chars = running_chars + line_chars + joiner;
+            if prospective_chars > budget.max_chars {
                 continue;
             }
 
             selected.insert(index);
+            running_chars = prospective_chars;
         }
     }
 

--- a/install.ps1
+++ b/install.ps1
@@ -45,6 +45,14 @@ try {
     exit 1
 }
 
+# Defence in depth: reject anything that isn't a recognisable semver tag
+# before it flows into download URLs, in case GitHub's payload shape ever
+# changes or a misconfigured proxy returns something else.
+if ([string]::IsNullOrWhiteSpace($version) -or $version -notmatch '^\d+\.\d+\.\d+([-+.][A-Za-z0-9.-]+)?$') {
+    Write-Error "GitHub API returned an unexpected version string: '$version'"
+    exit 1
+}
+
 Write-Host "  Latest version: v$version" -ForegroundColor Green
 
 # --- 3. Download binary ---

--- a/install.sh
+++ b/install.sh
@@ -64,6 +64,15 @@ if [ -z "$version" ]; then
     exit 1
 fi
 
+# Defence in depth: the sed-based extraction above can quietly produce a
+# non-version string if the GitHub API response changes shape or is replaced
+# with attacker-controlled content via a misconfigured proxy. Reject anything
+# that isn't a recognisable semver tag before it flows into download URLs.
+if ! [[ "$version" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+([-+.][A-Za-z0-9.-]+)?$ ]]; then
+    echo "Error: GitHub API returned an unexpected version string: '$version'" >&2
+    exit 1
+fi
+
 echo "Latest version: $version"
 
 # --- 3. Download binary ---


### PR DESCRIPTION
## Summary

Addresses the Critical / High / Medium findings from the recent thorough code review of the workspace. 22 fixes across the Rust crates, the install scripts, and CI, plus three follow-on commits (rustfmt, clippy cleanup, drive-by fix to a pre-existing test failure on the branch tip). One commit per issue.

This branch also bundles three earlier `feat(runtime)` commits that landed before the security pass began — see **Bundled feature work** below — and seven review-follow-up fixes addressing findings raised on the security pass itself.

### Security (A)
- **A1** — `crates/api/src/credentials.rs`: chmod 0600 on the credentials file so API keys / OAuth tokens aren't world-readable on shared hosts.
- **A2** — `crates/crawler/src/tools/navigate.rs`: allowlist `http`/`https` schemes; rejects `file://`, `javascript:`, `data:`, etc. (SSRF / local-file-disclosure primitive).
- **A3** — `crates/acrawl-cli/src/tui/auth_modal.rs`: wrap the in-progress API key buffer in `zeroize::Zeroizing` so it's wiped on modal transition / drop.
- **A4 / A5** — `install.sh` / `install.ps1`: reject anything that isn't a recognisable semver tag from the GitHub release API before it flows into download URLs.
- **A6** — `.github/workflows/release.yml`: pass `$VERSION` to `awk` via `-v` so regex metacharacters in a tag name can't break or broaden the changelog match.

### Robustness / DoS limits (B)
- **B1** — `crates/runtime/src/mcp/process.rs`: cap MCP `Content-Length` at 64 MiB before allocating, with a regression test.
- **B2** — `crates/crawler/src/fetcher.rs`: cap HTTP response bodies at 32 MiB, stream chunk-by-chunk, new `FetchError::BodyTooLarge`, regression test via local TCP listener.
- **B3** — `crates/acrawl-cli/src/tui/repl_app.rs`: bound `drain_events` and the typewriter backlog so a fast streamer can't starve the render loop or grow the VecDeque without limit.

### Correctness (C)
- **C1** — `Usage::total_tokens` now includes both cache-token fields (was undercounting when prompt caching was on).
- **C2** — verified false positive: all `.expect()` calls in `bedrock.rs` are inside `#[cfg(test)] mod tests`. No commit.
- **C3** — `ModelModal::take_outcome` so a single Enter can't fire a model switch twice.
- **C4** — global Ctrl+C suppressed while a modal is open (was orphaning OAuth threads).
- **C5** — fork child IDs come from a monotonic `AtomicU64` so IDs don't reuse after a `wait_for_subagents` drain.
- **C6** — `take_request_id` uses `checked_add` (wraps to 1) instead of `saturating_add` (would have pinned every subsequent id at `u64::MAX`).
- **C7** — central `REQUIRES_ASYNC_MARKER` constant + `is_requires_async_error` recogniser; eliminates the duplicated literal string. (Later promoted in E6 to a real `ToolError` variant — see Review follow-ups.)
- **C8** — `persist_session` recovers a poisoned `pending_title` mutex via `PoisonError::into_inner` instead of silently dropping the title.
- **C9** — `SseParser` errors with `ApiError::InvalidSseFrame` on invalid UTF-8 instead of silently lossy-decoding; regression tests for both mid-stream and trailing-buffer paths; Gemini stream caller updated.
- **C10** — new shared `crate::auth::load_credentials_or_warn` helper warns to stderr on a credential-load error before defaulting. Migrated the credential-mutating call sites.
- **C11** — log the tool-name + use-id + parse error before wrapping non-JSON tool input in `{"raw": ...}`.

### UX / diagnostics (D)
- **D1** — `/clear` strict-parses its flag; `/clear --comfirm` is now `Unknown` rather than silently wiping the session.
- **D2** — wait-for-OAuth-callback prints a remaining-time message every 30 s.
- **D3** — auth flows (`anthropic.rs`, `openai.rs`, `tui/auth_modal.rs` model fetch) reuse the process-wide `TOKIO_RUNTIME` instead of spinning up a fresh `Runtime` per call. The few remaining `Runtime::new()` sites live inside spawned background threads — same anti-pattern, but a wider refactor — and are called out in the commit message.
- **D4** — replace cryptic "server process missing after initialization" diagnostics with actionable messages pointing at the MCP server's stderr.

### Review follow-ups (E)
A second-pass review on the security commits flagged a few items; each got its own commit:
- **E1 / Finding #2** — `refactor(runtime): single source of truth for compact continuation prefix`. Removed the literal-substring probe in `conversation.rs` and replaced it with `crate::compact::is_compact_continuation_message`, so the preamble wording stays in one place (and silent-breaks when it evolves stop being possible).
- **E2 / Finding #3** — `fix(runtime): compress oversized LLM summaries instead of dropping them`. `try_llm_summarize` used to hard-reject any response over a 1_200-byte ceiling (with byte length checked against a char-counted budget on top of that), silently falling back to the mechanical path. Now every non-empty response flows through `compress_summary_text`, which already enforces the budget; reject paths emit `eprintln` warnings; regression test added.
- **E3 / Finding #1** — `security(api/tui): zeroize credential copies past the modal buffer`. Adds `zeroize` to the `api` crate, wraps the serialized JSON inside `save_credentials_to_path` in `Zeroizing<String>`, and scrubs the stored `config.api_key` in the `CredentialStore` after `save_credentials` returns. Comment updated to match the actual guarantee.
- **E4 / Finding #5** — `fix(crawler/playwright): reuse Turnstile-bypass html instead of refetching`. The navigate handler was overwriting `bypassTurnstileIfPresent`'s return value with a redundant `page.content()` call, doubling the bridge round-trip per navigate.
- **E5 / Finding #7 + minor** — `perf(runtime/summary_compression): O(N) line selection via running totals`. `select_line_indexes` rebuilt `joined_char_count(candidate)` per iteration (O(P · N · S)); now uses running counters for O(N) per priority pass. Also adds a doc comment to `SummaryCompressionResult::truncated`.
- **E6 / Finding #4** — `fix(crawler): promote requires-async ToolError to a typed variant`. `ToolError` is now an enum (`Message`/`RequiresAsync`); the registry stub builds the sentinel via `ToolError::requires_async(...)` and the agent loop recognises it through `error.is_requires_async()` instead of substring-matching `error.to_string()`. ~40 tuple-struct call sites swept to `ToolError::new(...)`. Includes a regression test asserting a `Message` whose text happens to mention the canonical phrase is NOT misclassified — exactly the false positive the old substring matcher would have produced.
- **E7 / Finding #6** — `fix(cli): reject unknown / non-resume-safe slash commands at --resume parse time`. `parse_resume_args` previously accepted anything starting with `/`; it now validates each grouped command's head token against `commands::resume_supported_slash_commands()` and errors at arg-parse time naming the offending command plus the supported set. Plus a `style: cargo fmt` cleanup for the wrap drift those two commits introduced.

### Follow-on commits
- `style: cargo fmt` — applies rustfmt to the touched files and the lingering drift in `runtime/src/compact.rs` (which was already out of formatter on the branch tip before this PR began).
- `chore: address clippy warnings introduced earlier in this branch` — three local lint allowances (`doc_markdown`, `too_many_lines` on `fetch_models_for_provider`, `needless_pass_by_value` on `save_api_key` where by-value is intentional for the zeroize-on-drop guarantee).
- `fix(commands): repair compact-slash-command test broken by walk-back` — drive-by fix for a test that was already failing on the branch tip from commit 59a4ab7's tool-pair walk-back, which the older test fixture in `commands/src/lib.rs` never got updated for.

### Bundled feature work (already on the branch when this PR started)
The branch tip already carried three feature commits when the security pass began. They aren't part of the security review itself but are merged in this PR — calling out so reviewers aren't approving them blind:
- `feat(runtime): add summary prefix detection and compression module` — new `crates/runtime/src/summary_compression.rs` (priority-based line selection, dedupe, whitespace normalisation), plus `prune_tool_outputs` in `compact.rs`.
- `feat(runtime): token-budget tail and summary merging for compaction` — replaces the fixed-message preserve window with a token-budget walk, adds `merge_compact_summaries`, wires the expanded `CompactionConfig` through `Settings`.
- `feat(runtime): LLM-powered summarization with mechanical fallback` — `try_llm_summarize` in `conversation.rs` (now also touched by E2 above).

### Out of scope
Low-severity findings from the review (clippy nits, big-function decomposition, grapheme handling in `wrap_ansi_line`, fetcher O(n²) tag stripping, `child_tabs` MAX_ENTRIES UX marker, OAuth error-enum granularity) — separate follow-up. The TUI "child tab concurrent modification" finding was investigated and discarded as a false positive (TUI runs single-threaded).

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — 872 passed, 0 failed, 7 ignored (was 835 before the follow-up fixes — 37 new regression tests across the branch)
- [ ] Manual: `ls -l ~/.acrawl/credentials.json` shows `-rw-------`
- [ ] Manual: agent attempt at `file:///etc/passwd` rejected by `navigate`
- [ ] Manual: `/clear --comfirm` does not clear the session
- [ ] Manual: open and close the auth modal during a long task — Ctrl+C inside the modal does not cancel the agent
- [ ] Manual: `acrawl --resume session.json /not-a-command` is rejected at the CLI with a useful error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
