### PR TITLE
feat: subagent control plane (cancel, status, URL claim registry)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,6 +519,7 @@ version = "0.4.7"
 dependencies = [
  "csv",
  "htmd",
+ "regex",
  "reqwest 0.12.28",
  "runtime",
  "serde",

--- a/crates/acrawl-cli/src/tui/child_tabs.rs
+++ b/crates/acrawl-cli/src/tui/child_tabs.rs
@@ -16,7 +16,6 @@ pub enum ChildTabStatus {
 #[derive(Clone)]
 pub struct ChildTabState {
     pub(super) child_id: String,
-    pub(super) sub_goal: String,
     pub(super) status: ChildTabStatus,
     pub(super) step: usize,
     pub(super) max_steps: usize,
@@ -32,16 +31,16 @@ pub struct ChildTabState {
 
 impl ChildTabState {
     pub fn new(child_id: String, sub_goal: String) -> Self {
+        let entries = vec![TranscriptEntry::Parent(sub_goal)];
         Self {
             child_id,
-            sub_goal,
             status: ChildTabStatus::Running,
             step: 0,
             max_steps: 0,
             tool_in_progress: None,
             items_extracted: 0,
             follow_bottom: true,
-            entries: Vec::new(),
+            entries,
             list_state: ListState::default(),
             last_wrapped_len: 0,
             last_view_height: 0,
@@ -364,8 +363,9 @@ mod tests {
             },
         );
         let tab = &panel.tabs[0];
-        assert_eq!(tab.entries.len(), 1);
-        match &tab.entries[0] {
+        // entries[0] is the initial Parent entry; entries[1] is the ToolCall
+        assert_eq!(tab.entries.len(), 2);
+        match &tab.entries[1] {
             TranscriptEntry::ToolCall { name, status, .. } => {
                 assert_eq!(name, "navigate");
                 assert!(matches!(status, ToolCallStatus::Running));
@@ -395,7 +395,8 @@ mod tests {
             },
         );
         let tab = &panel.tabs[0];
-        match &tab.entries[0] {
+        // entries[0] is the initial Parent entry; entries[1] is the ToolCall
+        match &tab.entries[1] {
             TranscriptEntry::ToolCall { status, .. } => {
                 assert!(matches!(status, ToolCallStatus::Success { .. }));
             }
@@ -424,7 +425,8 @@ mod tests {
             },
         );
         let tab = &panel.tabs[0];
-        match &tab.entries[0] {
+        // entries[0] is the initial Parent entry; entries[1] is the ToolCall
+        match &tab.entries[1] {
             TranscriptEntry::ToolCall { status, .. } => {
                 assert!(matches!(status, ToolCallStatus::Error(_)));
             }

--- a/crates/acrawl-cli/src/tui/child_tabs.rs
+++ b/crates/acrawl-cli/src/tui/child_tabs.rs
@@ -170,8 +170,6 @@ impl ChildTabPanel {
                 let tab = &mut self.tabs[idx];
                 tab.step = *step;
                 tab.max_steps = *max_steps;
-                tab.entries
-                    .push(TranscriptEntry::Status(format!("Step {step}/{max_steps}")));
             }
             crawler::ChildEventKind::PauseRequested { reason } => {
                 self.tabs[idx].status = ChildTabStatus::Paused {
@@ -491,15 +489,12 @@ mod tests {
     #[test]
     fn test_bounded_storage_cap() {
         let mut panel = ChildTabPanel::default();
-        // Push more than 1000 entries via StepStarted events
+        // Push more than 1000 entries via TextDelta events (one line each)
         for i in 0..1100u32 {
             panel.apply_event(
                 "child-1",
                 "goal",
-                &crawler::ChildEventKind::StepStarted {
-                    step: i as usize,
-                    max_steps: 1100,
-                },
+                &crawler::ChildEventKind::TextDelta(format!("line {i}\n")),
             );
         }
         let tab = &panel.tabs[0];

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -78,6 +78,7 @@ pub(super) enum TranscriptEntry {
     System(String),
     Status(String),
     User(String),
+    Parent(String),
     Stream(Line<'static>),
     SystemCard {
         title: String,

--- a/crates/acrawl-cli/src/tui/repl_render.rs
+++ b/crates/acrawl-cli/src/tui/repl_render.rs
@@ -404,6 +404,9 @@ pub(super) fn build_wrapped_list(
     let user_prefix_style = Style::default()
         .fg(Color::Cyan)
         .add_modifier(Modifier::BOLD);
+    let parent_prefix_style = Style::default()
+        .fg(Color::Green)
+        .add_modifier(Modifier::BOLD);
 
     for entry in entries {
         match entry {
@@ -431,6 +434,26 @@ pub(super) fn build_wrapped_list(
                     };
                     text_out.push(line_to_plain_text(&line));
                     out.push(ListItem::new(line).bg(user_bg));
+                }
+            }
+            TranscriptEntry::Parent(text) => {
+                let prefixed = format!("  Parent {text}");
+                let rows = wrap_plain_text(&prefixed, width);
+                let parent_bg = Color::Rgb(30, 45, 35);
+                for (idx, row) in rows.into_iter().enumerate() {
+                    let line = if idx == 0 && row.trim_start().starts_with("Parent ") {
+                        let trimmed = row.trim_start();
+                        let rest = trimmed.get(7..).unwrap_or("").to_string();
+                        Line::from(vec![
+                            Span::raw("  "),
+                            Span::styled("Parent ", parent_prefix_style),
+                            Span::raw(rest),
+                        ])
+                    } else {
+                        Line::from(Span::raw(row))
+                    };
+                    text_out.push(line_to_plain_text(&line));
+                    out.push(ListItem::new(line).bg(parent_bg));
                 }
             }
             TranscriptEntry::Status(text) => {
@@ -535,9 +558,11 @@ pub(super) fn build_wrapped_list(
             }
         }
 
-        // Add a blank separator line ONLY after User messages or Cards to separate blocks
+        // Add a blank separator line after User/Parent messages or Cards to separate blocks
         match entry {
-            TranscriptEntry::User(_) | TranscriptEntry::SystemCard { .. } => {
+            TranscriptEntry::User(_)
+            | TranscriptEntry::Parent(_)
+            | TranscriptEntry::SystemCard { .. } => {
                 out.push(ListItem::new(Line::from(" ")));
                 text_out.push(" ".to_string());
             }
@@ -984,7 +1009,6 @@ pub(super) fn draw_child_view(frame: &mut ratatui::Frame<'_>, state: &mut ReplTu
                 .fg(ratatui::style::Color::Cyan)
                 .add_modifier(ratatui::style::Modifier::BOLD),
         ),
-        ratatui::text::Span::raw(format!("  {} ", tab.sub_goal)),
         ratatui::text::Span::styled(
             format!("  {status_text} "),
             ratatui::style::Style::default().fg(status_color),

--- a/crates/acrawl-cli/src/tui/repl_render.rs
+++ b/crates/acrawl-cli/src/tui/repl_render.rs
@@ -443,7 +443,7 @@ pub(super) fn build_wrapped_list(
                 for (idx, row) in rows.into_iter().enumerate() {
                     let line = if idx == 0 && row.trim_start().starts_with("Parent ") {
                         let trimmed = row.trim_start();
-                        let rest = trimmed.get(7..).unwrap_or("").to_string();
+                        let rest = trimmed.get("Parent ".len()..).unwrap_or("").to_string();
                         Line::from(vec![
                             Span::raw("  "),
                             Span::styled("Parent ", parent_prefix_style),

--- a/crates/acrawl-cli/tests/child_escalation_test.rs
+++ b/crates/acrawl-cli/tests/child_escalation_test.rs
@@ -38,6 +38,7 @@ mod repl_app {
         System(String),
         Status(String),
         User(String),
+        Parent(String),
         Stream(ratatui::text::Line<'static>),
         SystemCard {
             title: String,

--- a/crates/crawler/Cargo.toml
+++ b/crates/crawler/Cargo.toml
@@ -13,6 +13,7 @@ tokio = { version = "1", features = ["io-util", "macros", "net", "process", "rt"
 csv = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 htmd = "0.5"
+regex = "1"
 
 [lints]
 workspace = true

--- a/crates/crawler/src/agent/fork.rs
+++ b/crates/crawler/src/agent/fork.rs
@@ -5,9 +5,21 @@ use runtime::ToolError;
 use super::CrawlerAgent;
 use crate::state::ChildBlock;
 use crate::{
-    tool_effect::{CancelSpec, ForkSpec, StatusSpec, WaitSpec},
-    BrowserContext, ToolRegistry,
+    tool_effect::{CancelSpec, CrawlScope, CrawlTask, StatusSpec, WaitSpec},
+    BrowserContext, ClaimGuard, ToolRegistry,
 };
+
+/// The initial URL the child should land on, derived from the task's
+/// [`CrawlScope`]. `UrlPattern` scopes do not specify a starting page; the
+/// parent's current URL is reused, and the LLM is expected to navigate
+/// within the pattern.
+fn scope_initial_url<'a>(scope: &'a CrawlScope, parent_url: Option<&'a str>) -> Option<&'a str> {
+    match scope {
+        CrawlScope::SinglePage { url } => Some(url.as_str()),
+        CrawlScope::UrlList { urls } => urls.first().map(String::as_str),
+        CrawlScope::UrlPattern { .. } => parent_url,
+    }
+}
 
 fn empty_wait_snapshot() -> String {
     serde_json::json!({
@@ -65,7 +77,15 @@ impl<'a> ForkSupervisor<'a> {
         format!("{}-child-{n}", self.agent.agent_id)
     }
 
-    async fn claim_child_slot(&mut self, child_id: &str) -> Result<(), ToolError> {
+    /// Atomically reserve a child slot and the URL scope. Both checks happen
+    /// under the same `agent_manager` lock so racing siblings cannot both
+    /// claim the same scope. On success returns the `ClaimGuard` whose drop
+    /// releases the URL claim.
+    async fn claim_child_slot(
+        &mut self,
+        child_id: &str,
+        scope: &CrawlScope,
+    ) -> Result<ClaimGuard, ToolError> {
         let settings = runtime::load_settings();
         let mut manager = self.agent.agent_manager.lock().await;
         if !manager.contains(&self.agent.agent_id) {
@@ -78,7 +98,17 @@ impl<'a> ForkSupervisor<'a> {
 
         manager
             .register_child(child_id.to_string(), &self.agent.agent_id, None)
-            .map_err(|error| ToolError::new(error.to_string()))
+            .map_err(|error| ToolError::new(error.to_string()))?;
+
+        match manager.url_claims.try_claim(scope, child_id) {
+            Ok(guard) => Ok(guard),
+            Err(conflict) => {
+                // Roll back the slot reservation we just made so a later
+                // retry with a non-overlapping scope can still succeed.
+                manager.mark_done(child_id);
+                Err(ToolError::new(conflict.to_string()))
+            }
+        }
     }
 
     async fn release_child_slot(&mut self, child_id: &str) {
@@ -87,22 +117,24 @@ impl<'a> ForkSupervisor<'a> {
 }
 
 impl CrawlerAgent {
-    pub(super) async fn handle_spawn(&mut self, fork_spec: ForkSpec) -> Result<String, ToolError> {
-        let child_max_steps =
+    pub(super) async fn handle_spawn(&mut self, task: CrawlTask) -> Result<String, ToolError> {
+        let default_max_steps =
             runtime::settings_get_fork_child_max_steps(&runtime::load_settings()) as usize;
+        let child_max_steps = task.max_steps.unwrap_or(default_max_steps);
         let child_id = ForkSupervisor::new(self).next_child_id();
-        ForkSupervisor::new(self)
-            .claim_child_slot(&child_id)
+        let claim_guard = ForkSupervisor::new(self)
+            .claim_child_slot(&child_id, &task.scope)
             .await?;
+
+        let parent_url = self.crawl_state.current_url.clone();
+        let initial_url = scope_initial_url(&task.scope, parent_url.as_deref()).map(str::to_owned);
 
         let setup = async {
             self.ensure_browser().await?;
 
-            let child_state = self.crawl_state.fork(
-                &fork_spec.goal,
-                self.crawl_state.current_url.as_deref(),
-                child_max_steps,
-            );
+            let child_state =
+                self.crawl_state
+                    .fork(&task.objective, initial_url.as_deref(), child_max_steps);
             let child_api_client = self
                 .api_client_arc
                 .clone()
@@ -111,9 +143,8 @@ impl CrawlerAgent {
                 .shared_bridge
                 .clone()
                 .ok_or_else(|| ToolError::new("fork: browser bridge not initialized"))?;
-            let target_url = self.crawl_state.current_url.clone();
             let page_index = self
-                .create_child_page(shared_bridge.clone(), target_url.as_deref())
+                .create_child_page(shared_bridge.clone(), initial_url.as_deref())
                 .await?;
 
             Ok::<_, ToolError>((child_state, child_api_client, shared_bridge, page_index))
@@ -123,6 +154,9 @@ impl CrawlerAgent {
         let (child_state, child_api_client, shared_bridge, page_index) = match setup {
             Ok(values) => values,
             Err(error) => {
+                // Drop the claim guard so the URL is free for another child,
+                // and roll back the agent-tree reservation.
+                drop(claim_guard);
                 ForkSupervisor::new(self)
                     .release_child_slot(&child_id)
                     .await;
@@ -134,7 +168,7 @@ impl CrawlerAgent {
         // parent's snapshot registry Arc so the parent can poll their
         // progress without joining.
         self.child_snapshots
-            .register(&child_id, &fork_spec.goal, child_max_steps);
+            .register(&child_id, &task.objective, child_max_steps);
 
         let mut child_agent = CrawlerAgent::new(
             BrowserContext::new_shared(shared_bridge.clone(), page_index),
@@ -163,22 +197,22 @@ impl CrawlerAgent {
         child_agent.crawl_state = child_state;
         child_agent.api_client_arc = Some(child_api_client.clone());
 
-        let fork_spec = ForkSpec {
-            page_index: Some(page_index),
-            ..fork_spec
-        };
-        let child_sub_goal = fork_spec.goal.clone();
+        let child_objective = task.objective.clone();
         let runtime_handle = tokio::runtime::Handle::current();
         let join_handle = tokio::task::spawn_blocking(move || {
             runtime_handle
-                .block_on(child_agent.run(&child_sub_goal, child_api_client))
+                .block_on(child_agent.run(&child_objective, child_api_client))
                 .ok()
                 .map(|crawl_result| crawl_result.extracted_data)
         });
-        self.child_tasks
-            .insert(child_id.clone(), (fork_spec.goal.clone(), join_handle));
+        self.child_tasks.insert(
+            child_id.clone(),
+            (task.objective.clone(), join_handle, Some(claim_guard)),
+        );
 
-        let observation = format!("Forked subagent {child_id} for: {}", fork_spec.goal);
+        let _ = page_index; // page_index is tracked on the BrowserContext
+
+        let observation = format!("Forked subagent {child_id} for: {}", task.objective);
         self.crawl_state.action_history.push(observation.clone());
         Ok(observation)
     }
@@ -218,7 +252,7 @@ impl CrawlerAgent {
             .filter_map(|child_id| {
                 self.child_tasks
                     .remove(&child_id)
-                    .map(|(sub_goal, handle)| (child_id, sub_goal, handle))
+                    .map(|(sub_goal, handle, claim)| (child_id, sub_goal, handle, claim))
             })
             .collect::<Vec<_>>();
 
@@ -230,17 +264,18 @@ impl CrawlerAgent {
         let mut finished_entries: Vec<serde_json::Value> = Vec::new();
         let mut still_running_entries: Vec<serde_json::Value> = Vec::new();
 
-        for (child_id, sub_goal, mut handle) in tasks {
+        for (child_id, sub_goal, mut handle, claim) in tasks {
             let remaining = deadline
                 .checked_duration_since(Instant::now())
                 .unwrap_or_default();
 
             // Zero remaining is identical to "timed out": never abort, just
-            // re-insert the handle so a future wait/cancel can still target
-            // it, and report the child as still running.
+            // re-insert the handle (and its URL claim) so a future
+            // wait/cancel can still target it, and report the child as
+            // still running.
             if remaining.is_zero() {
                 still_running_entries.push(running_snapshot(&child_id, &sub_goal));
-                self.child_tasks.insert(child_id, (sub_goal, handle));
+                self.child_tasks.insert(child_id, (sub_goal, handle, claim));
                 continue;
             }
 
@@ -313,10 +348,10 @@ impl CrawlerAgent {
                 }
                 Err(_) => {
                     // Deadline elapsed mid-await. The child is still running;
-                    // re-insert the handle and surface a "running" snapshot.
-                    // No cancellation is performed.
+                    // re-insert the handle (with its claim guard) and
+                    // surface a "running" snapshot. No cancellation.
                     still_running_entries.push(running_snapshot(&child_id, &sub_goal));
-                    self.child_tasks.insert(child_id, (sub_goal, handle));
+                    self.child_tasks.insert(child_id, (sub_goal, handle, claim));
                 }
             }
         }
@@ -367,8 +402,11 @@ impl CrawlerAgent {
             }
 
             match self.child_tasks.remove(&child_id) {
-                Some((sub_goal, handle)) => {
+                Some((sub_goal, handle, claim)) => {
                     handle.abort();
+                    // Drop the claim guard explicitly so the URL scope is
+                    // immediately available to another sub-agent.
+                    drop(claim);
                     let reason = spec
                         .reason
                         .clone()
@@ -569,7 +607,10 @@ mod tests {
         agent.fork_page_index_override = Some(1);
 
         let observation = agent
-            .execute("fork", r#"{"sub_goal":"collect details"}"#)
+            .execute(
+                "fork",
+                r#"{"objective":"collect details","scope":{"type":"single_page","url":"https://example.com"}}"#,
+            )
             .await
             .expect("fork should succeed");
 
@@ -581,7 +622,7 @@ mod tests {
             agent.child_tasks.get("root-child-1").unwrap().0,
             "collect details"
         );
-        for (_, (_, handle)) in agent.child_tasks.drain() {
+        for (_, (_, handle, _)) in agent.child_tasks.drain() {
             handle.abort();
         }
     }
@@ -604,7 +645,7 @@ mod tests {
         let observation = agent
             .execute(
                 "fork",
-                r#"{"sub_goal":"check result","url":"https://example.com"}"#,
+                r#"{"objective":"check result","scope":{"type":"single_page","url":"https://example.com"}}"#,
             )
             .await
             .expect("fork should succeed");
@@ -612,7 +653,7 @@ mod tests {
         assert!(observation.contains("Forked subagent root-child-1 for: check result"));
         assert_eq!(manager.lock().await.get_children("root").len(), 1);
         assert_eq!(agent.child_tasks.len(), 1);
-        for (_, (_, handle)) in agent.child_tasks.drain() {
+        for (_, (_, handle, _)) in agent.child_tasks.drain() {
             let _ = handle.await;
         }
         assert_eq!(
@@ -635,7 +676,10 @@ mod tests {
         agent.fork_page_index_override = Some(1);
 
         let error = agent
-            .execute("fork", r#"{"sub_goal":"collect details"}"#)
+            .execute(
+                "fork",
+                r#"{"objective":"collect details","scope":{"type":"single_page","url":"https://example.com"}}"#,
+            )
             .await
             .expect_err("fork should fail when api client is missing");
 
@@ -647,6 +691,51 @@ mod tests {
             .next()
             .expect("child slot should be tracked");
         assert_eq!(child.status, crate::AgentStatus::Done);
+    }
+
+    #[tokio::test]
+    async fn test_two_forks_on_same_url_second_is_rejected() {
+        let _env_guard = env_lock().lock().await;
+        std::env::set_var("HEADLESS", "true");
+        let manager = super::super::default_agent_manager();
+        manager.lock().await.register_root("root");
+
+        let mut agent = CrawlerAgent::new_for_testing(ToolRegistry::new_with_core_tools())
+            .with_agent_id("root".to_string())
+            .with_agent_manager(manager.clone());
+        agent.api_client_arc = Some(crate::SharedApiClient::new(TextOnlyApiClient));
+        agent.shared_bridge = Some(test_bridge().await);
+        agent.fork_page_index_override = Some(1);
+
+        let first = agent
+            .execute(
+                "fork",
+                r#"{"objective":"a","scope":{"type":"single_page","url":"https://example.com/x"}}"#,
+            )
+            .await
+            .expect("first fork should succeed");
+        assert!(first.contains("Forked subagent root-child-1"));
+
+        let err = agent
+            .execute(
+                "fork",
+                r#"{"objective":"b","scope":{"type":"single_page","url":"https://example.com/x"}}"#,
+            )
+            .await
+            .expect_err("second fork on same URL should be rejected");
+        let msg = err.to_string();
+        assert!(msg.contains("already claimed"), "unexpected error: {msg}");
+        assert!(msg.contains("root-child-1"), "unexpected error: {msg}");
+
+        for (_, (_, handle, _)) in agent.child_tasks.drain() {
+            handle.abort();
+        }
+    }
+
+    fn env_lock() -> &'static tokio::sync::Mutex<()> {
+        use std::sync::OnceLock;
+        static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
     }
 
     #[tokio::test]
@@ -671,7 +760,7 @@ mod tests {
         let handle: tokio::task::JoinHandle<Option<Vec<Value>>> = tokio::spawn(async { None });
         agent
             .child_tasks
-            .insert("child-1".to_string(), ("search".to_string(), handle));
+            .insert("child-1".to_string(), ("search".to_string(), handle, None));
 
         let result = agent.execute("wait_for_subagents", "{}").await.unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
@@ -695,10 +784,10 @@ mod tests {
             tokio::spawn(async { Some(vec![serde_json::json!({"from": "child-2"})]) });
         agent
             .child_tasks
-            .insert("child-1".to_string(), ("goal-1".to_string(), handle1));
+            .insert("child-1".to_string(), ("goal-1".to_string(), handle1, None));
         agent
             .child_tasks
-            .insert("child-2".to_string(), ("goal-2".to_string(), handle2));
+            .insert("child-2".to_string(), ("goal-2".to_string(), handle2, None));
 
         let result = agent
             .handle_wait_effect(WaitSpec {
@@ -712,7 +801,7 @@ mod tests {
         assert_eq!(agent.crawl_state.child_blocks.len(), 1);
         assert_eq!(agent.crawl_state.child_blocks[0].child_id, "child-1");
         assert!(agent.child_tasks.contains_key("child-2"));
-        for (_, (_, handle)) in agent.child_tasks.drain() {
+        for (_, (_, handle, _)) in agent.child_tasks.drain() {
             handle.abort();
         }
     }
@@ -724,7 +813,7 @@ mod tests {
             tokio::spawn(async { Some(vec![serde_json::json!({"data": 1})]) });
         agent
             .child_tasks
-            .insert("real-child".to_string(), ("goal".to_string(), handle));
+            .insert("real-child".to_string(), ("goal".to_string(), handle, None));
 
         let result = agent
             .handle_wait_effect(WaitSpec {
@@ -736,7 +825,7 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
         assert_eq!(parsed["waited"], 0);
         assert!(agent.child_tasks.contains_key("real-child"));
-        for (_, (_, handle)) in agent.child_tasks.drain() {
+        for (_, (_, handle, _)) in agent.child_tasks.drain() {
             handle.abort();
         }
     }
@@ -757,10 +846,10 @@ mod tests {
         });
         agent
             .child_tasks
-            .insert("child-1".to_string(), ("goal-1".to_string(), handle1));
+            .insert("child-1".to_string(), ("goal-1".to_string(), handle1, None));
         agent
             .child_tasks
-            .insert("child-2".to_string(), ("goal-2".to_string(), handle2));
+            .insert("child-2".to_string(), ("goal-2".to_string(), handle2, None));
 
         let result = agent
             .handle_wait_effect(WaitSpec { child_ids: None })
@@ -794,7 +883,7 @@ mod tests {
             tokio::spawn(async { Some(vec![serde_json::json!({"a": 1})]) });
         agent
             .child_tasks
-            .insert("child-1".to_string(), ("goal-1".to_string(), handle));
+            .insert("child-1".to_string(), ("goal-1".to_string(), handle, None));
 
         let result = agent
             .handle_wait_effect(WaitSpec {
@@ -836,7 +925,7 @@ mod tests {
         });
         agent
             .child_tasks
-            .insert("child-1".to_string(), ("goal-1".to_string(), handle));
+            .insert("child-1".to_string(), ("goal-1".to_string(), handle, None));
 
         let result = agent
             .handle_wait_effect_with_timeout(
@@ -867,7 +956,7 @@ mod tests {
 
         // The handle is re-inserted so a future wait/cancel can still target it.
         assert!(agent.child_tasks.contains_key("child-1"));
-        for (_, (_, handle)) in agent.child_tasks.drain() {
+        for (_, (_, handle, _)) in agent.child_tasks.drain() {
             handle.abort();
         }
     }
@@ -890,7 +979,7 @@ mod tests {
         });
         agent
             .child_tasks
-            .insert("child-1".to_string(), ("goal-1".to_string(), handle));
+            .insert("child-1".to_string(), ("goal-1".to_string(), handle, None));
 
         let result = agent
             .handle_cancel_effect(crate::tool_effect::CancelSpec {

--- a/crates/crawler/src/agent/fork.rs
+++ b/crates/crawler/src/agent/fork.rs
@@ -977,7 +977,7 @@ mod tests {
             .with_child_event_sender(tx)
             .with_child_control_registry(registry.clone());
         let handle: tokio::task::JoinHandle<Option<Vec<Value>>> = tokio::spawn(async {
-            tokio::time::sleep(Duration::from_secs(60)).await;
+            tokio::time::sleep(Duration::from_mins(1)).await;
             Some(Vec::new())
         });
         agent

--- a/crates/crawler/src/agent/fork.rs
+++ b/crates/crawler/src/agent/fork.rs
@@ -12,7 +12,8 @@ use crate::{
 /// The initial URL the child should land on, derived from the task's
 /// [`CrawlScope`]. `UrlPattern` scopes do not specify a starting page; the
 /// parent's current URL is reused, and the LLM is expected to navigate
-/// within the pattern.
+/// within the pattern. For `UrlList`, only the first URL is used as the
+/// landing page; the child's objective string must guide it to the rest.
 fn scope_initial_url<'a>(scope: &'a CrawlScope, parent_url: Option<&'a str>) -> Option<&'a str> {
     match scope {
         CrawlScope::SinglePage { url } => Some(url.as_str()),
@@ -164,9 +165,10 @@ impl CrawlerAgent {
             }
         };
 
-        // Register a fresh snapshot for this child. Children inherit the
-        // parent's snapshot registry Arc so the parent can poll their
-        // progress without joining.
+        // Register a fresh snapshot for this child. Direct children inherit
+        // the parent's snapshot registry Arc, giving the parent one-level-deep
+        // visibility. Grandchildren populate their own parent's registry, not
+        // the root's — so subagent_status only sees direct children.
         self.child_snapshots
             .register(&child_id, &task.objective, child_max_steps);
 
@@ -445,6 +447,7 @@ impl CrawlerAgent {
     /// them) in the snapshot registry and returns a JSON array of progress
     /// snapshots. Does NOT join, cancel, or otherwise mutate the running
     /// children — safe to call between any steps.
+    // async is required to match the dispatch signature in dispatch_tool_effect.
     #[allow(clippy::unused_async)]
     pub(super) async fn handle_status_effect(
         &mut self,

--- a/crates/crawler/src/agent/fork.rs
+++ b/crates/crawler/src/agent/fork.rs
@@ -4,7 +4,44 @@ use runtime::ToolError;
 
 use super::CrawlerAgent;
 use crate::state::ChildBlock;
-use crate::{tool_effect::ForkSpec, tool_effect::WaitSpec, BrowserContext, ToolRegistry};
+use crate::{
+    tool_effect::{CancelSpec, ForkSpec, StatusSpec, WaitSpec},
+    BrowserContext, ToolRegistry,
+};
+
+fn empty_wait_snapshot() -> String {
+    serde_json::json!({
+        "waited": 0,
+        "finished": [],
+        "still_running": [],
+    })
+    .to_string()
+}
+
+fn running_snapshot(child_id: &str, sub_goal: &str) -> serde_json::Value {
+    serde_json::json!({
+        "child_id": child_id,
+        "sub_goal": sub_goal,
+        "status": "running",
+    })
+}
+
+fn finished_snapshot(
+    child_id: &str,
+    sub_goal: &str,
+    success: bool,
+    items_extracted: usize,
+    error: Option<&str>,
+) -> serde_json::Value {
+    serde_json::json!({
+        "child_id": child_id,
+        "sub_goal": sub_goal,
+        "status": if success { "completed" } else { "failed" },
+        "success": success,
+        "items_extracted": items_extracted,
+        "error": error,
+    })
+}
 
 pub(crate) struct ForkSupervisor<'a> {
     agent: &'a mut CrawlerAgent,
@@ -150,7 +187,11 @@ impl CrawlerAgent {
             .await
     }
 
-    // Sequential child wait loop — extracting helpers would obscure the timeout/cancel logic.
+    // Wait collects results from finished children and reports back a typed
+    // snapshot for children that haven't finished by the deadline. The wait
+    // **never** aborts or cancels children: the deadline only controls how
+    // long the parent blocks before returning. Cancellation is an explicit
+    // action, surfaced via `cancel_subagent`.
     #[allow(clippy::too_many_lines)]
     async fn handle_wait_effect_with_timeout(
         &mut self,
@@ -161,7 +202,7 @@ impl CrawlerAgent {
             .child_ids
             .unwrap_or_else(|| self.child_tasks.keys().cloned().collect());
         if child_ids.is_empty() {
-            return Ok("No active subagents".to_string());
+            return Ok(empty_wait_snapshot());
         }
 
         let deadline = Instant::now() + wait_timeout;
@@ -175,102 +216,223 @@ impl CrawlerAgent {
             .collect::<Vec<_>>();
 
         if tasks.is_empty() {
-            return Ok("No active subagents".to_string());
+            return Ok(empty_wait_snapshot());
         }
 
         let task_count = tasks.len();
-        let mut total_items = 0_usize;
+        let mut finished_entries: Vec<serde_json::Value> = Vec::new();
+        let mut still_running_entries: Vec<serde_json::Value> = Vec::new();
 
         for (child_id, sub_goal, mut handle) in tasks {
             let remaining = deadline
                 .checked_duration_since(Instant::now())
                 .unwrap_or_default();
-            let (items, finished_event) = if remaining.is_zero() {
-                if let Some(registry) = &self.child_control_registry {
-                    if let Some(state) = registry.get(&child_id) {
-                        state.request_cancel();
-                    }
-                }
-                handle.abort();
-                (
-                    Vec::new(),
-                    crate::child_events::ChildEventKind::Finished {
-                        success: false,
-                        items_extracted: 0,
-                        error: Some("timed out".to_string()),
-                    },
-                )
-            } else {
-                match tokio::time::timeout(remaining, &mut handle).await {
-                    Ok(Ok(Some(items))) => {
-                        let item_count = items.len();
-                        (
-                            items,
-                            crate::child_events::ChildEventKind::Finished {
-                                success: true,
-                                items_extracted: item_count,
-                                error: None,
-                            },
-                        )
-                    }
-                    Ok(Ok(None)) => (
-                        Vec::new(),
-                        crate::child_events::ChildEventKind::Finished {
-                            success: false,
-                            items_extracted: 0,
-                            error: Some("child failed".to_string()),
-                        },
-                    ),
-                    Ok(Err(error)) => (
-                        Vec::new(),
-                        crate::child_events::ChildEventKind::Finished {
-                            success: false,
-                            items_extracted: 0,
-                            error: Some(error.to_string()),
-                        },
-                    ),
-                    Err(_) => {
-                        if let Some(registry) = &self.child_control_registry {
-                            if let Some(state) = registry.get(&child_id) {
-                                state.request_cancel();
-                            }
-                        }
-                        handle.abort();
-                        (
-                            Vec::new(),
-                            crate::child_events::ChildEventKind::Finished {
-                                success: false,
-                                items_extracted: 0,
-                                error: Some("timed out".to_string()),
-                            },
-                        )
-                    }
-                }
-            };
 
-            total_items += items.len();
-            if let Some(ref tx) = self.child_event_tx {
-                let _ = tx.send(crate::child_events::ChildEvent {
-                    child_id: child_id.clone(),
-                    sub_goal: sub_goal.clone(),
-                    event: finished_event,
-                });
+            // Zero remaining is identical to "timed out": never abort, just
+            // re-insert the handle so a future wait/cancel can still target
+            // it, and report the child as still running.
+            if remaining.is_zero() {
+                still_running_entries.push(running_snapshot(&child_id, &sub_goal));
+                self.child_tasks.insert(child_id, (sub_goal, handle));
+                continue;
             }
-            self.crawl_state.child_blocks.push(ChildBlock {
-                child_id: child_id.clone(),
-                sub_goal,
-                items,
-            });
-            if let Some(registry) = &self.child_control_registry {
-                registry.remove(&child_id);
+
+            match tokio::time::timeout(remaining, &mut handle).await {
+                Ok(Ok(Some(items))) => {
+                    let item_count = items.len();
+                    finished_entries.push(finished_snapshot(
+                        &child_id, &sub_goal, true, item_count, None,
+                    ));
+                    self.emit_finished_event(&child_id, &sub_goal, true, item_count, None);
+                    self.crawl_state.child_blocks.push(ChildBlock {
+                        child_id: child_id.clone(),
+                        sub_goal,
+                        items,
+                    });
+                    self.cleanup_finished(&child_id).await;
+                }
+                Ok(Ok(None)) => {
+                    finished_entries.push(finished_snapshot(
+                        &child_id,
+                        &sub_goal,
+                        false,
+                        0,
+                        Some("child failed"),
+                    ));
+                    self.emit_finished_event(
+                        &child_id,
+                        &sub_goal,
+                        false,
+                        0,
+                        Some("child failed".to_string()),
+                    );
+                    self.crawl_state.child_blocks.push(ChildBlock {
+                        child_id: child_id.clone(),
+                        sub_goal,
+                        items: Vec::new(),
+                    });
+                    self.cleanup_finished(&child_id).await;
+                }
+                Ok(Err(error)) => {
+                    let message = error.to_string();
+                    finished_entries.push(finished_snapshot(
+                        &child_id,
+                        &sub_goal,
+                        false,
+                        0,
+                        Some(&message),
+                    ));
+                    self.emit_finished_event(&child_id, &sub_goal, false, 0, Some(message));
+                    self.crawl_state.child_blocks.push(ChildBlock {
+                        child_id: child_id.clone(),
+                        sub_goal,
+                        items: Vec::new(),
+                    });
+                    self.cleanup_finished(&child_id).await;
+                }
+                Err(_) => {
+                    // Deadline elapsed mid-await. The child is still running;
+                    // re-insert the handle and surface a "running" snapshot.
+                    // No cancellation is performed.
+                    still_running_entries.push(running_snapshot(&child_id, &sub_goal));
+                    self.child_tasks.insert(child_id, (sub_goal, handle));
+                }
             }
-            self.agent_manager.lock().await.mark_done(&child_id);
         }
 
+        let finished_count = finished_entries.len();
+        let still_running_count = still_running_entries.len();
+        let total_items: u64 = finished_entries
+            .iter()
+            .map(|entry| {
+                entry
+                    .get("items_extracted")
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or(0)
+            })
+            .sum();
+
+        let payload = serde_json::json!({
+            "waited": task_count,
+            "finished": finished_entries,
+            "still_running": still_running_entries,
+        });
+
+        let message = format!(
+            "Waited on {task_count} subagent(s): {finished_count} finished, {still_running_count} still running. Collected {total_items} item(s)."
+        );
+        self.crawl_state.action_history.push(message);
+
+        Ok(payload.to_string())
+    }
+
+    /// Cancel running sub-agents abortively. Each requested child's control
+    /// state has `request_cancel()` called (so a cooperatively-yielding child
+    /// observes cancellation between turns) and its `JoinHandle` is aborted
+    /// immediately. The user-facing contract is "cancel = abort": discarded
+    /// in-flight work is not collected.
+    pub(super) async fn handle_cancel_effect(
+        &mut self,
+        spec: CancelSpec,
+    ) -> Result<String, ToolError> {
+        let mut cancelled: Vec<serde_json::Value> = Vec::new();
+        let mut not_found: Vec<String> = Vec::new();
+
+        for child_id in spec.child_ids {
+            if let Some(registry) = &self.child_control_registry {
+                if let Some(state) = registry.get(&child_id) {
+                    state.request_cancel();
+                }
+            }
+
+            match self.child_tasks.remove(&child_id) {
+                Some((sub_goal, handle)) => {
+                    handle.abort();
+                    let reason = spec
+                        .reason
+                        .clone()
+                        .unwrap_or_else(|| "cancelled by parent".to_string());
+                    self.emit_finished_event(&child_id, &sub_goal, false, 0, Some(reason.clone()));
+                    self.crawl_state.child_blocks.push(ChildBlock {
+                        child_id: child_id.clone(),
+                        sub_goal: sub_goal.clone(),
+                        items: Vec::new(),
+                    });
+                    cancelled.push(serde_json::json!({
+                        "child_id": child_id,
+                        "sub_goal": sub_goal,
+                        "reason": reason,
+                    }));
+                    self.cleanup_finished(&child_id).await;
+                }
+                None => not_found.push(child_id),
+            }
+        }
+
+        let cancelled_count = cancelled.len();
+        let not_found_count = not_found.len();
+        let payload = serde_json::json!({
+            "cancelled": cancelled,
+            "not_found": not_found,
+        });
         let message =
-            format!("Waited for {task_count} subagent(s). Collected {total_items} item(s).");
-        self.crawl_state.action_history.push(message.clone());
-        Ok(message)
+            format!("Cancelled {cancelled_count} subagent(s); {not_found_count} not found.");
+        self.crawl_state.action_history.push(message);
+        Ok(payload.to_string())
+    }
+
+    /// Read-only status surface. Filled in by Step 2; for now reports the
+    /// presence of each requested child in `child_tasks` and a placeholder
+    /// state. Returning a stub here keeps `dispatch_tool_effect` exhaustive
+    /// without blocking Step 1 from shipping. Async signature is kept because
+    /// Step 2 will need to lock the snapshot registry.
+    #[allow(clippy::unused_async)]
+    pub(super) async fn handle_status_effect(
+        &mut self,
+        spec: StatusSpec,
+    ) -> Result<String, ToolError> {
+        let child_ids = spec
+            .child_ids
+            .unwrap_or_else(|| self.child_tasks.keys().cloned().collect());
+        let entries: Vec<serde_json::Value> = child_ids
+            .into_iter()
+            .map(|child_id| {
+                let present = self.child_tasks.contains_key(&child_id);
+                serde_json::json!({
+                    "child_id": child_id,
+                    "state": if present { "running" } else { "unknown" },
+                })
+            })
+            .collect();
+        Ok(serde_json::json!({ "children": entries }).to_string())
+    }
+
+    fn emit_finished_event(
+        &self,
+        child_id: &str,
+        sub_goal: &str,
+        success: bool,
+        items_extracted: usize,
+        error: Option<String>,
+    ) {
+        if let Some(ref tx) = self.child_event_tx {
+            let _ = tx.send(crate::child_events::ChildEvent {
+                child_id: child_id.to_string(),
+                sub_goal: sub_goal.to_string(),
+                event: crate::child_events::ChildEventKind::Finished {
+                    success,
+                    items_extracted,
+                    error,
+                },
+            });
+        }
+    }
+
+    async fn cleanup_finished(&self, child_id: &str) {
+        if let Some(registry) = &self.child_control_registry {
+            registry.remove(child_id);
+        }
+        self.agent_manager.lock().await.mark_done(child_id);
     }
 
     async fn create_child_page(
@@ -451,10 +613,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_wait_no_children_returns_immediately() {
+    async fn test_wait_no_children_returns_empty_snapshot() {
         let mut agent = CrawlerAgent::new_for_testing(mock_registry());
-        let result = agent.handle_wait_effect(WaitSpec { child_ids: None }).await;
-        assert_eq!(result.unwrap(), "No active subagents");
+        let result = agent
+            .handle_wait_effect(WaitSpec { child_ids: None })
+            .await
+            .expect("wait with no children should succeed");
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["waited"], 0);
+        assert!(parsed["finished"].as_array().unwrap().is_empty());
+        assert!(parsed["still_running"].as_array().unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -469,8 +637,13 @@ mod tests {
             .insert("child-1".to_string(), ("search".to_string(), handle));
 
         let result = agent.execute("wait_for_subagents", "{}").await.unwrap();
-        assert_eq!(result, "Waited for 1 subagent(s). Collected 0 item(s).");
-        assert_eq!(agent.crawl_state.action_history[0], result);
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["waited"], 1);
+        // child returned None → counted as finished/failed, not still_running
+        assert_eq!(parsed["finished"].as_array().unwrap().len(), 1);
+        assert!(parsed["still_running"].as_array().unwrap().is_empty());
+        assert_eq!(agent.crawl_state.action_history.len(), 1);
+        assert!(agent.crawl_state.action_history[0].contains("Waited on 1 subagent(s)"));
     }
 
     #[tokio::test]
@@ -497,7 +670,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(result.contains("Waited for 1 subagent(s)"));
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["waited"], 1);
         assert_eq!(agent.crawl_state.child_blocks.len(), 1);
         assert_eq!(agent.crawl_state.child_blocks[0].child_id, "child-1");
         assert!(agent.child_tasks.contains_key("child-2"));
@@ -507,7 +681,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_wait_with_nonexistent_ids_returns_no_active() {
+    async fn test_wait_with_nonexistent_ids_returns_empty_snapshot() {
         let mut agent = CrawlerAgent::new_for_testing(mock_registry());
         let handle: tokio::task::JoinHandle<Option<Vec<Value>>> =
             tokio::spawn(async { Some(vec![serde_json::json!({"data": 1})]) });
@@ -522,7 +696,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(result, "No active subagents");
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["waited"], 0);
         assert!(agent.child_tasks.contains_key("real-child"));
         for (_, (_, handle)) in agent.child_tasks.drain() {
             handle.abort();
@@ -555,8 +730,16 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(result.contains("Waited for 2 subagent(s)"));
-        assert!(result.contains("Collected 3 item(s)"));
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["waited"], 2);
+        assert_eq!(parsed["finished"].as_array().unwrap().len(), 2);
+        let total: u64 = parsed["finished"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|e| e["items_extracted"].as_u64().unwrap())
+            .sum();
+        assert_eq!(total, 3);
         assert_eq!(agent.crawl_state.child_blocks.len(), 2);
         assert!(agent.child_tasks.is_empty());
     }
@@ -583,7 +766,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(result.contains("Collected 1 item(s)"));
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["finished"][0]["items_extracted"], 1);
         let event = rx.try_recv().expect("finished event should be emitted");
         assert_eq!(event.child_id, "child-1");
         assert_eq!(event.sub_goal, "goal-1");
@@ -598,7 +782,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_wait_emits_finished_event_on_timeout() {
+    async fn test_wait_returns_snapshot_on_timeout_without_aborting() {
         let manager = super::super::default_agent_manager();
         manager.lock().await.register_root("test-agent");
 
@@ -627,9 +811,67 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(result.contains("Collected 0 item(s)"));
+        // The child is still running, so the snapshot must report it under
+        // `still_running` and NOT abort or cancel it.
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["waited"], 1);
+        assert!(parsed["finished"].as_array().unwrap().is_empty());
+        let still_running = parsed["still_running"].as_array().unwrap();
+        assert_eq!(still_running.len(), 1);
+        assert_eq!(still_running[0]["child_id"], "child-1");
+        assert_eq!(still_running[0]["status"], "running");
+
+        // No cancel was requested and no Finished event was emitted.
+        assert!(!child_state.is_cancelled());
+        assert!(
+            rx.try_recv().is_err(),
+            "no Finished event should be emitted on timeout"
+        );
+
+        // The handle is re-inserted so a future wait/cancel can still target it.
+        assert!(agent.child_tasks.contains_key("child-1"));
+        for (_, (_, handle)) in agent.child_tasks.drain() {
+            handle.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cancel_subagent_aborts_handle_and_emits_finished_event() {
+        let manager = super::super::default_agent_manager();
+        manager.lock().await.register_root("test-agent");
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let registry = crate::ChildControlRegistry::default();
+        let child_state = registry.register("child-1");
+        let mut agent = CrawlerAgent::new_for_testing(mock_registry())
+            .with_agent_manager(manager)
+            .with_child_event_sender(tx)
+            .with_child_control_registry(registry.clone());
+        let handle: tokio::task::JoinHandle<Option<Vec<Value>>> = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            Some(Vec::new())
+        });
+        agent
+            .child_tasks
+            .insert("child-1".to_string(), ("goal-1".to_string(), handle));
+
+        let result = agent
+            .handle_cancel_effect(crate::tool_effect::CancelSpec {
+                child_ids: vec!["child-1".to_string()],
+                reason: Some("user pressed stop".to_string()),
+            })
+            .await
+            .unwrap();
+
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["cancelled"].as_array().unwrap().len(), 1);
+        assert_eq!(parsed["cancelled"][0]["child_id"], "child-1");
+        assert_eq!(parsed["cancelled"][0]["reason"], "user pressed stop");
+        assert!(parsed["not_found"].as_array().unwrap().is_empty());
+
         assert!(child_state.is_cancelled());
-        let event = rx.try_recv().expect("timeout event should be emitted");
+        assert!(!agent.child_tasks.contains_key("child-1"));
+        let event = rx.try_recv().expect("Finished event should be emitted");
         assert_eq!(event.child_id, "child-1");
         assert!(matches!(
             event.event,
@@ -637,8 +879,25 @@ mod tests {
                 success: false,
                 items_extracted: 0,
                 error: Some(ref error),
-            } if error == "timed out"
+            } if error == "user pressed stop"
         ));
+    }
+
+    #[tokio::test]
+    async fn test_cancel_subagent_reports_unknown_child_ids() {
+        let mut agent = CrawlerAgent::new_for_testing(mock_registry());
+        let result = agent
+            .handle_cancel_effect(crate::tool_effect::CancelSpec {
+                child_ids: vec!["ghost".to_string()],
+                reason: None,
+            })
+            .await
+            .unwrap();
+
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert!(parsed["cancelled"].as_array().unwrap().is_empty());
+        assert_eq!(parsed["not_found"].as_array().unwrap().len(), 1);
+        assert_eq!(parsed["not_found"][0], "ghost");
     }
 
     #[test]

--- a/crates/crawler/src/agent/fork.rs
+++ b/crates/crawler/src/agent/fork.rs
@@ -130,6 +130,12 @@ impl CrawlerAgent {
             }
         };
 
+        // Register a fresh snapshot for this child. Children inherit the
+        // parent's snapshot registry Arc so the parent can poll their
+        // progress without joining.
+        self.child_snapshots
+            .register(&child_id, &fork_spec.goal, child_max_steps);
+
         let mut child_agent = CrawlerAgent::new(
             BrowserContext::new_shared(shared_bridge.clone(), page_index),
             ToolRegistry::new_with_core_tools(),
@@ -137,6 +143,7 @@ impl CrawlerAgent {
         .with_max_steps(child_max_steps)
         .with_agent_id(child_id.clone())
         .with_agent_manager(self.agent_manager.clone())
+        .with_child_snapshots(self.child_snapshots.clone())
         .with_control_state({
             if let Some(registry) = &self.child_control_registry {
                 registry.register(&child_id)
@@ -244,6 +251,10 @@ impl CrawlerAgent {
                         &child_id, &sub_goal, true, item_count, None,
                     ));
                     self.emit_finished_event(&child_id, &sub_goal, true, item_count, None);
+                    self.child_snapshots.update_with(&child_id, |snapshot| {
+                        snapshot.state = crate::child_events::ChildLifecycle::Completed;
+                        snapshot.items_extracted = item_count;
+                    });
                     self.crawl_state.child_blocks.push(ChildBlock {
                         child_id: child_id.clone(),
                         sub_goal,
@@ -266,6 +277,12 @@ impl CrawlerAgent {
                         0,
                         Some("child failed".to_string()),
                     );
+                    self.child_snapshots.update_with(&child_id, |snapshot| {
+                        snapshot.state = crate::child_events::ChildLifecycle::Failed;
+                        snapshot
+                            .error
+                            .get_or_insert_with(|| "child failed".to_string());
+                    });
                     self.crawl_state.child_blocks.push(ChildBlock {
                         child_id: child_id.clone(),
                         sub_goal,
@@ -282,7 +299,11 @@ impl CrawlerAgent {
                         0,
                         Some(&message),
                     ));
-                    self.emit_finished_event(&child_id, &sub_goal, false, 0, Some(message));
+                    self.emit_finished_event(&child_id, &sub_goal, false, 0, Some(message.clone()));
+                    self.child_snapshots.update_with(&child_id, |snapshot| {
+                        snapshot.state = crate::child_events::ChildLifecycle::Failed;
+                        snapshot.error = Some(message);
+                    });
                     self.crawl_state.child_blocks.push(ChildBlock {
                         child_id: child_id.clone(),
                         sub_goal,
@@ -353,6 +374,7 @@ impl CrawlerAgent {
                         .clone()
                         .unwrap_or_else(|| "cancelled by parent".to_string());
                     self.emit_finished_event(&child_id, &sub_goal, false, 0, Some(reason.clone()));
+                    self.child_snapshots.mark_cancelled(&child_id, &reason);
                     self.crawl_state.child_blocks.push(ChildBlock {
                         child_id: child_id.clone(),
                         sub_goal: sub_goal.clone(),
@@ -381,26 +403,41 @@ impl CrawlerAgent {
         Ok(payload.to_string())
     }
 
-    /// Read-only status surface. Filled in by Step 2; for now reports the
-    /// presence of each requested child in `child_tasks` and a placeholder
-    /// state. Returning a stub here keeps `dispatch_tool_effect` exhaustive
-    /// without blocking Step 1 from shipping. Async signature is kept because
-    /// Step 2 will need to lock the snapshot registry.
+    /// Read-only status surface. Looks up the requested children (or all of
+    /// them) in the snapshot registry and returns a JSON array of progress
+    /// snapshots. Does NOT join, cancel, or otherwise mutate the running
+    /// children — safe to call between any steps.
     #[allow(clippy::unused_async)]
     pub(super) async fn handle_status_effect(
         &mut self,
         spec: StatusSpec,
     ) -> Result<String, ToolError> {
-        let child_ids = spec
-            .child_ids
-            .unwrap_or_else(|| self.child_tasks.keys().cloned().collect());
-        let entries: Vec<serde_json::Value> = child_ids
+        let snapshots: Vec<crate::child_events::ChildSnapshot> = match spec.child_ids {
+            Some(ids) => ids
+                .into_iter()
+                .filter_map(|id| self.child_snapshots.get(&id))
+                .collect(),
+            None => self.child_snapshots.list(),
+        };
+
+        let now = std::time::Instant::now();
+        let entries: Vec<serde_json::Value> = snapshots
             .into_iter()
-            .map(|child_id| {
-                let present = self.child_tasks.contains_key(&child_id);
+            .map(|snapshot| {
+                let last_event_secs_ago = now
+                    .saturating_duration_since(snapshot.last_event_at)
+                    .as_secs();
                 serde_json::json!({
-                    "child_id": child_id,
-                    "state": if present { "running" } else { "unknown" },
+                    "child_id": snapshot.child_id,
+                    "sub_goal": snapshot.sub_goal,
+                    "state": snapshot.state.as_str(),
+                    "step": snapshot.step,
+                    "max_steps": snapshot.max_steps,
+                    "last_tool": snapshot.last_tool,
+                    "last_text": snapshot.last_text,
+                    "items_extracted": snapshot.items_extracted,
+                    "last_event_secs_ago": last_event_secs_ago,
+                    "error": snapshot.error,
                 })
             })
             .collect();
@@ -881,6 +918,50 @@ mod tests {
                 error: Some(ref error),
             } if error == "user pressed stop"
         ));
+    }
+
+    #[tokio::test]
+    async fn test_handle_status_effect_returns_snapshots() {
+        let mut agent = CrawlerAgent::new_for_testing(mock_registry());
+        agent
+            .child_snapshots
+            .register("child-1", "search page 2", 15);
+        agent.child_snapshots.update_with("child-1", |snapshot| {
+            snapshot.state = crate::child_events::ChildLifecycle::Running;
+            snapshot.last_tool = Some("navigate".to_string());
+            snapshot.step = 3;
+        });
+
+        let result = agent
+            .handle_status_effect(crate::tool_effect::StatusSpec { child_ids: None })
+            .await
+            .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let children = parsed["children"].as_array().unwrap();
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0]["child_id"], "child-1");
+        assert_eq!(children[0]["state"], "running");
+        assert_eq!(children[0]["last_tool"], "navigate");
+        assert_eq!(children[0]["step"], 3);
+        assert_eq!(children[0]["max_steps"], 15);
+    }
+
+    #[tokio::test]
+    async fn test_handle_status_effect_filters_by_child_ids() {
+        let mut agent = CrawlerAgent::new_for_testing(mock_registry());
+        agent.child_snapshots.register("child-1", "g1", 10);
+        agent.child_snapshots.register("child-2", "g2", 10);
+
+        let result = agent
+            .handle_status_effect(crate::tool_effect::StatusSpec {
+                child_ids: Some(vec!["child-2".to_string(), "unknown".to_string()]),
+            })
+            .await
+            .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let children = parsed["children"].as_array().unwrap();
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0]["child_id"], "child-2");
     }
 
     #[tokio::test]

--- a/crates/crawler/src/agent/mod.rs
+++ b/crates/crawler/src/agent/mod.rs
@@ -75,7 +75,15 @@ pub trait CrawlAgent {
     }
 }
 
-type ChildTaskMap = HashMap<String, (String, tokio::task::JoinHandle<Option<Vec<Value>>>)>;
+/// Per-child task slot: sub-goal text, the spawned task handle, and the
+/// URL [`crate::ClaimGuard`] (dropping the guard releases the claim so a
+/// sibling can re-use the scope).
+pub(crate) type ChildTaskEntry = (
+    String,
+    tokio::task::JoinHandle<Option<Vec<Value>>>,
+    Option<crate::ClaimGuard>,
+);
+type ChildTaskMap = HashMap<String, ChildTaskEntry>;
 
 pub struct CrawlerAgent {
     pub(super) browser: Option<BrowserContext>,
@@ -295,8 +303,12 @@ impl CrawlerAgent {
 }
 
 impl Drop for CrawlerAgent {
+    /// Children should not outlive the parent: any handle still in
+    /// `child_tasks` when the agent is dropped is aborted immediately. This
+    /// is the same semantics as an explicit `cancel_subagent` (abort = no
+    /// graceful drain) — see plan step 1.
     fn drop(&mut self) {
-        for (_, (_, handle)) in self.child_tasks.drain() {
+        for (_, (_, handle, _)) in self.child_tasks.drain() {
             handle.abort();
         }
     }
@@ -647,8 +659,14 @@ mod tests {
         agent.fork_page_index_override = Some(1);
 
         let observation = agent
-            .dispatch_tool_effect(ToolEffect::Spawn(crate::ForkSpec {
-                goal: "collect details".to_string(),
+            .dispatch_tool_effect(ToolEffect::Spawn(crate::CrawlTask {
+                objective: "collect details".to_string(),
+                scope: crate::CrawlScope::SinglePage {
+                    url: "https://example.com".to_string(),
+                },
+                success_criteria: None,
+                max_steps: None,
+                deadline_secs: None,
                 page_index: None,
             }))
             .await
@@ -659,7 +677,7 @@ mod tests {
             "Forked subagent root-child-1 for: collect details"
         );
         assert_eq!(agent.child_tasks.len(), 1);
-        for (_, (_, handle)) in agent.child_tasks.drain() {
+        for (_, (_, handle, _)) in agent.child_tasks.drain() {
             handle.abort();
         }
     }
@@ -673,7 +691,7 @@ mod tests {
         let handle = tokio::spawn(async { Some(vec![serde_json::json!({"child": 1})]) });
         agent
             .child_tasks
-            .insert("child-1".to_string(), ("goal".to_string(), handle));
+            .insert("child-1".to_string(), ("goal".to_string(), handle, None));
 
         let result = agent
             .dispatch_tool_effect(ToolEffect::Wait(crate::WaitSpec {
@@ -861,7 +879,7 @@ mod tests {
         let observation = agent
             .execute(
                 "fork",
-                r#"{"sub_goal":"check result","url":"https://example.com"}"#,
+                r#"{"objective":"check result","scope":{"type":"single_page","url":"https://example.com"}}"#,
             )
             .await
             .expect("fork should succeed");
@@ -869,7 +887,7 @@ mod tests {
         assert!(observation.contains("Forked subagent root-child-1 for: check result"));
         assert_eq!(manager.lock().await.get_children("root").len(), 1);
         assert_eq!(agent.child_tasks.len(), 1);
-        for (_, (_, handle)) in agent.child_tasks.drain() {
+        for (_, (_, handle, _)) in agent.child_tasks.drain() {
             let _ = handle.await;
         }
 
@@ -900,7 +918,10 @@ mod tests {
         agent.fork_page_index_override = Some(1);
 
         let observation = agent
-            .execute("fork", r#"{"sub_goal":"collect details"}"#)
+            .execute(
+                "fork",
+                r#"{"objective":"collect details","scope":{"type":"single_page","url":"https://example.com"}}"#,
+            )
             .await
             .expect("fork should succeed");
 
@@ -909,7 +930,7 @@ mod tests {
             "Forked subagent root-child-1 for: collect details"
         );
 
-        for (_, (_, handle)) in agent.child_tasks.drain() {
+        for (_, (_, handle, _)) in agent.child_tasks.drain() {
             handle.abort();
         }
     }
@@ -925,7 +946,10 @@ mod tests {
         agent.api_client_arc = Some(SharedApiClient::new(TextOnlyApiClient));
 
         let err = agent
-            .execute("fork", r#"{"sub_goal":"blocked"}"#)
+            .execute(
+                "fork",
+                r#"{"objective":"blocked","scope":{"type":"single_page","url":"https://example.com"}}"#,
+            )
             .await
             .expect_err("fork at limit should return an error");
 
@@ -936,7 +960,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_fork_empty_subgoal_returns_error() {
+    async fn test_fork_empty_objective_returns_error() {
         let manager = default_agent_manager();
         manager.lock().await.register_root("root");
 
@@ -945,11 +969,14 @@ mod tests {
             .with_agent_manager(manager);
 
         let err = agent
-            .execute("fork", r#"{"sub_goal":"   "}"#)
+            .execute(
+                "fork",
+                r#"{"objective":"   ","scope":{"type":"single_page","url":"https://example.com"}}"#,
+            )
             .await
-            .expect_err("empty sub_goal should fail");
+            .expect_err("empty objective should fail");
 
-        assert_eq!(err.to_string(), "fork requires non-empty sub_goal");
+        assert_eq!(err.to_string(), "fork requires non-empty objective");
     }
 
     #[tokio::test]
@@ -976,7 +1003,7 @@ mod tests {
         let handle: tokio::task::JoinHandle<Option<Vec<Value>>> = tokio::spawn(async { None });
         agent
             .child_tasks
-            .insert("child-1".to_string(), ("search".to_string(), handle));
+            .insert("child-1".to_string(), ("search".to_string(), handle, None));
 
         let result = agent.execute("wait_for_subagents", "{}").await.unwrap();
 
@@ -1002,7 +1029,7 @@ mod tests {
             tokio::spawn(async { Some(vec![serde_json::json!({"data": 1})]) });
         agent
             .child_tasks
-            .insert("child-1".to_string(), ("search".to_string(), handle));
+            .insert("child-1".to_string(), ("search".to_string(), handle, None));
 
         let result = agent.execute("wait_for_subagents", "{}").await.unwrap();
 
@@ -1030,7 +1057,7 @@ mod tests {
         let handle = tokio::spawn(async { Some(vec![serde_json::json!({"child": 1})]) });
         agent
             .child_tasks
-            .insert("child-1".to_string(), ("goal".to_string(), handle));
+            .insert("child-1".to_string(), ("goal".to_string(), handle, None));
 
         let _ = agent.execute("wait_for_subagents", "{}").await;
 
@@ -1059,9 +1086,10 @@ mod tests {
                 serde_json::json!({"child": 2}),
             ])
         });
-        parent
-            .child_tasks
-            .insert("child-1".to_string(), ("search page 2".to_string(), handle));
+        parent.child_tasks.insert(
+            "child-1".to_string(),
+            ("search page 2".to_string(), handle, None),
+        );
 
         let wait_result = parent.execute("wait_for_subagents", "{}").await.unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&wait_result).unwrap();

--- a/crates/crawler/src/agent/mod.rs
+++ b/crates/crawler/src/agent/mod.rs
@@ -664,9 +664,7 @@ mod tests {
                 scope: crate::CrawlScope::SinglePage {
                     url: "https://example.com".to_string(),
                 },
-                success_criteria: None,
                 max_steps: None,
-                deadline_secs: None,
                 page_index: None,
             }))
             .await

--- a/crates/crawler/src/agent/mod.rs
+++ b/crates/crawler/src/agent/mod.rs
@@ -94,6 +94,7 @@ pub struct CrawlerAgent {
     control_state: Option<Arc<ControlState>>,
     child_event_tx: Option<std::sync::mpsc::Sender<crate::child_events::ChildEvent>>,
     child_control_registry: Option<crate::child_events::ChildControlRegistry>,
+    pub(super) child_snapshots: crate::child_events::ChildSnapshotRegistry,
     #[cfg(test)]
     pub(super) fork_page_index_override: Option<usize>,
 }
@@ -118,6 +119,7 @@ impl CrawlerAgent {
             control_state: None,
             child_event_tx: None,
             child_control_registry: None,
+            child_snapshots: crate::child_events::ChildSnapshotRegistry::default(),
             #[cfg(test)]
             fork_page_index_override: None,
         }
@@ -142,6 +144,7 @@ impl CrawlerAgent {
             control_state: None,
             child_event_tx: None,
             child_control_registry: None,
+            child_snapshots: crate::child_events::ChildSnapshotRegistry::default(),
             #[cfg(test)]
             fork_page_index_override: None,
         }
@@ -166,6 +169,7 @@ impl CrawlerAgent {
             control_state: None,
             child_event_tx: None,
             child_control_registry: None,
+            child_snapshots: crate::child_events::ChildSnapshotRegistry::default(),
             #[cfg(test)]
             fork_page_index_override: None,
         }
@@ -220,6 +224,15 @@ impl CrawlerAgent {
         self
     }
 
+    #[must_use]
+    pub fn with_child_snapshots(
+        mut self,
+        snapshots: crate::child_events::ChildSnapshotRegistry,
+    ) -> Self {
+        self.child_snapshots = snapshots;
+        self
+    }
+
     pub fn set_control_state(&mut self, state: Arc<ControlState>) {
         self.control_state = Some(state);
     }
@@ -250,14 +263,17 @@ impl CrawlerAgent {
             ConversationRuntime::new(Session::new(), shared_client.clone(), self, system_prompt)
                 .with_max_iterations(max_steps);
 
-        // Attach child event observer for streaming child output to TUI
+        // Attach child event observer for streaming child output to TUI and
+        // mirroring lifecycle/heartbeat data into the shared snapshot registry.
         if let Some(tx) = runtime.tool_executor_mut().child_event_tx.take() {
+            let snapshots = runtime.tool_executor_mut().child_snapshots.clone();
             let observer = crate::child_events::ChildEventSender::new(
                 runtime.tool_executor_mut().agent_id.clone(),
                 goal.to_string(),
                 tx,
                 max_steps,
-            );
+            )
+            .with_snapshots(snapshots);
             runtime = runtime.with_observer(Box::new(observer));
         }
 

--- a/crates/crawler/src/agent/mod.rs
+++ b/crates/crawler/src/agent/mod.rs
@@ -341,6 +341,8 @@ impl CrawlerAgent {
             ToolEffect::Reply(output) => Ok(output),
             ToolEffect::Spawn(spec) => self.handle_spawn(spec).await,
             ToolEffect::Wait(spec) => self.handle_wait_effect(spec).await,
+            ToolEffect::Cancel(spec) => self.handle_cancel_effect(spec).await,
+            ToolEffect::Status(spec) => self.handle_status_effect(spec).await,
             ToolEffect::Pause { reason } => self.handle_pause(reason).await,
         }
     }
@@ -664,7 +666,9 @@ mod tests {
             .await
             .expect("wait effect should collect child results");
 
-        assert_eq!(result, "Waited for 1 subagent(s). Collected 1 item(s).");
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["waited"], 1);
+        assert_eq!(parsed["finished"][0]["items_extracted"], 1);
         assert_eq!(agent.crawl_state.child_blocks.len(), 1);
     }
 
@@ -933,14 +937,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_wait_no_children_returns_immediately() {
+    async fn test_wait_no_children_returns_empty_snapshot() {
         let mut agent = CrawlerAgent::new_for_testing(mock_registry());
 
         let result = agent
             .handle_wait_effect(crate::WaitSpec { child_ids: None })
-            .await;
+            .await
+            .expect("wait with no children should succeed");
 
-        assert_eq!(result.unwrap(), "No active subagents");
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["waited"], 0);
+        assert!(parsed["finished"].as_array().unwrap().is_empty());
+        assert!(parsed["still_running"].as_array().unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -956,9 +964,11 @@ mod tests {
 
         let result = agent.execute("wait_for_subagents", "{}").await.unwrap();
 
-        assert_eq!(result, "Waited for 1 subagent(s). Collected 0 item(s).");
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["waited"], 1);
+        assert_eq!(parsed["finished"].as_array().unwrap().len(), 1);
         assert_eq!(agent.crawl_state.action_history.len(), 1);
-        assert_eq!(agent.crawl_state.action_history[0], result);
+        assert!(agent.crawl_state.action_history[0].contains("Waited on 1 subagent(s)"));
     }
 
     #[tokio::test]
@@ -980,7 +990,8 @@ mod tests {
 
         let result = agent.execute("wait_for_subagents", "{}").await.unwrap();
 
-        assert!(result.contains("Collected 1"));
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["finished"][0]["items_extracted"], 1);
         assert_eq!(agent.crawl_state.child_blocks.len(), 1);
         assert_eq!(agent.crawl_state.child_blocks[0].child_id, "child-1");
         assert_eq!(agent.crawl_state.child_blocks[0].sub_goal, "search");
@@ -1037,7 +1048,8 @@ mod tests {
             .insert("child-1".to_string(), ("search page 2".to_string(), handle));
 
         let wait_result = parent.execute("wait_for_subagents", "{}").await.unwrap();
-        assert!(wait_result.contains("Collected 2"));
+        let parsed: serde_json::Value = serde_json::from_str(&wait_result).unwrap();
+        assert_eq!(parsed["finished"][0]["items_extracted"], 2);
 
         let all = parent.crawl_state.all_data();
         assert_eq!(all.len(), 3);

--- a/crates/crawler/src/child_events.rs
+++ b/crates/crawler/src/child_events.rs
@@ -118,6 +118,12 @@ impl ChildSnapshot {
 /// Concurrent map of `ChildSnapshot`s keyed by child id. Cloning is cheap
 /// (Arc); the same registry instance is shared between parent and child
 /// agents.
+///
+/// The registry does not self-prune: completed, failed, and cancelled
+/// entries remain visible via [`Self::list`] and [`Self::get`] until
+/// [`Self::remove`] is called explicitly (the wait/cancel paths do this via
+/// `cleanup_finished`). In long-running sessions with many forks, callers
+/// are responsible for timely cleanup.
 #[derive(Clone, Default)]
 pub struct ChildSnapshotRegistry {
     inner: Arc<Mutex<HashMap<String, ChildSnapshot>>>,

--- a/crates/crawler/src/child_events.rs
+++ b/crates/crawler/src/child_events.rs
@@ -2,6 +2,7 @@ use runtime::{ControlState, RuntimeObserver};
 use std::collections::HashMap;
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 // ── Event types ──────────────────────────────────────────────────────────────
 
@@ -39,6 +40,155 @@ pub struct ChildEvent {
     pub child_id: String,
     pub sub_goal: String,
     pub event: ChildEventKind,
+}
+
+// ── ChildSnapshotRegistry ────────────────────────────────────────────────────
+
+const LAST_TEXT_MAX_CHARS: usize = 200;
+const LAST_TOOL_INPUT_MAX_CHARS: usize = 100;
+
+/// Lifecycle state of a child agent as seen by the parent. Updated whenever
+/// the corresponding observer hook fires, plus on cancel/finish in the wait
+/// path. Reported by the `subagent_status` tool.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChildLifecycle {
+    /// Registered but no events yet (or no LLM turn yet).
+    Created,
+    /// At least one observer event seen and the child hasn't ended.
+    Running,
+    /// The child requested a pause (waiting for human / cancel).
+    Paused,
+    /// Child returned successfully.
+    Completed,
+    /// Child returned with an error (panic, hard runtime error).
+    Failed,
+    /// Cancelled by parent via `cancel_subagent` or `Drop`.
+    Cancelled,
+}
+
+impl ChildLifecycle {
+    /// Wire format used by the LLM-facing `subagent_status` payload.
+    #[must_use]
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Created => "created",
+            Self::Running => "running",
+            Self::Paused => "paused",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+/// A point-in-time picture of one child agent's progress. Populated by
+/// `ChildEventSender` from inside the child's runtime; read by
+/// `subagent_status` from the parent.
+#[derive(Debug, Clone)]
+pub struct ChildSnapshot {
+    pub child_id: String,
+    pub sub_goal: String,
+    pub state: ChildLifecycle,
+    pub step: usize,
+    pub max_steps: usize,
+    pub last_tool: Option<String>,
+    pub last_text: Option<String>,
+    pub items_extracted: usize,
+    pub error: Option<String>,
+    pub last_event_at: Instant,
+}
+
+impl ChildSnapshot {
+    fn new(child_id: String, sub_goal: String, max_steps: usize) -> Self {
+        Self {
+            child_id,
+            sub_goal,
+            state: ChildLifecycle::Created,
+            step: 0,
+            max_steps,
+            last_tool: None,
+            last_text: None,
+            items_extracted: 0,
+            error: None,
+            last_event_at: Instant::now(),
+        }
+    }
+}
+
+/// Concurrent map of `ChildSnapshot`s keyed by child id. Cloning is cheap
+/// (Arc); the same registry instance is shared between parent and child
+/// agents.
+#[derive(Clone, Default)]
+pub struct ChildSnapshotRegistry {
+    inner: Arc<Mutex<HashMap<String, ChildSnapshot>>>,
+}
+
+impl ChildSnapshotRegistry {
+    /// Insert a fresh snapshot for a newly-spawned child. Overwrites any
+    /// stale entry from a previous lifecycle.
+    pub fn register(&self, child_id: &str, sub_goal: &str, max_steps: usize) {
+        self.inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(
+                child_id.to_string(),
+                ChildSnapshot::new(child_id.to_string(), sub_goal.to_string(), max_steps),
+            );
+    }
+
+    /// Apply a mutation under the lock. The closure receives `&mut
+    /// ChildSnapshot`; if the entry is missing the closure is not invoked.
+    pub fn update_with<F: FnOnce(&mut ChildSnapshot)>(&self, child_id: &str, f: F) {
+        let mut guard = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(snapshot) = guard.get_mut(child_id) {
+            snapshot.last_event_at = Instant::now();
+            f(snapshot);
+        }
+    }
+
+    /// Convenience: set the lifecycle state. Bumps `last_event_at`.
+    pub fn set_state(&self, child_id: &str, state: ChildLifecycle) {
+        self.update_with(child_id, |snapshot| snapshot.state = state);
+    }
+
+    /// Convenience used by the cancel path: mark a child as Cancelled with
+    /// an error message.
+    pub fn mark_cancelled(&self, child_id: &str, reason: &str) {
+        self.update_with(child_id, |snapshot| {
+            snapshot.state = ChildLifecycle::Cancelled;
+            snapshot.error = Some(reason.to_string());
+        });
+    }
+
+    #[must_use]
+    pub fn get(&self, child_id: &str) -> Option<ChildSnapshot> {
+        self.inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(child_id)
+            .cloned()
+    }
+
+    /// Snapshot every entry under the lock and return as a Vec.
+    #[must_use]
+    pub fn list(&self) -> Vec<ChildSnapshot> {
+        self.inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .values()
+            .cloned()
+            .collect()
+    }
+
+    pub fn remove(&self, child_id: &str) {
+        self.inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(child_id);
+    }
 }
 
 // ── ChildControlRegistry ─────────────────────────────────────────────────────
@@ -106,12 +256,17 @@ impl ChildControlRegistry {
 
 /// Implements `RuntimeObserver` and forwards events through an mpsc channel.
 /// Lives in the crawler crate (same as `ChildEvent`) to avoid cyclic dependencies.
+///
+/// Also mirrors every observer callback into an optional
+/// [`ChildSnapshotRegistry`] so the parent can poll a child's state without
+/// joining or cancelling it (see the `subagent_status` tool).
 pub struct ChildEventSender {
     child_id: String,
     sub_goal: String,
     tx: Sender<ChildEvent>,
     step: usize,
     max_steps: usize,
+    snapshots: Option<ChildSnapshotRegistry>,
 }
 
 impl ChildEventSender {
@@ -128,7 +283,16 @@ impl ChildEventSender {
             tx,
             step: 0,
             max_steps,
+            snapshots: None,
         }
+    }
+
+    /// Attach a snapshot registry. The sender will mirror its observer
+    /// callbacks into the registry entry for `child_id`.
+    #[must_use]
+    pub fn with_snapshots(mut self, snapshots: ChildSnapshotRegistry) -> Self {
+        self.snapshots = Some(snapshots);
+        self
     }
 
     fn send(&self, event: ChildEventKind) {
@@ -137,6 +301,12 @@ impl ChildEventSender {
             sub_goal: self.sub_goal.clone(),
             event,
         });
+    }
+
+    fn update_snapshot<F: FnOnce(&mut ChildSnapshot)>(&self, f: F) {
+        if let Some(snapshots) = &self.snapshots {
+            snapshots.update_with(&self.child_id, f);
+        }
     }
 }
 
@@ -155,44 +325,75 @@ fn truncate(s: &str, max_chars: usize) -> String {
 impl RuntimeObserver for ChildEventSender {
     fn on_text_delta(&mut self, text: &str) {
         self.send(ChildEventKind::TextDelta(text.to_string()));
+        let truncated = truncate(text, LAST_TEXT_MAX_CHARS);
+        self.update_snapshot(|snapshot| {
+            snapshot.last_text = Some(truncated);
+            if snapshot.state == ChildLifecycle::Created {
+                snapshot.state = ChildLifecycle::Running;
+            }
+        });
     }
 
     fn on_tool_call_start(&mut self, _id: &str, name: &str, input: &str) {
         self.send(ChildEventKind::ToolCallStart {
             name: name.to_string(),
-            input_summary: truncate(input, 100),
+            input_summary: truncate(input, LAST_TOOL_INPUT_MAX_CHARS),
+        });
+        let tool_name = name.to_string();
+        self.update_snapshot(|snapshot| {
+            snapshot.last_tool = Some(tool_name);
+            if snapshot.state == ChildLifecycle::Created {
+                snapshot.state = ChildLifecycle::Running;
+            }
         });
     }
 
     fn on_tool_result(&mut self, name: &str, output: &str, is_error: bool) {
         self.send(ChildEventKind::ToolCallComplete {
             name: name.to_string(),
-            output_summary: truncate(output, 100),
+            output_summary: truncate(output, LAST_TOOL_INPUT_MAX_CHARS),
             is_error,
         });
+        // Tool result is also a heartbeat — bump the timestamp.
+        self.update_snapshot(|_| {});
     }
 
     fn on_pause_started(&mut self, reason: &str) {
         self.send(ChildEventKind::PauseRequested {
             reason: reason.to_string(),
         });
+        self.update_snapshot(|snapshot| snapshot.state = ChildLifecycle::Paused);
     }
 
     fn on_pause_ended(&mut self) {
         self.send(ChildEventKind::Resumed);
+        self.update_snapshot(|snapshot| snapshot.state = ChildLifecycle::Running);
     }
 
     fn on_turn_finished(&mut self, result: &Result<(), String>) {
         self.step += 1;
+        let step_now = self.step;
+        let max_steps = self.max_steps;
         self.send(ChildEventKind::StepStarted {
-            step: self.step,
-            max_steps: self.max_steps,
+            step: step_now,
+            max_steps,
+        });
+        self.update_snapshot(|snapshot| {
+            snapshot.step = step_now;
+            if snapshot.state == ChildLifecycle::Created {
+                snapshot.state = ChildLifecycle::Running;
+            }
         });
         if let Err(e) = result {
             self.send(ChildEventKind::Finished {
                 success: false,
                 items_extracted: 0,
                 error: Some(e.clone()),
+            });
+            let error_text = e.clone();
+            self.update_snapshot(|snapshot| {
+                snapshot.state = ChildLifecycle::Failed;
+                snapshot.error = Some(error_text);
             });
         }
     }
@@ -250,5 +451,73 @@ mod tests {
         drop(rx); // drop receiver first
         let mut sender = ChildEventSender::new("c".into(), "g".into(), tx, 5);
         sender.on_text_delta("orphan"); // must not panic
+    }
+
+    #[test]
+    fn snapshot_registry_lifecycle() {
+        let registry = ChildSnapshotRegistry::default();
+        registry.register("c1", "goal", 10);
+        let snapshot = registry.get("c1").expect("snapshot should exist");
+        assert_eq!(snapshot.sub_goal, "goal");
+        assert_eq!(snapshot.state, ChildLifecycle::Created);
+        assert_eq!(snapshot.max_steps, 10);
+
+        registry.set_state("c1", ChildLifecycle::Running);
+        assert_eq!(registry.get("c1").unwrap().state, ChildLifecycle::Running);
+
+        registry.remove("c1");
+        assert!(registry.get("c1").is_none());
+    }
+
+    #[test]
+    fn snapshot_updates_on_observer_callbacks() {
+        let (tx, _rx) = mpsc::channel::<ChildEvent>();
+        let snapshots = ChildSnapshotRegistry::default();
+        snapshots.register("c1", "goal", 5);
+        let mut sender = ChildEventSender::new("c1".into(), "goal".into(), tx, 5)
+            .with_snapshots(snapshots.clone());
+
+        sender.on_tool_call_start("call-1", "navigate", "{}");
+        let s = snapshots.get("c1").unwrap();
+        assert_eq!(s.state, ChildLifecycle::Running);
+        assert_eq!(s.last_tool.as_deref(), Some("navigate"));
+
+        sender.on_text_delta("hello world");
+        let s = snapshots.get("c1").unwrap();
+        assert_eq!(s.last_text.as_deref(), Some("hello world"));
+
+        sender.on_turn_finished(&Err("boom".to_string()));
+        let s = snapshots.get("c1").unwrap();
+        assert_eq!(s.state, ChildLifecycle::Failed);
+        assert_eq!(s.error.as_deref(), Some("boom"));
+        assert_eq!(s.step, 1);
+    }
+
+    #[test]
+    fn snapshot_last_text_truncates_to_200_chars() {
+        let (tx, _rx) = mpsc::channel::<ChildEvent>();
+        let snapshots = ChildSnapshotRegistry::default();
+        snapshots.register("c1", "goal", 5);
+        let mut sender = ChildEventSender::new("c1".into(), "goal".into(), tx, 5)
+            .with_snapshots(snapshots.clone());
+        let huge = "x".repeat(500);
+        sender.on_text_delta(&huge);
+        let last_text = snapshots.get("c1").unwrap().last_text.unwrap();
+        // 200 chars + 1 ellipsis = 201 chars in last_text.
+        assert_eq!(last_text.chars().count(), 201);
+    }
+
+    #[test]
+    fn snapshot_pause_resume_flips_lifecycle() {
+        let (tx, _rx) = mpsc::channel::<ChildEvent>();
+        let snapshots = ChildSnapshotRegistry::default();
+        snapshots.register("c1", "goal", 5);
+        let mut sender = ChildEventSender::new("c1".into(), "goal".into(), tx, 5)
+            .with_snapshots(snapshots.clone());
+
+        sender.on_pause_started("captcha");
+        assert_eq!(snapshots.get("c1").unwrap().state, ChildLifecycle::Paused);
+        sender.on_pause_ended();
+        assert_eq!(snapshots.get("c1").unwrap().state, ChildLifecycle::Running);
     }
 }

--- a/crates/crawler/src/lib.rs
+++ b/crates/crawler/src/lib.rs
@@ -27,7 +27,7 @@ pub use playwright::{
 pub use prompt::build_system_prompt;
 pub use shared_client::SharedApiClient;
 pub use state::CrawlState;
-pub use tool_effect::{ForkSpec, ToolEffect, ToolError, WaitSpec};
+pub use tool_effect::{CancelSpec, ForkSpec, StatusSpec, ToolEffect, ToolError, WaitSpec};
 pub use tool_registry::{ToolHandler, ToolRegistry};
 
 /// Specification for a single tool that the agent can invoke.
@@ -299,14 +299,42 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: "wait_for_subagents",
-            description: "Wait for all active subagents to complete and collect their results. Returns immediately if no subagents are active.",
+            description: "Wait for active subagents and return a JSON snapshot of each one's status. Children that finish during the wait have their items collected and merged. Children that have not finished by the timeout are reported as `status: \"running\"` and KEEP RUNNING — wait NEVER cancels or aborts. Use `cancel_subagent` if you actually want to stop a child.",
             input_schema: json!({
                 "type": "object",
-                "properties": {},
+                "properties": {
+                    "child_ids": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Optional list of child IDs to wait for. Defaults to all active children."
+                    }
+                },
                 "additionalProperties": false
             }),
 
-            instructions: Some("Only call this when you need subagent results before deciding your next action."),
+            instructions: Some("Returns a JSON object: {\"waited\": N, \"finished\": [...], \"still_running\": [...]}. Finished entries include items_extracted and success/error. Still-running entries can be polled again (via another wait_for_subagents) or cancelled (via cancel_subagent). Do NOT assume a timeout means the child failed."),
+        },
+        ToolSpec {
+            name: "cancel_subagent",
+            description: "Abort one or more running subagents immediately. Their in-flight work is discarded. Use this only when you have decided the child's result is no longer needed.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "child_ids": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "minItems": 1,
+                        "description": "Child IDs to cancel (required, non-empty)."
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": "Optional human-readable reason for cancellation (logged in the Finished event)."
+                    }
+                },
+                "required": ["child_ids"],
+                "additionalProperties": false
+            }),
+            instructions: Some("Cancellation is abortive: the child JoinHandle is aborted and any partial extracted data is discarded. If you want results, call wait_for_subagents instead and let the child finish."),
         },
         ToolSpec {
             name: "wait_for_human",
@@ -345,16 +373,17 @@ mod tests {
     use super::mvp_tool_specs;
 
     #[test]
-    fn mvp_tool_specs_contains_expected_19_tools() {
+    fn mvp_tool_specs_contains_expected_20_tools() {
         let specs = mvp_tool_specs();
-        assert_eq!(specs.len(), 19);
+        assert_eq!(specs.len(), 20);
 
         let names: BTreeSet<_> = specs.iter().map(|spec| spec.name).collect();
-        assert_eq!(names.len(), 19, "tool names should be unique");
+        assert_eq!(names.len(), 20, "tool names should be unique");
         assert!(names.contains("navigate"));
         assert!(names.contains("save_file"));
         assert!(names.contains("fork"));
         assert!(names.contains("wait_for_subagents"));
+        assert!(names.contains("cancel_subagent"));
     }
 
     #[test]

--- a/crates/crawler/src/lib.rs
+++ b/crates/crawler/src/lib.rs
@@ -17,7 +17,10 @@ mod tools;
 
 pub use agent::{AgentHandle, AgentState, CrawlAgent, CrawlError, CrawlResult, CrawlerAgent};
 pub use browser::BrowserContext;
-pub use child_events::{ChildControlRegistry, ChildEvent, ChildEventKind, ChildEventSender};
+pub use child_events::{
+    ChildControlRegistry, ChildEvent, ChildEventKind, ChildEventSender, ChildLifecycle,
+    ChildSnapshot, ChildSnapshotRegistry,
+};
 pub use fetcher::{FetchError, FetchRouter, FetchedPage};
 pub use manager::{AgentInfo, AgentManager, AgentStatus, ForkLimitError, SharedAgentManager};
 pub use output::{write_output, OutputError, OutputFormat};
@@ -315,6 +318,22 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
             instructions: Some("Returns a JSON object: {\"waited\": N, \"finished\": [...], \"still_running\": [...]}. Finished entries include items_extracted and success/error. Still-running entries can be polled again (via another wait_for_subagents) or cancelled (via cancel_subagent). Do NOT assume a timeout means the child failed."),
         },
         ToolSpec {
+            name: "subagent_status",
+            description: "Read-only poll: returns a JSON snapshot of each subagent's lifecycle, current step, last tool call, last text output, items extracted, and how long ago its last event was observed. Never joins or cancels — safe to call between any other actions.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "child_ids": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Optional list of child IDs to inspect. Defaults to all tracked children."
+                    }
+                },
+                "additionalProperties": false
+            }),
+            instructions: Some("Returns {\"children\": [{child_id, sub_goal, state, step, max_steps, last_tool, last_text, items_extracted, last_event_secs_ago, error}, ...]}. State is one of: created, running, paused, completed, failed, cancelled. Use this to decide whether to wait, cancel, or fork more — without consuming the child."),
+        },
+        ToolSpec {
             name: "cancel_subagent",
             description: "Abort one or more running subagents immediately. Their in-flight work is discarded. Use this only when you have decided the child's result is no longer needed.",
             input_schema: json!({
@@ -373,17 +392,18 @@ mod tests {
     use super::mvp_tool_specs;
 
     #[test]
-    fn mvp_tool_specs_contains_expected_20_tools() {
+    fn mvp_tool_specs_contains_expected_21_tools() {
         let specs = mvp_tool_specs();
-        assert_eq!(specs.len(), 20);
+        assert_eq!(specs.len(), 21);
 
         let names: BTreeSet<_> = specs.iter().map(|spec| spec.name).collect();
-        assert_eq!(names.len(), 20, "tool names should be unique");
+        assert_eq!(names.len(), 21, "tool names should be unique");
         assert!(names.contains("navigate"));
         assert!(names.contains("save_file"));
         assert!(names.contains("fork"));
         assert!(names.contains("wait_for_subagents"));
         assert!(names.contains("cancel_subagent"));
+        assert!(names.contains("subagent_status"));
     }
 
     #[test]

--- a/crates/crawler/src/lib.rs
+++ b/crates/crawler/src/lib.rs
@@ -315,7 +315,6 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                         },
                         "required": ["type"]
                     },
-                    "success_criteria": { "type": "string", "description": "Optional definition of done." },
                     "max_steps": { "type": "integer", "minimum": 1, "description": "Override the child's step budget." }
                 },
                 "required": ["objective", "scope"],

--- a/crates/crawler/src/lib.rs
+++ b/crates/crawler/src/lib.rs
@@ -14,6 +14,7 @@ mod state;
 pub mod tool_effect;
 mod tool_registry;
 mod tools;
+mod url_claim;
 
 pub use agent::{AgentHandle, AgentState, CrawlAgent, CrawlError, CrawlResult, CrawlerAgent};
 pub use browser::BrowserContext;
@@ -30,8 +31,11 @@ pub use playwright::{
 pub use prompt::build_system_prompt;
 pub use shared_client::SharedApiClient;
 pub use state::CrawlState;
-pub use tool_effect::{CancelSpec, ForkSpec, StatusSpec, ToolEffect, ToolError, WaitSpec};
+pub use tool_effect::{
+    CancelSpec, CrawlScope, CrawlTask, StatusSpec, ToolEffect, ToolError, WaitSpec,
+};
 pub use tool_registry::{ToolHandler, ToolRegistry};
+pub use url_claim::{ClaimConflict, ClaimGuard, UrlClaimRegistry};
 
 /// Specification for a single tool that the agent can invoke.
 pub struct ToolSpec {
@@ -287,18 +291,38 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: "fork",
-            description: "Spawn a parallel subagent on a new browser tab to explore a URL or complete a sub-goal independently. Results are merged when the subagent completes.",
+            description: "Spawn a parallel subagent on a new browser tab with a typed work packet. The packet declares an `objective` (what to do) and a `scope` (which URLs the child is allowed to claim). Sibling forks CANNOT claim overlapping URLs/patterns — the call errors atomically with the conflicting owner.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
-                    "sub_goal": { "type": "string" },
-                    "url": { "type": "string" }
+                    "objective": {
+                        "type": "string",
+                        "description": "Human-readable goal for the subagent (e.g., 'extract all product titles')."
+                    },
+                    "scope": {
+                        "type": "object",
+                        "description": "Declared work boundary. Exactly one of single_page, url_list, or url_pattern.",
+                        "properties": {
+                            "type": { "type": "string", "enum": ["single_page", "url_list", "url_pattern"] },
+                            "url": { "type": "string", "description": "Required when type=single_page." },
+                            "urls": {
+                                "type": "array",
+                                "items": { "type": "string" },
+                                "minItems": 1,
+                                "description": "Required when type=url_list."
+                            },
+                            "regex": { "type": "string", "description": "Required when type=url_pattern. Must compile." }
+                        },
+                        "required": ["type"]
+                    },
+                    "success_criteria": { "type": "string", "description": "Optional definition of done." },
+                    "max_steps": { "type": "integer", "minimum": 1, "description": "Override the child's step budget." }
                 },
-                "required": ["sub_goal"],
+                "required": ["objective", "scope"],
                 "additionalProperties": false
             }),
 
-            instructions: Some("Use fork when you need to visit multiple pages in parallel — e.g., scraping pagination, exploring search results, or comparing products. Each subagent has a step budget and works independently. Fork multiple subagents before waiting for any of them."),
+            instructions: Some("Use fork to parallelize crawls — e.g., scraping pagination, exploring search results, comparing products. Each subagent gets its own browser tab and step budget. Scope is mandatory: choose single_page for one URL, url_list for a small set, url_pattern (regex) for a navigable subdomain. Siblings CANNOT overlap — if two forks would touch the same URL, the second errors with the conflicting child's id. Plan scope upfront to avoid duplicate work. Fork multiple subagents in a row, then poll with subagent_status or wait_for_subagents."),
         },
         ToolSpec {
             name: "wait_for_subagents",

--- a/crates/crawler/src/lib.rs
+++ b/crates/crawler/src/lib.rs
@@ -321,7 +321,7 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
                 "additionalProperties": false
             }),
 
-            instructions: Some("Use fork to parallelize crawls — e.g., scraping pagination, exploring search results, comparing products. Each subagent gets its own browser tab and step budget. Scope is mandatory: choose single_page for one URL, url_list for a small set, url_pattern (regex) for a navigable subdomain. Siblings CANNOT overlap — if two forks would touch the same URL, the second errors with the conflicting child's id. Plan scope upfront to avoid duplicate work. Fork multiple subagents in a row, then poll with subagent_status or wait_for_subagents."),
+            instructions: Some("Use fork to parallelize crawls — e.g., scraping pagination, exploring search results, comparing products. Each subagent gets its own browser tab and step budget. Scope is mandatory: choose single_page for one URL, url_list for a small set, url_pattern (regex) for a navigable subdomain. Siblings CANNOT overlap — if two forks would touch the same URL, the second errors with the conflicting child's id. Pattern overlap is detected only for identical regex strings; subtly different but semantically overlapping patterns (e.g. /posts/.* and /posts/2024/.*) are not caught, so use non-overlapping patterns deliberately. Plan scope upfront to avoid duplicate work. Fork multiple subagents in a row, then poll with subagent_status or wait_for_subagents."),
         },
         ToolSpec {
             name: "wait_for_subagents",

--- a/crates/crawler/src/manager.rs
+++ b/crates/crawler/src/manager.rs
@@ -52,21 +52,29 @@ impl std::fmt::Display for ForkLimitError {
 impl std::error::Error for ForkLimitError {}
 
 /// Manages a hierarchical agent tree and enforces fork limits.
+///
+/// Also holds the [`crate::UrlClaimRegistry`] used to dispatch
+/// non-overlapping crawl scope to sibling sub-agents. The registry is shared
+/// (via `Arc`) across the parent agent and all of its descendants so that
+/// claim conflicts are visible everywhere in the tree.
 pub struct AgentManager {
     pub max_concurrent_per_parent: usize,
     pub max_depth: usize,
     pub max_total: usize,
+    pub url_claims: crate::UrlClaimRegistry,
     agents: HashMap<String, AgentInfo>,
 }
 
 impl AgentManager {
-    /// Create a new manager with the given limits.
+    /// Create a new manager with the given limits and a fresh
+    /// [`crate::UrlClaimRegistry`].
     #[must_use]
     pub fn new(max_concurrent_per_parent: usize, max_depth: usize, max_total: usize) -> Self {
         Self {
             max_concurrent_per_parent,
             max_depth,
             max_total,
+            url_claims: crate::UrlClaimRegistry::new(),
             agents: HashMap::new(),
         }
     }

--- a/crates/crawler/src/tool_effect.rs
+++ b/crates/crawler/src/tool_effect.rs
@@ -5,8 +5,8 @@ use serde_json::Value;
 pub enum ToolEffect {
     /// Tool produced a plain string reply (the most common case).
     Reply(String),
-    /// Tool requests spawning a sub-agent with the given spec.
-    Spawn(ForkSpec),
+    /// Tool requests spawning a sub-agent with the given typed work packet.
+    Spawn(CrawlTask),
     /// Tool requests waiting for sub-agents to finish.
     Wait(WaitSpec),
     /// Tool requests cancelling running sub-agents. Cancellation is abortive:
@@ -27,11 +27,35 @@ impl ToolEffect {
     }
 }
 
-/// Parameters for spawning a sub-agent.
+/// A typed, validated work packet for a forked sub-agent. The `scope`
+/// declares which URLs the child is allowed to claim; siblings cannot fork
+/// onto overlapping scope. This is the atomic dispatch primitive that
+/// replaces the free-form `{ sub_goal: String }` of older versions.
 #[derive(Debug, Clone)]
-pub struct ForkSpec {
-    pub goal: String,
+pub struct CrawlTask {
+    pub objective: String,
+    pub scope: CrawlScope,
+    pub success_criteria: Option<String>,
+    pub max_steps: Option<usize>,
+    pub deadline_secs: Option<u64>,
+    /// Set by the fork supervisor once a page is allocated; never provided
+    /// by the LLM.
     pub page_index: Option<usize>,
+}
+
+/// Declared work boundary for a sub-agent. The fork supervisor refuses to
+/// dispatch overlapping scopes (same URL, overlapping pattern) so siblings
+/// don't redo each other's work.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CrawlScope {
+    /// Crawl one specific URL.
+    SinglePage { url: String },
+    /// Crawl an explicit list of URLs (≥ 1).
+    UrlList { urls: Vec<String> },
+    /// Crawl any URL matching this regex. The pattern source string is used
+    /// as the conflict key — siblings cannot request the same pattern, and
+    /// the pattern cannot overlap with already-claimed exact URLs.
+    UrlPattern { regex: String },
 }
 
 /// Parameters for waiting on sub-agents.

--- a/crates/crawler/src/tool_effect.rs
+++ b/crates/crawler/src/tool_effect.rs
@@ -9,6 +9,13 @@ pub enum ToolEffect {
     Spawn(ForkSpec),
     /// Tool requests waiting for sub-agents to finish.
     Wait(WaitSpec),
+    /// Tool requests cancelling running sub-agents. Cancellation is abortive:
+    /// the children are torn down immediately and their in-flight work is
+    /// discarded.
+    Cancel(CancelSpec),
+    /// Tool requests a read-only snapshot of running sub-agents. Never joins
+    /// or cancels — safe to call between steps.
+    Status(StatusSpec),
     /// Tool requests pausing execution for human intervention.
     Pause { reason: String },
 }
@@ -30,6 +37,19 @@ pub struct ForkSpec {
 /// Parameters for waiting on sub-agents.
 #[derive(Debug, Clone)]
 pub struct WaitSpec {
+    pub child_ids: Option<Vec<String>>,
+}
+
+/// Parameters for explicitly cancelling sub-agents.
+#[derive(Debug, Clone)]
+pub struct CancelSpec {
+    pub child_ids: Vec<String>,
+    pub reason: Option<String>,
+}
+
+/// Parameters for polling sub-agent status without joining them.
+#[derive(Debug, Clone)]
+pub struct StatusSpec {
     pub child_ids: Option<Vec<String>>,
 }
 

--- a/crates/crawler/src/tool_effect.rs
+++ b/crates/crawler/src/tool_effect.rs
@@ -35,9 +35,7 @@ impl ToolEffect {
 pub struct CrawlTask {
     pub objective: String,
     pub scope: CrawlScope,
-    pub success_criteria: Option<String>,
     pub max_steps: Option<usize>,
-    pub deadline_secs: Option<u64>,
     /// Set by the fork supervisor once a page is allocated; never provided
     /// by the LLM.
     pub page_index: Option<usize>,

--- a/crates/crawler/src/tool_registry.rs
+++ b/crates/crawler/src/tool_registry.rs
@@ -42,7 +42,7 @@ impl ToolRegistry {
         Self::new_with_options(true)
     }
 
-    /// Create a registry with all 20 core tools.
+    /// Create a registry with all 21 core tools.
     /// `is_interactive` controls whether `wait_for_human` is allowed to pause.
     #[must_use]
     pub fn new_with_options(is_interactive: bool) -> Self {
@@ -62,6 +62,10 @@ impl ToolRegistry {
         registry.register(
             "cancel_subagent",
             Box::new(crate::tools::cancel_subagent::execute),
+        );
+        registry.register(
+            "subagent_status",
+            Box::new(crate::tools::subagent_status::execute),
         );
         registry.register(
             "wait_for_human",
@@ -138,15 +142,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn new_with_core_tools_registers_all_twenty() {
+    fn new_with_core_tools_registers_all_twenty_one() {
         let registry = ToolRegistry::new_with_core_tools();
         let effect_tools = [
             "fork",
             "wait_for_subagents",
             "cancel_subagent",
+            "subagent_status",
             "wait_for_human",
         ];
-        assert_eq!(registry.len(), 20);
+        assert_eq!(registry.len(), 21);
         for &name in ASYNC_TOOLS.iter().chain(effect_tools.iter()) {
             assert!(registry.contains(name), "missing core tool: {name}");
         }

--- a/crates/crawler/src/tool_registry.rs
+++ b/crates/crawler/src/tool_registry.rs
@@ -42,7 +42,7 @@ impl ToolRegistry {
         Self::new_with_options(true)
     }
 
-    /// Create a registry with all 19 core tools.
+    /// Create a registry with all 20 core tools.
     /// `is_interactive` controls whether `wait_for_human` is allowed to pause.
     #[must_use]
     pub fn new_with_options(is_interactive: bool) -> Self {
@@ -58,6 +58,10 @@ impl ToolRegistry {
         registry.register(
             "wait_for_subagents",
             Box::new(crate::tools::wait_for_subagents::execute),
+        );
+        registry.register(
+            "cancel_subagent",
+            Box::new(crate::tools::cancel_subagent::execute),
         );
         registry.register(
             "wait_for_human",
@@ -134,10 +138,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn new_with_core_tools_registers_all_nineteen() {
+    fn new_with_core_tools_registers_all_twenty() {
         let registry = ToolRegistry::new_with_core_tools();
-        let effect_tools = ["fork", "wait_for_subagents", "wait_for_human"];
-        assert_eq!(registry.len(), 19);
+        let effect_tools = [
+            "fork",
+            "wait_for_subagents",
+            "cancel_subagent",
+            "wait_for_human",
+        ];
+        assert_eq!(registry.len(), 20);
         for &name in ASYNC_TOOLS.iter().chain(effect_tools.iter()) {
             assert!(registry.contains(name), "missing core tool: {name}");
         }

--- a/crates/crawler/src/tools/cancel_subagent.rs
+++ b/crates/crawler/src/tools/cancel_subagent.rs
@@ -1,0 +1,71 @@
+use serde_json::Value;
+
+use crate::{tool_effect::CancelSpec, ToolEffect, ToolError};
+
+pub fn execute(input: &Value) -> Result<ToolEffect, ToolError> {
+    let raw_ids = input
+        .get("child_ids")
+        .ok_or_else(|| ToolError::new("cancel_subagent requires child_ids".to_string()))?
+        .as_array()
+        .ok_or_else(|| ToolError::new("cancel_subagent child_ids must be an array".to_string()))?;
+
+    if raw_ids.is_empty() {
+        return Err(ToolError::new(
+            "cancel_subagent child_ids must not be empty".to_string(),
+        ));
+    }
+
+    let child_ids = raw_ids
+        .iter()
+        .map(|value| {
+            value.as_str().map(str::to_owned).ok_or_else(|| {
+                ToolError::new("cancel_subagent child_ids entries must be strings".to_string())
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let reason = input
+        .get("reason")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+
+    Ok(ToolEffect::Cancel(CancelSpec { child_ids, reason }))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn cancel_returns_cancel_effect() {
+        let effect = execute(&json!({"child_ids": ["c1", "c2"], "reason": "timed out goal"}))
+            .expect("cancel_subagent should parse");
+        match effect {
+            ToolEffect::Cancel(spec) => {
+                assert_eq!(spec.child_ids, vec!["c1".to_string(), "c2".to_string()]);
+                assert_eq!(spec.reason.as_deref(), Some("timed out goal"));
+            }
+            _ => panic!("expected Cancel effect"),
+        }
+    }
+
+    #[test]
+    fn cancel_rejects_missing_child_ids() {
+        let err = execute(&json!({})).expect_err("cancel_subagent without child_ids should fail");
+        assert!(err.to_string().contains("requires child_ids"));
+    }
+
+    #[test]
+    fn cancel_rejects_empty_child_ids() {
+        let err = execute(&json!({"child_ids": []})).expect_err("empty child_ids should fail");
+        assert!(err.to_string().contains("must not be empty"));
+    }
+
+    #[test]
+    fn cancel_rejects_non_string_entries() {
+        let err = execute(&json!({"child_ids": [42]})).expect_err("non-string entry should fail");
+        assert!(err.to_string().contains("must be strings"));
+    }
+}

--- a/crates/crawler/src/tools/fork.rs
+++ b/crates/crawler/src/tools/fork.rs
@@ -1,23 +1,140 @@
+use regex::Regex;
 use serde_json::Value;
 
-use crate::{ForkSpec, ToolEffect, ToolError};
+use crate::{
+    tool_effect::{CrawlScope, CrawlTask},
+    ToolEffect, ToolError,
+};
 
+/// Parse the LLM's fork tool input into a typed [`CrawlTask`]. The shape is:
+///
+/// ```json
+/// {
+///   "objective": "collect details from posts page 2",
+///   "scope": { "type": "single_page", "url": "https://example.com/posts?page=2" },
+///   "success_criteria": "extracted at least 10 items",
+///   "max_steps": 12
+/// }
+/// ```
+///
+/// `scope.type` is one of `single_page`, `url_list`, `url_pattern`. The
+/// parser validates the regex compiles when `scope.type == url_pattern`.
 pub fn execute(input: &Value) -> Result<ToolEffect, ToolError> {
-    let goal = input
-        .get("sub_goal")
+    let objective = input
+        .get("objective")
         .and_then(Value::as_str)
-        .map_or("", str::trim)
+        .map(str::trim)
+        .ok_or_else(|| ToolError::new("fork requires objective".to_string()))?
         .to_string();
-    if goal.is_empty() {
+    if objective.is_empty() {
         return Err(ToolError::new(
-            "fork requires non-empty sub_goal".to_string(),
+            "fork requires non-empty objective".to_string(),
         ));
     }
 
-    Ok(ToolEffect::Spawn(ForkSpec {
-        goal,
+    let scope_value = input
+        .get("scope")
+        .ok_or_else(|| ToolError::new("fork requires scope".to_string()))?;
+    let scope = parse_scope(scope_value)?;
+
+    let success_criteria = input
+        .get("success_criteria")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    let max_steps = input
+        .get("max_steps")
+        .and_then(Value::as_u64)
+        .map(|v| usize::try_from(v).unwrap_or(usize::MAX));
+    let deadline_secs = input.get("deadline_secs").and_then(Value::as_u64);
+
+    Ok(ToolEffect::Spawn(CrawlTask {
+        objective,
+        scope,
+        success_criteria,
+        max_steps,
+        deadline_secs,
         page_index: None,
     }))
+}
+
+fn parse_scope(value: &Value) -> Result<CrawlScope, ToolError> {
+    let obj = value
+        .as_object()
+        .ok_or_else(|| ToolError::new("fork scope must be an object".to_string()))?;
+    let kind = obj
+        .get("type")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ToolError::new("fork scope.type must be a string".to_string()))?;
+    match kind {
+        "single_page" => {
+            let url = obj
+                .get("url")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .ok_or_else(|| {
+                    ToolError::new("fork scope.url is required for single_page".to_string())
+                })?;
+            if url.is_empty() {
+                return Err(ToolError::new(
+                    "fork scope.url must not be empty".to_string(),
+                ));
+            }
+            Ok(CrawlScope::SinglePage {
+                url: url.to_string(),
+            })
+        }
+        "url_list" => {
+            let urls = obj.get("urls").and_then(Value::as_array).ok_or_else(|| {
+                ToolError::new("fork scope.urls is required for url_list".to_string())
+            })?;
+            if urls.is_empty() {
+                return Err(ToolError::new(
+                    "fork scope.urls must contain at least one URL".to_string(),
+                ));
+            }
+            let urls = urls
+                .iter()
+                .map(|entry| {
+                    entry
+                        .as_str()
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                        .map(str::to_owned)
+                        .ok_or_else(|| {
+                            ToolError::new(
+                                "fork scope.urls entries must be non-empty strings".to_string(),
+                            )
+                        })
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(CrawlScope::UrlList { urls })
+        }
+        "url_pattern" => {
+            let regex = obj
+                .get("regex")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .ok_or_else(|| {
+                    ToolError::new("fork scope.regex is required for url_pattern".to_string())
+                })?;
+            if regex.is_empty() {
+                return Err(ToolError::new(
+                    "fork scope.regex must not be empty".to_string(),
+                ));
+            }
+            // Compile to surface invalid regex early — the registry will
+            // re-compile, but the parser surfaces the error before the
+            // claim attempt.
+            Regex::new(regex)
+                .map_err(|error| ToolError::new(format!("fork scope.regex is invalid: {error}")))?;
+            Ok(CrawlScope::UrlPattern {
+                regex: regex.to_string(),
+            })
+        }
+        other => Err(ToolError::new(format!(
+            "fork scope.type must be `single_page`, `url_list`, or `url_pattern`; got `{other}`"
+        ))),
+    }
 }
 
 #[cfg(test)]
@@ -27,21 +144,120 @@ mod tests {
     use super::*;
 
     #[test]
-    fn fork_returns_spawn_effect() {
-        let effect =
-            execute(&json!({"sub_goal": "collect details"})).expect("fork should parse sub_goal");
+    fn fork_returns_spawn_effect_for_single_page() {
+        let effect = execute(&json!({
+            "objective": "collect details",
+            "scope": { "type": "single_page", "url": "https://example.com/a" }
+        }))
+        .expect("fork should parse single_page scope");
         match effect {
-            ToolEffect::Spawn(spec) => {
-                assert_eq!(spec.goal, "collect details");
-                assert_eq!(spec.page_index, None);
+            ToolEffect::Spawn(task) => {
+                assert_eq!(task.objective, "collect details");
+                assert_eq!(
+                    task.scope,
+                    CrawlScope::SinglePage {
+                        url: "https://example.com/a".to_string()
+                    }
+                );
+                assert_eq!(task.page_index, None);
             }
-            _ => panic!("expected spawn effect"),
+            _ => panic!("expected Spawn effect"),
         }
     }
 
     #[test]
-    fn fork_rejects_empty_sub_goal() {
-        let error = execute(&json!({"sub_goal": "   "})).expect_err("empty sub_goal should fail");
-        assert_eq!(error.to_string(), "fork requires non-empty sub_goal");
+    fn fork_returns_spawn_effect_for_url_list() {
+        let effect = execute(&json!({
+            "objective": "compare results",
+            "scope": { "type": "url_list", "urls": ["https://a.com", "https://b.com"] }
+        }))
+        .expect("fork should parse url_list scope");
+        match effect {
+            ToolEffect::Spawn(task) => {
+                assert_eq!(
+                    task.scope,
+                    CrawlScope::UrlList {
+                        urls: vec!["https://a.com".to_string(), "https://b.com".to_string()]
+                    }
+                );
+            }
+            _ => panic!("expected Spawn effect"),
+        }
+    }
+
+    #[test]
+    fn fork_returns_spawn_effect_for_url_pattern() {
+        let effect = execute(&json!({
+            "objective": "crawl posts",
+            "scope": { "type": "url_pattern", "regex": "^https://example\\.com/posts/.*" }
+        }))
+        .expect("fork should parse url_pattern scope");
+        match effect {
+            ToolEffect::Spawn(task) => {
+                assert_eq!(
+                    task.scope,
+                    CrawlScope::UrlPattern {
+                        regex: "^https://example\\.com/posts/.*".to_string()
+                    }
+                );
+            }
+            _ => panic!("expected Spawn effect"),
+        }
+    }
+
+    #[test]
+    fn fork_rejects_missing_objective() {
+        let err = execute(&json!({
+            "scope": { "type": "single_page", "url": "https://example.com" }
+        }))
+        .expect_err("missing objective should fail");
+        assert!(err.to_string().contains("requires objective"));
+    }
+
+    #[test]
+    fn fork_rejects_empty_objective() {
+        let err = execute(&json!({
+            "objective": "   ",
+            "scope": { "type": "single_page", "url": "https://example.com" }
+        }))
+        .expect_err("empty objective should fail");
+        assert!(err.to_string().contains("non-empty objective"));
+    }
+
+    #[test]
+    fn fork_rejects_missing_scope() {
+        let err =
+            execute(&json!({"objective": "do something"})).expect_err("missing scope should fail");
+        assert!(err.to_string().contains("requires scope"));
+    }
+
+    #[test]
+    fn fork_rejects_unknown_scope_type() {
+        let err = execute(&json!({
+            "objective": "x",
+            "scope": { "type": "everything" }
+        }))
+        .expect_err("unknown scope.type should fail");
+        assert!(err.to_string().contains("must be `single_page`"));
+    }
+
+    #[test]
+    fn fork_rejects_empty_url_list() {
+        let err = execute(&json!({
+            "objective": "x",
+            "scope": { "type": "url_list", "urls": [] }
+        }))
+        .expect_err("empty urls should fail");
+        assert!(err.to_string().contains("at least one URL"));
+    }
+
+    #[test]
+    fn fork_rejects_invalid_regex() {
+        let err = execute(&json!({
+            "objective": "x",
+            "scope": { "type": "url_pattern", "regex": "[broken" }
+        }))
+        .expect_err("invalid regex should fail");
+        assert!(err.to_string().contains("invalid"));
     }
 }

--- a/crates/crawler/src/tools/fork.rs
+++ b/crates/crawler/src/tools/fork.rs
@@ -12,7 +12,6 @@ use crate::{
 /// {
 ///   "objective": "collect details from posts page 2",
 ///   "scope": { "type": "single_page", "url": "https://example.com/posts?page=2" },
-///   "success_criteria": "extracted at least 10 items",
 ///   "max_steps": 12
 /// }
 /// ```
@@ -37,22 +36,15 @@ pub fn execute(input: &Value) -> Result<ToolEffect, ToolError> {
         .ok_or_else(|| ToolError::new("fork requires scope".to_string()))?;
     let scope = parse_scope(scope_value)?;
 
-    let success_criteria = input
-        .get("success_criteria")
-        .and_then(Value::as_str)
-        .map(str::to_owned);
     let max_steps = input
         .get("max_steps")
         .and_then(Value::as_u64)
         .map(|v| usize::try_from(v).unwrap_or(usize::MAX));
-    let deadline_secs = input.get("deadline_secs").and_then(Value::as_u64);
 
     Ok(ToolEffect::Spawn(CrawlTask {
         objective,
         scope,
-        success_criteria,
         max_steps,
-        deadline_secs,
         page_index: None,
     }))
 }

--- a/crates/crawler/src/tools/mod.rs
+++ b/crates/crawler/src/tools/mod.rs
@@ -1,3 +1,4 @@
+pub mod cancel_subagent;
 pub mod click;
 pub mod feedback;
 pub mod fill_form;

--- a/crates/crawler/src/tools/mod.rs
+++ b/crates/crawler/src/tools/mod.rs
@@ -16,6 +16,7 @@ pub mod press_key;
 pub mod save_file;
 pub mod scroll;
 pub mod select_option;
+pub mod subagent_status;
 pub mod switch_tab;
 pub mod wait;
 pub mod wait_for_human;

--- a/crates/crawler/src/tools/subagent_status.rs
+++ b/crates/crawler/src/tools/subagent_status.rs
@@ -1,0 +1,70 @@
+use serde_json::Value;
+
+use crate::{tool_effect::StatusSpec, ToolEffect, ToolError};
+
+pub fn execute(input: &Value) -> Result<ToolEffect, ToolError> {
+    let child_ids = match input.get("child_ids") {
+        None | Some(Value::Null) => None,
+        Some(value) => {
+            let array = value.as_array().ok_or_else(|| {
+                ToolError::new("subagent_status child_ids must be an array".to_string())
+            })?;
+            let ids = array
+                .iter()
+                .map(|entry| {
+                    entry.as_str().map(str::to_owned).ok_or_else(|| {
+                        ToolError::new(
+                            "subagent_status child_ids entries must be strings".to_string(),
+                        )
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            Some(ids)
+        }
+    };
+
+    Ok(ToolEffect::Status(StatusSpec { child_ids }))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn status_returns_status_effect_with_filter() {
+        let effect = execute(&json!({"child_ids": ["c1", "c2"]}))
+            .expect("subagent_status should parse child_ids");
+        match effect {
+            ToolEffect::Status(spec) => {
+                assert_eq!(
+                    spec.child_ids,
+                    Some(vec!["c1".to_string(), "c2".to_string()])
+                );
+            }
+            _ => panic!("expected Status effect"),
+        }
+    }
+
+    #[test]
+    fn status_returns_unfiltered_when_no_child_ids() {
+        let effect = execute(&json!({})).expect("status should default to all children");
+        match effect {
+            ToolEffect::Status(spec) => assert_eq!(spec.child_ids, None),
+            _ => panic!("expected Status effect"),
+        }
+    }
+
+    #[test]
+    fn status_rejects_non_string_entries() {
+        let err = execute(&json!({"child_ids": [123]})).expect_err("non-string entry should fail");
+        assert!(err.to_string().contains("must be strings"));
+    }
+
+    #[test]
+    fn status_rejects_non_array_child_ids() {
+        let err = execute(&json!({"child_ids": "c1"})).expect_err("non-array should fail");
+        assert!(err.to_string().contains("must be an array"));
+    }
+}

--- a/crates/crawler/src/url_claim.rs
+++ b/crates/crawler/src/url_claim.rs
@@ -460,7 +460,7 @@ mod tests {
     #[test]
     fn url_list_deduplicates_intra_list_duplicate_urls() {
         let registry = UrlClaimRegistry::new();
-        let _g = registry
+        let guard = registry
             .try_claim(
                 &CrawlScope::UrlList {
                     urls: vec![
@@ -478,7 +478,7 @@ mod tests {
 
         // The deduplicated URL is still claimable by another child after the
         // guard drops (this verifies len() tracked correctly).
-        drop(_g);
+        drop(guard);
         assert_eq!(registry.len(), 0);
     }
 

--- a/crates/crawler/src/url_claim.rs
+++ b/crates/crawler/src/url_claim.rs
@@ -1,0 +1,485 @@
+//! Atomic URL/scope claim registry.
+//!
+//! Two sibling sub-agents cannot crawl overlapping URLs. Before the fork
+//! supervisor spawns a child, it calls [`UrlClaimRegistry::try_claim`] with
+//! the child's [`CrawlScope`]; on success the registry returns a
+//! [`ClaimGuard`] that owns the lifetime of the claim — when the guard
+//! drops (child finishes, cancelled, or supervisor aborts setup), the
+//! claim is released and another sibling may claim the same scope.
+//!
+//! Overlap policy:
+//! - exact-vs-exact: same URL string fails the second claim.
+//! - pattern-vs-pattern: identical regex source fails (conservative; subtly
+//!   different but semantically overlapping regexes are an accepted
+//!   footgun).
+//! - exact-vs-pattern: an exact URL conflicts with any *already-claimed*
+//!   pattern that matches it, and a pattern conflicts with any
+//!   already-claimed exact URL it would match.
+
+use std::sync::{Arc, Mutex};
+
+use regex::Regex;
+
+use crate::tool_effect::CrawlScope;
+
+/// Reason a claim was rejected. Surfaced to the LLM so it can adjust scope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClaimConflict {
+    /// Exact URL already claimed by another owner.
+    ExactUrl { url: String, owner: String },
+    /// Same regex pattern already claimed.
+    Pattern { regex: String, owner: String },
+    /// A pattern matched an already-claimed exact URL, or vice versa.
+    PatternMatchesExact {
+        regex: String,
+        url: String,
+        owner: String,
+    },
+    /// Pattern was syntactically invalid.
+    InvalidRegex { regex: String, error: String },
+}
+
+impl std::fmt::Display for ClaimConflict {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ExactUrl { url, owner } => {
+                write!(f, "url `{url}` already claimed by sub-agent `{owner}`")
+            }
+            Self::Pattern { regex, owner } => write!(
+                f,
+                "pattern `{regex}` already claimed by sub-agent `{owner}`"
+            ),
+            Self::PatternMatchesExact { regex, url, owner } => write!(
+                f,
+                "pattern `{regex}` overlaps url `{url}` already claimed by sub-agent `{owner}`"
+            ),
+            Self::InvalidRegex { regex, error } => {
+                write!(f, "invalid regex `{regex}`: {error}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ClaimConflict {}
+
+#[derive(Debug)]
+enum Entry {
+    Exact {
+        url: String,
+        owner: String,
+    },
+    Pattern {
+        regex: Regex,
+        source: String,
+        owner: String,
+    },
+}
+
+#[derive(Default)]
+struct Inner {
+    entries: Vec<Entry>,
+}
+
+/// Concurrent, atomic registry of in-flight URL/scope claims.
+#[derive(Default, Clone)]
+pub struct UrlClaimRegistry {
+    inner: Arc<Mutex<Inner>>,
+}
+
+impl UrlClaimRegistry {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Attempt to claim `scope` on behalf of `owner_id`. On success returns a
+    /// [`ClaimGuard`]; dropping the guard releases the claim. On conflict
+    /// returns the specific [`ClaimConflict`] reason.
+    ///
+    /// Atomic: the conflict check and registration happen under the same
+    /// lock, so two racing siblings cannot both succeed.
+    ///
+    /// # Errors
+    /// See [`ClaimConflict`].
+    pub fn try_claim(
+        &self,
+        scope: &CrawlScope,
+        owner_id: &str,
+    ) -> Result<ClaimGuard, ClaimConflict> {
+        let mut guard = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        match scope {
+            CrawlScope::SinglePage { url } => {
+                check_and_insert_exact(&mut guard, url, owner_id)?;
+                Ok(ClaimGuard {
+                    registry: Arc::clone(&self.inner),
+                    keys: vec![ClaimKey::Exact(url.clone())],
+                })
+            }
+            CrawlScope::UrlList { urls } => {
+                // All-or-nothing: validate every URL before inserting any.
+                for url in urls {
+                    check_exact(&guard, url, owner_id)?;
+                }
+                let keys = urls
+                    .iter()
+                    .map(|url| {
+                        guard.entries.push(Entry::Exact {
+                            url: url.clone(),
+                            owner: owner_id.to_string(),
+                        });
+                        ClaimKey::Exact(url.clone())
+                    })
+                    .collect();
+                Ok(ClaimGuard {
+                    registry: Arc::clone(&self.inner),
+                    keys,
+                })
+            }
+            CrawlScope::UrlPattern { regex } => {
+                let compiled = Regex::new(regex).map_err(|error| ClaimConflict::InvalidRegex {
+                    regex: regex.clone(),
+                    error: error.to_string(),
+                })?;
+                check_pattern(&guard, regex, &compiled, owner_id)?;
+                guard.entries.push(Entry::Pattern {
+                    regex: compiled,
+                    source: regex.clone(),
+                    owner: owner_id.to_string(),
+                });
+                Ok(ClaimGuard {
+                    registry: Arc::clone(&self.inner),
+                    keys: vec![ClaimKey::Pattern(regex.clone())],
+                })
+            }
+        }
+    }
+
+    /// Snapshot of currently claimed entries; intended for tests/debug.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .entries
+            .len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+fn check_exact(inner: &Inner, url: &str, _owner_id: &str) -> Result<(), ClaimConflict> {
+    for entry in &inner.entries {
+        match entry {
+            Entry::Exact {
+                url: claimed,
+                owner,
+            } if claimed == url => {
+                return Err(ClaimConflict::ExactUrl {
+                    url: url.to_string(),
+                    owner: owner.clone(),
+                });
+            }
+            Entry::Pattern {
+                regex,
+                source,
+                owner,
+            } if regex.is_match(url) => {
+                return Err(ClaimConflict::PatternMatchesExact {
+                    regex: source.clone(),
+                    url: url.to_string(),
+                    owner: owner.clone(),
+                });
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn check_and_insert_exact(
+    inner: &mut Inner,
+    url: &str,
+    owner_id: &str,
+) -> Result<(), ClaimConflict> {
+    check_exact(inner, url, owner_id)?;
+    inner.entries.push(Entry::Exact {
+        url: url.to_string(),
+        owner: owner_id.to_string(),
+    });
+    Ok(())
+}
+
+fn check_pattern(
+    inner: &Inner,
+    source: &str,
+    compiled: &Regex,
+    _owner_id: &str,
+) -> Result<(), ClaimConflict> {
+    for entry in &inner.entries {
+        match entry {
+            Entry::Pattern {
+                source: existing,
+                owner,
+                ..
+            } if existing == source => {
+                return Err(ClaimConflict::Pattern {
+                    regex: source.to_string(),
+                    owner: owner.clone(),
+                });
+            }
+            Entry::Exact { url, owner } if compiled.is_match(url) => {
+                return Err(ClaimConflict::PatternMatchesExact {
+                    regex: source.to_string(),
+                    url: url.clone(),
+                    owner: owner.clone(),
+                });
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+enum ClaimKey {
+    Exact(String),
+    Pattern(String),
+}
+
+/// RAII handle that releases its claim(s) when dropped.
+pub struct ClaimGuard {
+    registry: Arc<Mutex<Inner>>,
+    keys: Vec<ClaimKey>,
+}
+
+impl Drop for ClaimGuard {
+    fn drop(&mut self) {
+        let mut guard = self
+            .registry
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        guard.entries.retain(|entry| match entry {
+            Entry::Exact { url, .. } => !self
+                .keys
+                .iter()
+                .any(|k| matches!(k, ClaimKey::Exact(claimed) if claimed == url)),
+            Entry::Pattern { source, .. } => !self
+                .keys
+                .iter()
+                .any(|k| matches!(k, ClaimKey::Pattern(claimed) if claimed == source)),
+        });
+    }
+}
+
+impl std::fmt::Debug for ClaimGuard {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClaimGuard")
+            .field("keys", &self.keys)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_page_exact_claim_succeeds_then_blocks_duplicate() {
+        let registry = UrlClaimRegistry::new();
+        let _g = registry
+            .try_claim(
+                &CrawlScope::SinglePage {
+                    url: "https://example.com/a".to_string(),
+                },
+                "child-1",
+            )
+            .expect("first claim should succeed");
+
+        let err = registry
+            .try_claim(
+                &CrawlScope::SinglePage {
+                    url: "https://example.com/a".to_string(),
+                },
+                "child-2",
+            )
+            .expect_err("duplicate claim should fail");
+        assert!(matches!(
+            err,
+            ClaimConflict::ExactUrl { ref url, ref owner }
+                if url == "https://example.com/a" && owner == "child-1"
+        ));
+    }
+
+    #[test]
+    fn dropping_guard_releases_claim() {
+        let registry = UrlClaimRegistry::new();
+        let guard = registry
+            .try_claim(
+                &CrawlScope::SinglePage {
+                    url: "https://example.com/a".to_string(),
+                },
+                "child-1",
+            )
+            .unwrap();
+        drop(guard);
+
+        registry
+            .try_claim(
+                &CrawlScope::SinglePage {
+                    url: "https://example.com/a".to_string(),
+                },
+                "child-2",
+            )
+            .expect("re-claim after drop should succeed");
+    }
+
+    #[test]
+    fn url_list_is_all_or_nothing() {
+        let registry = UrlClaimRegistry::new();
+        let _g1 = registry
+            .try_claim(
+                &CrawlScope::SinglePage {
+                    url: "https://example.com/x".to_string(),
+                },
+                "child-1",
+            )
+            .unwrap();
+        let err = registry
+            .try_claim(
+                &CrawlScope::UrlList {
+                    urls: vec![
+                        "https://example.com/y".to_string(),
+                        "https://example.com/x".to_string(),
+                    ],
+                },
+                "child-2",
+            )
+            .expect_err("UrlList overlap should fail");
+        assert!(matches!(err, ClaimConflict::ExactUrl { .. }));
+        // Verify no partial insertion: y is still claimable.
+        registry
+            .try_claim(
+                &CrawlScope::SinglePage {
+                    url: "https://example.com/y".to_string(),
+                },
+                "child-3",
+            )
+            .expect("y should not have been partially claimed");
+    }
+
+    #[test]
+    fn pattern_conflicts_with_exact_url() {
+        let registry = UrlClaimRegistry::new();
+        let _exact = registry
+            .try_claim(
+                &CrawlScope::SinglePage {
+                    url: "https://example.com/posts/42".to_string(),
+                },
+                "child-1",
+            )
+            .unwrap();
+        let err = registry
+            .try_claim(
+                &CrawlScope::UrlPattern {
+                    regex: r"^https://example\.com/posts/.*".to_string(),
+                },
+                "child-2",
+            )
+            .expect_err("pattern matching claimed exact should fail");
+        assert!(matches!(err, ClaimConflict::PatternMatchesExact { .. }));
+    }
+
+    #[test]
+    fn exact_url_conflicts_with_existing_pattern() {
+        let registry = UrlClaimRegistry::new();
+        let _pat = registry
+            .try_claim(
+                &CrawlScope::UrlPattern {
+                    regex: r"^https://example\.com/posts/.*".to_string(),
+                },
+                "child-1",
+            )
+            .unwrap();
+        let err = registry
+            .try_claim(
+                &CrawlScope::SinglePage {
+                    url: "https://example.com/posts/99".to_string(),
+                },
+                "child-2",
+            )
+            .expect_err("exact URL inside claimed pattern should fail");
+        assert!(matches!(err, ClaimConflict::PatternMatchesExact { .. }));
+    }
+
+    #[test]
+    fn identical_pattern_conflicts() {
+        let registry = UrlClaimRegistry::new();
+        let _p1 = registry
+            .try_claim(
+                &CrawlScope::UrlPattern {
+                    regex: r"^https://example\.com/x/.*".to_string(),
+                },
+                "child-1",
+            )
+            .unwrap();
+        let err = registry
+            .try_claim(
+                &CrawlScope::UrlPattern {
+                    regex: r"^https://example\.com/x/.*".to_string(),
+                },
+                "child-2",
+            )
+            .expect_err("duplicate pattern should fail");
+        assert!(matches!(err, ClaimConflict::Pattern { .. }));
+    }
+
+    #[test]
+    fn invalid_pattern_returns_invalid_regex_conflict() {
+        let registry = UrlClaimRegistry::new();
+        let err = registry
+            .try_claim(
+                &CrawlScope::UrlPattern {
+                    regex: "[broken".to_string(),
+                },
+                "child-1",
+            )
+            .expect_err("invalid regex should fail");
+        assert!(matches!(err, ClaimConflict::InvalidRegex { .. }));
+    }
+
+    #[test]
+    fn racing_claims_only_one_wins() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let registry = Arc::new(UrlClaimRegistry::new());
+        let mut handles = Vec::new();
+        for i in 0..50 {
+            let reg = Arc::clone(&registry);
+            handles.push(thread::spawn(move || {
+                reg.try_claim(
+                    &CrawlScope::SinglePage {
+                        url: "https://example.com/race".to_string(),
+                    },
+                    &format!("child-{i}"),
+                )
+                .ok()
+            }));
+        }
+        // Collect ALL results first so the winning thread's ClaimGuard stays
+        // alive while the late-joining threads finish their own try_claim
+        // calls. Counting + dropping inside a single iterator chain would
+        // free the entry between iterations and let late losers re-claim.
+        let results: Vec<Option<ClaimGuard>> =
+            handles.into_iter().map(|h| h.join().unwrap()).collect();
+        let successes = results.iter().filter(|c| c.is_some()).count();
+        assert_eq!(successes, 1);
+    }
+}

--- a/crates/crawler/src/url_claim.rs
+++ b/crates/crawler/src/url_claim.rs
@@ -124,16 +124,19 @@ impl UrlClaimRegistry {
                 for url in urls {
                     check_exact(&guard, url, owner_id)?;
                 }
-                let keys = urls
-                    .iter()
-                    .map(|url| {
+                // Deduplicate within the submitted list; the LLM may
+                // accidentally list the same URL twice.
+                let mut seen = std::collections::HashSet::new();
+                let mut keys = Vec::new();
+                for url in urls {
+                    if seen.insert(url.as_str()) {
                         guard.entries.push(Entry::Exact {
                             url: url.clone(),
                             owner: owner_id.to_string(),
                         });
-                        ClaimKey::Exact(url.clone())
-                    })
-                    .collect();
+                        keys.push(ClaimKey::Exact(url.clone()));
+                    }
+                }
                 Ok(ClaimGuard {
                     registry: Arc::clone(&self.inner),
                     keys,
@@ -452,6 +455,31 @@ mod tests {
             )
             .expect_err("invalid regex should fail");
         assert!(matches!(err, ClaimConflict::InvalidRegex { .. }));
+    }
+
+    #[test]
+    fn url_list_deduplicates_intra_list_duplicate_urls() {
+        let registry = UrlClaimRegistry::new();
+        let _g = registry
+            .try_claim(
+                &CrawlScope::UrlList {
+                    urls: vec![
+                        "https://example.com/a".to_string(),
+                        "https://example.com/b".to_string(),
+                        "https://example.com/a".to_string(), // duplicate
+                    ],
+                },
+                "child-1",
+            )
+            .expect("claim with intra-list duplicate should succeed (deduped)");
+
+        // Only 2 entries registered, not 3.
+        assert_eq!(registry.len(), 2);
+
+        // The deduplicated URL is still claimable by another child after the
+        // guard drops (this verifies len() tracked correctly).
+        drop(_g);
+        assert_eq!(registry.len(), 0);
     }
 
     #[test]

--- a/crates/runtime/src/settings.rs
+++ b/crates/runtime/src/settings.rs
@@ -551,7 +551,7 @@ mod tests {
         assert_eq!(settings.max_concurrent_per_parent, Some(5));
         assert_eq!(settings.max_fork_depth, Some(3));
         assert_eq!(settings.max_total_agents, Some(10));
-        assert_eq!(settings.fork_child_max_steps, Some(15));
+        assert_eq!(settings.fork_child_max_steps, Some(100));
         assert_eq!(settings.fork_wait_timeout_secs, Some(60));
     }
 
@@ -644,7 +644,7 @@ mod tests {
         assert_eq!(settings_get_max_concurrent_per_parent(&settings), 5);
         assert_eq!(settings_get_max_fork_depth(&settings), 3);
         assert_eq!(settings_get_max_total_agents(&settings), 10);
-        assert_eq!(settings_get_fork_child_max_steps(&settings), 15);
+        assert_eq!(settings_get_fork_child_max_steps(&settings), 100);
         assert_eq!(settings_get_fork_wait_timeout_secs(&settings), 60);
     }
 

--- a/crates/runtime/src/settings.rs
+++ b/crates/runtime/src/settings.rs
@@ -43,7 +43,7 @@ pub struct Settings {
     #[serde(default)]
     pub max_total_agents: Option<u32>,
 
-    /// Max steps for forked child agents (default: 15)
+    /// Max steps for forked child agents (default: 100)
     #[serde(default)]
     pub fork_child_max_steps: Option<u32>,
 
@@ -88,7 +88,7 @@ impl Default for Settings {
             max_concurrent_per_parent: Some(5),
             max_fork_depth: Some(3),
             max_total_agents: Some(10),
-            fork_child_max_steps: Some(15),
+            fork_child_max_steps: Some(100),
             fork_wait_timeout_secs: Some(60),
             compaction_prune_protect_tokens: None,
             compaction_prune_max_output_chars: None,
@@ -209,7 +209,7 @@ pub fn settings_get_max_total_agents(s: &Settings) -> u32 {
 /// Get `fork_child_max_steps` setting, with default fallback.
 #[must_use]
 pub fn settings_get_fork_child_max_steps(s: &Settings) -> u32 {
-    s.fork_child_max_steps.unwrap_or(15)
+    s.fork_child_max_steps.unwrap_or(100)
 }
 
 /// Get `fork_wait_timeout_secs` setting, with default fallback.


### PR DESCRIPTION
## Summary

- **`cancel_subagent` tool**: parent agent can abortively cancel named children; wait timeout no longer aborts children (non-destructive by default)
- **`subagent_status` tool**: read-only poll of per-child progress snapshots between steps — no join, no cancel
- **Typed `CrawlTask` + `UrlClaimRegistry`**: forks now carry a structured scope (`single_page`, `url_list`, `url_pattern`); the registry atomically prevents siblings from claiming overlapping URLs, with RAII `ClaimGuard` releasing claims on child exit
- **TUI**: parent sub-goal rendered as an inline styled prefix in the child panel
- **Step budget**: fork child default bumped from 15 → 100 steps

Post-review fixes:
- Failing test assertions updated to match the new default (15 → 100)
- Removed unimplemented `deadline_secs` / `success_criteria` fields advertised in schema but never consumed
- `UrlList` intra-list duplicate URLs are now silently deduplicated before insertion
- Comments clarified: grandchild snapshot visibility is one level deep; `ChildSnapshotRegistry` growth documented; pattern-overlap footgun surfaced in fork tool instructions

## Test plan

- [x] `cargo test -p crawler -p runtime -p acrawl-cli` — 717 tests, 0 failures
- [x] Fork two subagents on the same URL — verify second is rejected with the first child's ID in the error
- [x] `cancel_subagent` with a running child — verify handle aborted, URL claim released, `Finished` event emitted
- [x] `subagent_status` mid-run — verify snapshot fields (`state`, `step`, `last_tool`, `last_event_secs_ago`) populate correctly
- [x] `url_list` with a duplicate URL — verify only one registry entry registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)