### PR TITLE
feat(mcp): add mcp uninstall command and fix install override behavior

### DIFF
--- a/crates/acrawl-cli/src/main.rs
+++ b/crates/acrawl-cli/src/main.rs
@@ -103,6 +103,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         CliAction::InstallBrowser => install_browser()?,
         CliAction::Mcp => mcp_server::run(),
         CliAction::McpInstall => mcp_install::run()?,
+        CliAction::McpUninstall => mcp_install::run_uninstall()?,
         CliAction::Repl {
             model,
             allowed_tools,
@@ -141,6 +142,7 @@ enum CliAction {
     InstallBrowser,
     Mcp,
     McpInstall,
+    McpUninstall,
     Repl {
         model: Option<String>,
         allowed_tools: Option<AllowedToolSet>,
@@ -297,10 +299,12 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
         "mcp" => match rest.get(1).map(String::as_str) {
             None => Ok(CliAction::Mcp),
             Some("install") if rest.len() == 2 => Ok(CliAction::McpInstall),
+            Some("uninstall") if rest.len() == 2 => Ok(CliAction::McpUninstall),
             Some("--help" | "-h" | "help") if rest.len() == 2 => Ok(CliAction::Help),
             Some("install") => Err("`acrawl mcp install` does not accept extra arguments".to_string()),
+            Some("uninstall") => Err("`acrawl mcp uninstall` does not accept extra arguments".to_string()),
             Some(other) => Err(format!(
-                "unknown mcp subcommand: {other} (supported: install)"
+                "unknown mcp subcommand: {other} (supported: install, uninstall)"
             )),
         },
         "prompt" => {
@@ -658,6 +662,8 @@ fn print_help_to(out: &mut impl Write) -> io::Result<()> {
     writeln!(out, "      Start the built-in MCP server over stdio")?;
     writeln!(out, "  acrawl mcp install")?;
     writeln!(out, "      Configure supported IDEs to launch `acrawl mcp`")?;
+    writeln!(out, "  acrawl mcp uninstall")?;
+    writeln!(out, "      Remove acrawl from IDE MCP configurations")?;
     writeln!(out, "  acrawl install-browser")?;
     writeln!(
         out,

--- a/crates/acrawl-cli/src/mcp_install.rs
+++ b/crates/acrawl-cli/src/mcp_install.rs
@@ -228,31 +228,15 @@ fn merge_json_config(
 
 fn install_claude_code_global(acrawl_path: &str) -> io::Result<String> {
     if command_exists("claude") {
+        // Always remove first (ignore errors — may not exist) to guarantee override.
+        let _ = Command::new("claude")
+            .args(["mcp", "remove", "acrawl"])
+            .output();
         let status = Command::new("claude")
             .args(["mcp", "add", "acrawl", "--", acrawl_path, "mcp"])
             .status()?;
         if status.success() {
             return Ok("configured via `claude mcp add`".to_string());
-        }
-        match Command::new("claude")
-            .args(["mcp", "remove", "acrawl"])
-            .status()
-        {
-            Ok(s) if !s.success() => {
-                eprintln!("note: `claude mcp remove acrawl` exited with {s} — retrying add anyway");
-            }
-            Err(e) => {
-                eprintln!(
-                    "note: `claude mcp remove acrawl` failed to run: {e} — retrying add anyway"
-                );
-            }
-            Ok(_) => {}
-        }
-        let retry = Command::new("claude")
-            .args(["mcp", "add", "acrawl", "--", acrawl_path, "mcp"])
-            .status()?;
-        if retry.success() {
-            return Ok("updated via `claude mcp add` (replaced existing)".to_string());
         }
     }
     let home = home_dir()
@@ -360,6 +344,177 @@ fn install_for_ide(ide: Ide, scope: Scope, acrawl_path: &str) -> io::Result<Stri
         Ide::VsCode => install_vscode(acrawl_path, scope),
         Ide::OpenCode => install_opencode(acrawl_path, scope),
     }
+}
+
+fn remove_json_config(path: &Path, root_key: &str, server_name: &str) -> io::Result<bool> {
+    if !path.exists() {
+        return Ok(false);
+    }
+    let content = fs::read_to_string(path)?;
+    let existing: Value = serde_json::from_str(&content).unwrap_or_else(|_| json!({}));
+    let mut doc = existing.as_object().cloned().unwrap_or_default();
+
+    let removed = doc
+        .get_mut(root_key)
+        .and_then(|v| v.as_object_mut())
+        .map(|servers| servers.remove(server_name).is_some())
+        .unwrap_or(false);
+
+    if removed {
+        let formatted =
+            serde_json::to_string_pretty(&Value::Object(doc)).map_err(io::Error::other)?;
+        fs::write(path, formatted.as_bytes())?;
+    }
+
+    Ok(removed)
+}
+
+fn uninstall_claude_code_global() -> io::Result<String> {
+    if command_exists("claude") {
+        let status = Command::new("claude")
+            .args(["mcp", "remove", "acrawl"])
+            .status()?;
+        if status.success() {
+            return Ok("removed via `claude mcp remove`".to_string());
+        }
+    }
+    let home = home_dir()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "cannot determine home dir"))?;
+    let config_path = home.join(".claude.json");
+    if remove_json_config(&config_path, "mcpServers", "acrawl")? {
+        Ok(format!("removed from {}", config_path.display()))
+    } else {
+        Ok(format!("not found in {}", config_path.display()))
+    }
+}
+
+fn uninstall_claude_code_project() -> io::Result<String> {
+    let config_path = PathBuf::from(".mcp.json");
+    if remove_json_config(&config_path, "mcpServers", "acrawl")? {
+        Ok(format!("removed from {}", config_path.display()))
+    } else {
+        Ok(format!("not found in {}", config_path.display()))
+    }
+}
+
+fn uninstall_cursor(scope: Scope) -> io::Result<String> {
+    let config_path = match scope {
+        Scope::Global => {
+            let home = home_dir().ok_or_else(|| {
+                io::Error::new(io::ErrorKind::NotFound, "cannot determine home dir")
+            })?;
+            home.join(".cursor").join("mcp.json")
+        }
+        Scope::Project => PathBuf::from(".cursor").join("mcp.json"),
+    };
+    if remove_json_config(&config_path, "mcpServers", "acrawl")? {
+        Ok(format!("removed from {}", config_path.display()))
+    } else {
+        Ok(format!("not found in {}", config_path.display()))
+    }
+}
+
+fn uninstall_windsurf() -> io::Result<String> {
+    let home = home_dir()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "cannot determine home dir"))?;
+    let config_path = home
+        .join(".codeium")
+        .join("windsurf")
+        .join("mcp_config.json");
+    if remove_json_config(&config_path, "mcpServers", "acrawl")? {
+        Ok(format!("removed from {}", config_path.display()))
+    } else {
+        Ok(format!("not found in {}", config_path.display()))
+    }
+}
+
+fn uninstall_vscode(scope: Scope) -> io::Result<String> {
+    let config_path = match scope {
+        Scope::Global => {
+            let home = home_dir().ok_or_else(|| {
+                io::Error::new(io::ErrorKind::NotFound, "cannot determine home dir")
+            })?;
+            home.join(".vscode").join("mcp.json")
+        }
+        Scope::Project => PathBuf::from(".vscode").join("mcp.json"),
+    };
+    if remove_json_config(&config_path, "servers", "acrawl")? {
+        Ok(format!("removed from {}", config_path.display()))
+    } else {
+        Ok(format!("not found in {}", config_path.display()))
+    }
+}
+
+fn uninstall_opencode(scope: Scope) -> io::Result<String> {
+    let config_path = match scope {
+        Scope::Global => global_opencode_config_path(),
+        Scope::Project => PathBuf::from("opencode.json"),
+    };
+    if remove_json_config(&config_path, "mcp", "acrawl")? {
+        Ok(format!("removed from {}", config_path.display()))
+    } else {
+        Ok(format!("not found in {}", config_path.display()))
+    }
+}
+
+fn uninstall_for_ide(ide: Ide, scope: Scope) -> io::Result<String> {
+    match ide {
+        Ide::ClaudeCode => match scope {
+            Scope::Global => uninstall_claude_code_global(),
+            Scope::Project => uninstall_claude_code_project(),
+        },
+        Ide::Cursor => uninstall_cursor(scope),
+        Ide::Windsurf => uninstall_windsurf(),
+        Ide::VsCode => uninstall_vscode(scope),
+        Ide::OpenCode => uninstall_opencode(scope),
+    }
+}
+
+pub fn run_uninstall() -> Result<(), Box<dyn std::error::Error>> {
+    let detected = detect_ides();
+
+    if detected.is_empty() {
+        eprintln!("No supported IDEs detected on this system.");
+        eprintln!("Supported: Claude Code, Cursor, Windsurf, VS Code, OpenCode");
+        eprintln!("\nYou can still select IDEs to unconfigure manually.");
+    }
+
+    let selected = prompt_ide_selection(&detected)?;
+    if selected.is_empty() {
+        eprintln!("No IDEs selected. Nothing to do.");
+        return Ok(());
+    }
+
+    let scope = prompt_scope()?;
+
+    eprintln!("\nRemoving acrawl MCP server configuration...\n");
+
+    let mut success_count = 0u32;
+    for ide in &selected {
+        if scope == Scope::Project && !ide.supports_project_scope() {
+            eprintln!("  ⚠ {} — skipped (global config only)", ide.name());
+            continue;
+        }
+        match uninstall_for_ide(*ide, scope) {
+            Ok(detail) => {
+                eprintln!("  ✓ {} — {detail}", ide.name());
+                success_count += 1;
+            }
+            Err(e) => {
+                eprintln!("  ✗ {} — error: {e}", ide.name());
+            }
+        }
+    }
+
+    if success_count > 0 {
+        eprintln!(
+            "\nDone. acrawl MCP server removed from {success_count} IDE{}.",
+            if success_count == 1 { "" } else { "s" }
+        );
+    } else {
+        eprintln!("\nNo configurations were removed.");
+    }
+    Ok(())
 }
 
 pub fn run() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/acrawl-cli/src/mcp_install.rs
+++ b/crates/acrawl-cli/src/mcp_install.rs
@@ -357,8 +357,7 @@ fn remove_json_config(path: &Path, root_key: &str, server_name: &str) -> io::Res
     let removed = doc
         .get_mut(root_key)
         .and_then(|v| v.as_object_mut())
-        .map(|servers| servers.remove(server_name).is_some())
-        .unwrap_or(false);
+        .is_some_and(|servers| servers.remove(server_name).is_some());
 
     if removed {
         let formatted =

--- a/crates/acrawl-cli/src/mcp_server.rs
+++ b/crates/acrawl-cli/src/mcp_server.rs
@@ -841,7 +841,7 @@ fn handle_tools_call(
         match rt.block_on(PlaywrightBridge::new()) {
             Ok(bridge) => {
                 let shared = std::sync::Arc::new(tokio::sync::Mutex::new(
-                    Box::new(bridge) as Box<dyn BrowserBackend + Send>,
+                    Box::new(bridge) as Box<dyn BrowserBackend + Send>
                 ));
                 *browser = Some(BrowserContext::new(shared));
             }


### PR DESCRIPTION
## Summary

- **`mcp install` always overrides**: Previously, `acrawl mcp install` relied on `claude mcp add` failing before it would remove-and-retry. Now it always silently removes the existing entry first, guaranteeing the new binary path replaces any stale config on re-install.
- **New `acrawl mcp uninstall` command**: Mirrors the install UX — detect IDEs, multi-select which to unconfigure, choose scope (global/project), then remove the `acrawl` entry from each config file. Uses `claude mcp remove` for Claude Code; direct JSON key removal for all other IDEs while preserving other servers.

## Test plan

- [x] `cargo test -p acrawl-cli` — all 268 tests pass
- [x] Run `acrawl mcp install` twice; verify second run updates the config (no stale path)
- [x] Run `acrawl mcp uninstall`; verify the `acrawl` key is removed from the relevant config file while other MCP servers are preserved
- [x] Run `acrawl --help`; verify `mcp uninstall` appears in usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)