### PR TITLE
perf(tui): make input rendering O(1) allocations for large text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ opencode/
 .graphify_*
 graphify-out/
 crates/graphify-out/
+
+# Superpowers specs (local, not committed)
+docs/superpowers/

--- a/crates/acrawl-cli/src/mcp_install.rs
+++ b/crates/acrawl-cli/src/mcp_install.rs
@@ -228,6 +228,11 @@ fn merge_json_config(
 
 fn install_claude_code_global(acrawl_path: &str) -> io::Result<String> {
     if command_exists("claude") {
+        // Try `add` first (idempotent on first install).  If it fails — e.g.
+        // because an existing entry with a different path is registered — fall
+        // back to remove-then-add so upgrades stay idempotent.  The standalone
+        // `acrawl mcp uninstall` subcommand was removed; users should use the
+        // IDE's native MCP management UI to remove the server.
         let status = Command::new("claude")
             .args(["mcp", "add", "acrawl", "--", acrawl_path, "mcp"])
             .status()?;

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -64,43 +64,6 @@ fn read_clipboard_text() -> Option<String> {
     Some(normalize_pasted_text(&text))
 }
 
-/// Mask any paste at or above this byte length.
-const PASTE_MASK_THRESHOLD_BYTES: usize = 150;
-
-/// Count logical lines in `text` by physical newline count plus one.  O(n) byte
-/// scan, no UTF-8 decoding — `\n` is ASCII so this is safe on any UTF-8 string.
-fn count_lines(text: &str) -> usize {
-    text.bytes().filter(|&b| b == b'\n').count() + 1
-}
-
-/// Whether a paste should be replaced by a placeholder mask.
-/// Inclusive at the threshold: returns true when `text.len() >= PASTE_MASK_THRESHOLD_BYTES`.
-fn should_mask_paste(text: &str) -> bool {
-    text.len() >= PASTE_MASK_THRESHOLD_BYTES
-}
-
-/// Format the visible placeholder for a masked paste.
-fn format_paste_placeholder(id: u32, line_count: usize) -> String {
-    format!("[#{id} Pasted ~{line_count} lines]")
-}
-
-/// Replace each paste mask's placeholder with its original content.  Used at
-/// submit time so the model receives the full pasted text, and at clipboard
-/// yank time so copying the input bar produces the original content.
-///
-/// Known limitation: if the user manually types text that exactly matches a
-/// live placeholder (e.g. `[#1 Pasted ~5 lines]` character-for-character), that
-/// typed text will also be replaced with the paste content.  This is rare in
-/// practice — the per-prompt `#N` index and the specific bracket+tilde format
-/// make accidental collisions unlikely.
-fn expand_masks(text: &str, pastes: &[PasteEntry]) -> String {
-    let mut out = text.to_string();
-    for p in pastes {
-        out = out.replace(&p.placeholder, &p.content);
-    }
-    out
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum AppUiState {
     WelcomeMode,
@@ -202,11 +165,6 @@ struct InputEditorState {
     /// when the cursor is set directly (clamp / `set_line_col`).
     byte_cursor: usize,
     preferred_col: Option<usize>,
-    /// Active paste masks, in insertion order.  Empty when no pastes are masked.
-    pastes: Vec<PasteEntry>,
-    /// Monotonically increases as masks are inserted within one prompt; reset to
-    /// 1 on submit, clear, or new-prompt boundary.
-    next_paste_id: u32,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -215,19 +173,6 @@ struct InputUndoSnapshot {
     cursor: usize,
     preferred_col: Option<usize>,
     selection: Option<(usize, usize)>,
-    pastes: Vec<PasteEntry>,
-    next_paste_id: u32,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct PasteEntry {
-    /// 1-based, per-prompt index. Resets to 1 on submit / clear.
-    id: u32,
-    /// Visible placeholder, e.g. "[#1 Pasted ~42 lines]".
-    /// Uniqueness is guaranteed by `id`, so `text.find(&placeholder)` is safe.
-    placeholder: String,
-    /// Original pasted content (after newline normalisation).
-    content: String,
 }
 
 #[derive(Default)]
@@ -336,8 +281,6 @@ impl ReplTuiState {
                 cursor: 0,
                 byte_cursor: 0,
                 preferred_col: None,
-                pastes: Vec::new(),
-                next_paste_id: 1,
             },
             status_line: String::new(),
             busy: false,
@@ -469,8 +412,6 @@ impl ReplTuiState {
             cursor: self.input.cursor,
             preferred_col: self.input.preferred_col,
             selection: self.input_selection,
-            pastes: self.input.pastes.clone(),
-            next_paste_id: self.input.next_paste_id,
         }
     }
 
@@ -481,8 +422,6 @@ impl ReplTuiState {
         self.input.preferred_col = snapshot.preferred_col;
         self.input_selection = snapshot.selection;
         self.input_click_anchor = None;
-        self.input.pastes = snapshot.pastes;
-        self.input.next_paste_id = snapshot.next_paste_id;
         self.resync_byte_cursor();
         self.input_scroll_offset = usize::MAX;
     }
@@ -505,21 +444,14 @@ impl ReplTuiState {
         self.input_redo_stack.clear();
     }
 
-    /// Reset all input editor fields atomically. Ensures `text`, cursors,
-    /// `pastes`, and `next_paste_id` always move together so no stale mask
-    /// entries survive a prompt boundary.
     fn reset_input(&mut self) {
         self.input.text.clear();
         self.input.cursor = 0;
         self.input.byte_cursor = 0;
         self.input.preferred_col = None;
-        self.input.pastes.clear();
-        self.input.next_paste_id = 1;
     }
 
-    /// Ctrl-W: delete backward to the previous word boundary, treating each
-    /// paste mask as a single atomic unit (stops at the mask boundary rather
-    /// than scanning inside it).
+    /// Ctrl-W: delete backward to the previous word boundary.
     fn word_backspace(&mut self) {
         self.input_scroll_manual = false;
         self.clamp_input_cursor();
@@ -530,30 +462,6 @@ impl ReplTuiState {
         if self.delete_selection_range() {
             return;
         }
-        let ranges = self.compute_mask_ranges();
-        // Cursor at a mask's end → delete the whole mask atom (same as backspace).
-        if let Some((idx, r)) = ranges
-            .iter()
-            .find(|(_, r)| r.end == self.input.byte_cursor)
-            .map(|(i, r)| (*i, r.clone()))
-        {
-            let del_end = if self.input.text.len() > r.end
-                && self.input.text.as_bytes()[r.end] == b' '
-            {
-                r.end + 1
-            } else {
-                r.end
-            };
-            self.input.text.replace_range(r.start..del_end, "");
-            self.input.pastes.remove(idx);
-            self.input.byte_cursor = r.start;
-            self.input.cursor = self.input.text[..r.start].chars().count();
-            self.input.preferred_col = None;
-            self.input_scroll_offset = usize::MAX;
-            return;
-        }
-        // Walk backward: skip trailing whitespace, then skip word chars.
-        // Stop at any mask-end boundary so masks are deleted atomically.
         let bc = self.input.byte_cursor;
         let chars_before: Vec<(usize, char)> = self.input.text[..bc].char_indices().collect();
         let mut i = chars_before.len();
@@ -561,16 +469,17 @@ impl ReplTuiState {
             i -= 1;
         }
         while i > 0 {
-            let (byte_pos, ch) = chars_before[i - 1];
+            let (_, ch) = chars_before[i - 1];
             if ch.is_whitespace() {
-                break;
-            }
-            if ranges.iter().any(|(_, r)| r.end == byte_pos) {
                 break;
             }
             i -= 1;
         }
-        let del_start = if i < chars_before.len() { chars_before[i].0 } else { bc };
+        let del_start = if i < chars_before.len() {
+            chars_before[i].0
+        } else {
+            bc
+        };
         if del_start == bc {
             return;
         }
@@ -660,16 +569,12 @@ impl ReplTuiState {
         self.input.text.get(sel_start..sel_end)
     }
 
-    /// Returns the currently selected input slice with paste masks expanded back
-    /// to their original content.  Used by clipboard copy/cut so the OS clipboard
-    /// receives real text, not the placeholder.
-    fn selected_input_text_expanded(&self) -> Option<String> {
-        let raw = self.selected_input_text()?.to_string();
-        Some(expand_masks(&raw, &self.input.pastes))
+    fn selected_input_text_string(&self) -> Option<String> {
+        Some(self.selected_input_text()?.to_string())
     }
 
     fn cut_input_selection_text(&mut self) -> Option<String> {
-        let text = self.selected_input_text_expanded()?;
+        let text = self.selected_input_text_string()?;
         self.record_input_undo_snapshot();
         self.delete_selection_range();
         Some(text)
@@ -703,60 +608,9 @@ impl ReplTuiState {
         self.input_scroll_offset = usize::MAX;
     }
 
-    /// Insert a paste as an atomic masked token.
-    ///
-    /// The pasted text has already been normalised by the caller.  This method:
-    ///   1. Records an undo snapshot.
-    ///   2. Generates a `[#N Pasted ~K lines]` placeholder and appends a trailing
-    ///      space so subsequent typing doesn't visually fuse with the mask.
-    ///   3. Stores the original content in `pastes` for later expansion on submit
-    ///      or clipboard yank.
-    fn insert_paste_mask(&mut self, raw: &str) {
-        self.input_scroll_manual = false;
-        if raw.is_empty() {
-            return;
-        }
-        self.record_input_undo_snapshot();
-        self.delete_selection_range();
-        self.clamp_input_cursor();
-
-        // Edge case: if cursor is strictly inside any existing mask, snap to the
-        // nearer boundary before inserting.  Prevents the placeholder from being
-        // inserted mid-placeholder which would break later text.find lookups for
-        // the first mask.
-        let ranges = self.compute_mask_ranges();
-        if let Some(r) = Self::mask_containing(self.input.byte_cursor, &ranges) {
-            let snap_to = if self.input.byte_cursor - r.start < r.end - self.input.byte_cursor {
-                r.start
-            } else {
-                r.end
-            };
-            self.input.byte_cursor = snap_to;
-            self.input.cursor = self.input.text[..snap_to].chars().count();
-        }
-
-        let id = self.input.next_paste_id;
-        self.input.next_paste_id += 1;
-        let placeholder = format_paste_placeholder(id, count_lines(raw));
-        let to_insert = format!("{placeholder} ");
-
-        self.input.text.insert_str(self.input.byte_cursor, &to_insert);
-        let char_count = to_insert.chars().count();
-        self.input.cursor = self.input.cursor.saturating_add(char_count);
-        self.input.byte_cursor = self.input.byte_cursor.saturating_add(to_insert.len());
-        self.input.preferred_col = None;
-        self.input_scroll_offset = usize::MAX;
-
-        self.input.pastes.push(PasteEntry {
-            id,
-            placeholder,
-            content: raw.to_string(),
-        });
-    }
-
     /// Single entry point for any pasted text, regardless of source (bracketed
     /// paste, Ctrl+V, Shift+Insert, burst flush).  Normalises newlines and
-    /// either masks the paste (>= threshold) or inserts it raw.
+    /// inserts the result directly into the input.
     ///
     /// Note: this does NOT set `suppress_paste_until` — that suppression is
     /// only appropriate for the bracketed-paste / Ctrl+V paths (where stray
@@ -766,11 +620,7 @@ impl ReplTuiState {
     /// Callers that need post-paste suppression set it themselves.
     fn handle_paste_event(&mut self, raw: &str) {
         let normalised = normalize_pasted_text(raw);
-        if should_mask_paste(&normalised) {
-            self.insert_paste_mask(&normalised);
-        } else {
-            self.insert_input_str(&normalised);
-        }
+        self.insert_input_str(&normalised);
     }
 
     /// Arm the post-paste suppression window used by the bracketed-paste and
@@ -778,8 +628,7 @@ impl ReplTuiState {
     /// for each `\n` in a paste are discarded for the next 100 ms so they
     /// don't trigger an accidental send.
     fn arm_paste_enter_suppression(&mut self) {
-        self.selection.suppress_paste_until =
-            Some(Instant::now() + Duration::from_millis(100));
+        self.selection.suppress_paste_until = Some(Instant::now() + Duration::from_millis(100));
     }
 
     /// Maximum gap (ms) between consecutive keystrokes considered a paste burst.
@@ -795,7 +644,7 @@ impl ReplTuiState {
     }
 
     /// If the burst accumulator has any chars, drain it into the input via
-    /// `handle_paste_event` (which applies masking and newline suppression).
+    /// `handle_paste_event`.
     /// Called when the burst ends, or before any non-burst-compatible key.
     fn flush_paste_burst(&mut self) {
         if self.paste_burst_chars.is_empty() {
@@ -819,70 +668,6 @@ impl ReplTuiState {
             )
     }
 
-    /// Locate every active paste mask's current byte range in `self.input.text`.
-    ///
-    /// Returns `(paste_index, byte_range)` pairs sorted by `byte_range.start`.
-    /// Because placeholders include a unique per-prompt `#N` index, `str::find`
-    /// returns at most one position per placeholder; no overlap handling needed.
-    /// Orphaned entries (placeholder absent from text) are silently skipped.
-    fn compute_mask_ranges(&self) -> Vec<(usize, std::ops::Range<usize>)> {
-        let mut out: Vec<(usize, std::ops::Range<usize>)> = self
-            .input
-            .pastes
-            .iter()
-            .enumerate()
-            .filter_map(|(i, p)| {
-                self.input
-                    .text
-                    .find(&p.placeholder)
-                    .map(|s| (i, s..s + p.placeholder.len()))
-            })
-            .collect();
-        out.sort_by_key(|(_, r)| r.start);
-        out
-    }
-
-    /// Returns mask ranges in CHAR-index space.  Used by the input renderer to
-    /// style placeholder text (`[#N Pasted ~K lines]`) with a meta-token
-    /// modifier (dim + italic) so it visually reads as a token rather than
-    /// user-typed content.  Sorted by `start` (matches `compute_mask_ranges`).
-    fn compute_mask_char_ranges(&self) -> Vec<(usize, usize)> {
-        let byte_ranges = self.compute_mask_ranges();
-        if byte_ranges.is_empty() {
-            return Vec::new();
-        }
-        // Build a sorted (byte_offset, char_index) table in one pass; then use
-        // binary search per range — O(n) build, O(log n) per lookup.
-        let text = &self.input.text;
-        let mut byte_to_char: Vec<(usize, usize)> =
-            text.char_indices().enumerate().map(|(ci, (bi, _))| (bi, ci)).collect();
-        let total_chars = byte_to_char.len();
-        byte_to_char.push((text.len(), total_chars));
-
-        let lookup = |byte_pos: usize| -> usize {
-            let idx = byte_to_char.partition_point(|(bi, _)| *bi < byte_pos);
-            byte_to_char.get(idx).map_or(total_chars, |(_, ci)| *ci)
-        };
-
-        byte_ranges
-            .iter()
-            .map(|(_, r)| (lookup(r.start), lookup(r.end)))
-            .collect()
-    }
-
-    /// Returns the mask range that strictly contains `byte_pos`, or `None` if the
-    /// position is at a boundary or outside any mask.  Boundaries are valid cursor
-    /// positions; only interior positions need to be snapped.
-    fn mask_containing(
-        byte_pos: usize,
-        ranges: &[(usize, std::ops::Range<usize>)],
-    ) -> Option<std::ops::Range<usize>> {
-        ranges
-            .iter()
-            .find(|(_, r)| byte_pos > r.start && byte_pos < r.end)
-            .map(|(_, r)| r.clone())
-    }
-
     fn backspace_input_char(&mut self) {
         self.input_scroll_manual = false;
         let had_selection = self.input_selection.is_some();
@@ -894,31 +679,6 @@ impl ReplTuiState {
         // If selection is active, delete it instead of a single char.
         if self.delete_selection_range() {
             return;
-        }
-        // Atomic-mask deletion: cursor at a mask's end byte -> drop whole mask
-        // plus its trailing separator space.
-        if !had_selection {
-            let ranges = self.compute_mask_ranges();
-            if let Some((idx, r)) = ranges
-                .iter()
-                .find(|(_, r)| r.end == self.input.byte_cursor)
-                .map(|(i, r)| (*i, r.clone()))
-            {
-                let del_end = if self.input.text.len() > r.end
-                    && self.input.text.as_bytes()[r.end] == b' '
-                {
-                    r.end + 1
-                } else {
-                    r.end
-                };
-                self.input.text.replace_range(r.start..del_end, "");
-                self.input.pastes.remove(idx);
-                self.input.byte_cursor = r.start;
-                self.input.cursor = self.input.text[..r.start].chars().count();
-                self.input.preferred_col = None;
-                self.input_scroll_offset = usize::MAX;
-                return;
-            }
         }
         // Find byte-offset of the character before cursor
         let prev_byte = if self.input.byte_cursor > 0 {
@@ -943,38 +703,13 @@ impl ReplTuiState {
 
     fn delete_input_char(&mut self) {
         self.input_scroll_manual = false;
-        let had_selection = self.input_selection.is_some();
         self.clamp_input_cursor();
-        if !had_selection && self.input.cursor >= self.input_char_len() {
+        if self.input_selection.is_none() && self.input.cursor >= self.input_char_len() {
             return;
         }
         self.record_input_undo_snapshot();
         if self.delete_selection_range() {
             return;
-        }
-        // Atomic-mask deletion: cursor at a mask's start byte -> drop whole mask
-        // plus its trailing separator space.
-        if !had_selection {
-            let ranges = self.compute_mask_ranges();
-            if let Some((idx, r)) = ranges
-                .iter()
-                .find(|(_, r)| r.start == self.input.byte_cursor)
-                .map(|(i, r)| (*i, r.clone()))
-            {
-                let del_end = if self.input.text.len() > r.end
-                    && self.input.text.as_bytes()[r.end] == b' '
-                {
-                    r.end + 1
-                } else {
-                    r.end
-                };
-                self.input.text.replace_range(r.start..del_end, "");
-                self.input.pastes.remove(idx);
-                // byte_cursor stays at r.start; char cursor stays the same.
-                self.input.preferred_col = None;
-                self.input_scroll_offset = usize::MAX;
-                return;
-            }
         }
         // Find byte-offset of the character after cursor
         let bytes = self.input.text.as_bytes();
@@ -1042,12 +777,6 @@ impl ReplTuiState {
         self.input.cursor -= 1;
         self.input.preferred_col = None;
         self.input_scroll_offset = usize::MAX;
-        // Atomic-mask snap: if we landed strictly inside any mask, jump to its start.
-        let ranges = self.compute_mask_ranges();
-        if let Some(r) = Self::mask_containing(self.input.byte_cursor, &ranges) {
-            self.input.byte_cursor = r.start;
-            self.input.cursor = self.input.text[..r.start].chars().count();
-        }
     }
 
     fn move_input_cursor_right(&mut self) {
@@ -1067,12 +796,6 @@ impl ReplTuiState {
         self.input.cursor += 1;
         self.input.preferred_col = None;
         self.input_scroll_offset = usize::MAX;
-        // Atomic-mask snap: if we landed strictly inside any mask, jump to its end.
-        let ranges = self.compute_mask_ranges();
-        if let Some(r) = Self::mask_containing(self.input.byte_cursor, &ranges) {
-            self.input.byte_cursor = r.end;
-            self.input.cursor = self.input.text[..r.end].chars().count();
-        }
     }
 
     fn move_input_cursor_home(&mut self) {
@@ -1119,63 +842,171 @@ impl ReplTuiState {
     /// Callers use `starts_paragraph` instead of re-scanning the text with
     /// `chars().nth()` to check for a trailing `\n` at a line boundary.
     fn visual_line_info(&self, safe_width: usize) -> Vec<(usize, usize, bool)> {
+        self.visual_line_info_capped(safe_width, usize::MAX)
+    }
+
+    fn visual_line_info_capped(
+        &self,
+        safe_width: usize,
+        max_lines: usize,
+    ) -> Vec<(usize, usize, bool)> {
+        if max_lines == 0 {
+            return Vec::new();
+        }
+
         let mut lines = Vec::new();
         let mut char_idx = 0usize;
-        let parts: Vec<&str> = self.input.text.split('\n').collect();
-        for (logical_idx, logical_line) in parts.iter().enumerate() {
-            let logical_chars: Vec<char> = logical_line.chars().collect();
+        let mut parts = self.input.text.split('\n').peekable();
+        let mut logical_idx = 0usize;
+        while let Some(logical_line) = parts.next() {
+            let has_more = parts.peek().is_some();
             let prompt_offset = if logical_idx == 0 { 2usize } else { 0 };
             let first_cap = safe_width.saturating_sub(prompt_offset);
-            let cap = safe_width;
-            let mut offset = 0usize;
-            loop {
-                let remaining = logical_chars.len().saturating_sub(offset);
-                if remaining == 0 {
-                    if offset == 0 {
-                        // First visual line of a new paragraph starts after \n
-                        // (except the very first logical line which has no preceding \n).
-                        lines.push((char_idx, 0, logical_idx > 0));
-                    }
-                    break;
+            let mut line_start = char_idx;
+            let mut col = 0usize;
+            let mut is_first_chunk = true;
+            let mut has_chars = false;
+
+            if logical_line.is_empty() {
+                lines.push((char_idx, 0, logical_idx > 0));
+                if lines.len() >= max_lines {
+                    return lines;
                 }
-                let w = if offset == 0 { first_cap } else { cap };
-                // Walk forward up to `w` display cells
-                let mut col = 0usize;
-                let mut end = offset;
-                while end < logical_chars.len() {
-                    let cw = char_display_width(logical_chars[end]);
-                    if col + cw > w {
-                        break;
+            } else {
+                for ch in logical_line.chars() {
+                    let target = if is_first_chunk {
+                        first_cap
+                    } else {
+                        safe_width
+                    };
+                    let cw = char_display_width(ch);
+                    if has_chars && col + cw > target {
+                        lines.push((line_start, col, is_first_chunk && logical_idx > 0));
+                        if lines.len() >= max_lines {
+                            return lines;
+                        }
+                        line_start = char_idx;
+                        col = 0;
+                        is_first_chunk = false;
                     }
+
                     col += cw;
-                    end += 1;
+                    char_idx += 1;
+                    has_chars = true;
+
+                    if col >= target {
+                        lines.push((line_start, col, is_first_chunk && logical_idx > 0));
+                        if lines.len() >= max_lines {
+                            return lines;
+                        }
+                        line_start = char_idx;
+                        col = 0;
+                        is_first_chunk = false;
+                        has_chars = false;
+                    }
                 }
-                // starts_paragraph: first soft-wrap line of a new logical paragraph
-                let starts_paragraph = offset == 0 && logical_idx > 0;
-                lines.push((char_idx + offset, col, starts_paragraph));
-                if end == offset {
-                    // Zero-width char at start — force advance
-                    end = offset + 1;
+
+                if has_chars {
+                    lines.push((line_start, col, is_first_chunk && logical_idx > 0));
+                    if lines.len() >= max_lines {
+                        return lines;
+                    }
                 }
-                offset = end;
             }
-            char_idx += logical_chars.len();
-            // Only add 1 for the newline separator if this is not the last part
-            if logical_idx < parts.len() - 1 {
+
+            if has_more {
                 char_idx += 1;
             }
+
+            logical_idx += 1;
         }
         lines
     }
 
+    fn count_visual_lines_with_caret(
+        &self,
+        safe_width: usize,
+        caret_char_idx: usize,
+    ) -> (usize, usize) {
+        let mut total = 0usize;
+        let mut caret_line = 0usize;
+        let mut char_cursor = 0usize;
+        let mut caret_found = false;
+        let mut parts = self.input.text.split('\n').peekable();
+        let mut logical_idx = 0usize;
+
+        while let Some(part) = parts.next() {
+            let has_more = parts.peek().is_some();
+            let first_cap = safe_width.saturating_sub(if logical_idx == 0 { 2 } else { 0 });
+
+            if part.is_empty() {
+                if !caret_found && char_cursor == caret_char_idx {
+                    caret_line = total;
+                    caret_found = true;
+                }
+                total += 1;
+            } else {
+                let mut col = 0usize;
+                let mut is_first_chunk = true;
+                let mut has_chars = false;
+
+                for c in part.chars() {
+                    if !caret_found && char_cursor == caret_char_idx {
+                        caret_line = total;
+                        caret_found = true;
+                    }
+
+                    let target = if is_first_chunk {
+                        first_cap
+                    } else {
+                        safe_width
+                    };
+                    let cw = char_display_width(c);
+
+                    if has_chars && col + cw > target {
+                        total += 1;
+                        col = 0;
+                        is_first_chunk = false;
+                    }
+
+                    col += cw;
+                    char_cursor += 1;
+                    has_chars = true;
+
+                    if col >= target {
+                        total += 1;
+                        col = 0;
+                        is_first_chunk = false;
+                        has_chars = false;
+                    }
+                }
+
+                if !caret_found && char_cursor == caret_char_idx {
+                    caret_line = total;
+                    caret_found = true;
+                }
+
+                if has_chars || char_cursor == caret_char_idx {
+                    total += 1;
+                }
+            }
+
+            if has_more {
+                char_cursor += 1;
+            }
+
+            logical_idx += 1;
+        }
+
+        if !caret_found {
+            caret_line = total.saturating_sub(1);
+        }
+
+        (total.max(1), caret_line)
+    }
+
     fn move_input_cursor_up(&mut self) {
         self.move_input_cursor_up_inner();
-        // Atomic-mask snap: up = treat like left = snap to start.
-        let ranges = self.compute_mask_ranges();
-        if let Some(r) = Self::mask_containing(self.input.byte_cursor, &ranges) {
-            self.input.byte_cursor = r.start;
-            self.input.cursor = self.input.text[..r.start].chars().count();
-        }
     }
 
     fn move_input_cursor_up_inner(&mut self) {
@@ -1245,12 +1076,6 @@ impl ReplTuiState {
 
     fn move_input_cursor_down(&mut self) {
         self.move_input_cursor_down_inner();
-        // Atomic-mask snap: down = treat like right = snap to end.
-        let ranges = self.compute_mask_ranges();
-        if let Some(r) = Self::mask_containing(self.input.byte_cursor, &ranges) {
-            self.input.byte_cursor = r.end;
-            self.input.cursor = self.input.text[..r.end].chars().count();
-        }
     }
 
     fn move_input_cursor_down_inner(&mut self) {
@@ -1470,52 +1295,6 @@ impl ReplTuiState {
     }
 
     #[allow(clippy::too_many_lines)]
-    /// Push spans for `text` whose characters start at absolute char index
-    /// `text_char_start` within `self.input.text`, applying `mask_style` for
-    /// any chars overlapping a mask range and `base_style` otherwise.  Mask
-    /// ranges are absolute (input-text char indices) and assumed sorted.
-    fn push_input_text_spans(
-        spans: &mut Vec<Span<'static>>,
-        text: &str,
-        text_char_start: usize,
-        base_style: Style,
-        mask_style: Style,
-        masks: &[(usize, usize)],
-    ) {
-        if text.is_empty() {
-            return;
-        }
-        if masks.is_empty() {
-            spans.push(Span::styled(text.to_string(), base_style));
-            return;
-        }
-        let chars: Vec<char> = text.chars().collect();
-        let text_char_end = text_char_start + chars.len();
-        // Find masks that overlap [text_char_start, text_char_end).
-        let mut cursor = 0usize; // char index within `text`
-        for &(m_start, m_end) in masks {
-            if m_end <= text_char_start || m_start >= text_char_end {
-                continue;
-            }
-            let local_start = m_start.saturating_sub(text_char_start);
-            let local_end = (m_end - text_char_start).min(chars.len());
-            if local_start > cursor {
-                let pre: String = chars[cursor..local_start].iter().collect();
-                spans.push(Span::styled(pre, base_style));
-            }
-            if local_end > local_start {
-                let inside: String = chars[local_start..local_end].iter().collect();
-                spans.push(Span::styled(inside, mask_style));
-            }
-            cursor = local_end;
-        }
-        if cursor < chars.len() {
-            let tail: String = chars[cursor..].iter().collect();
-            spans.push(Span::styled(tail, base_style));
-        }
-    }
-
-    #[allow(clippy::too_many_lines)]
     pub(super) fn calculate_input_dimensions(
         &mut self,
         width: u16,
@@ -1525,28 +1304,33 @@ impl ReplTuiState {
         self.clamp_input_cursor();
         let is_placeholder = self.input.text.is_empty();
         let placeholder_text = self.input_placeholder();
-        let mut input_with_caret = self.input.text.clone();
-        if !is_placeholder {
-            let caret_idx = self.input_char_to_byte(self.input.cursor);
-            input_with_caret.insert(caret_idx, INPUT_CARET_MARKER);
-        }
-        let source = if is_placeholder {
-            placeholder_text.to_owned()
-        } else {
-            input_with_caret
-        };
-        let mut lines_data = source
-            .split('\n')
-            .map(ToOwned::to_owned)
-            .collect::<Vec<_>>();
-        if lines_data.is_empty() {
-            lines_data.push(String::new());
-        }
-
         let safe_width = width.saturating_sub(5).max(5) as usize;
-        let mut visual_lines = Vec::new();
-        let mut caret_row_idx = 0usize;
-        let mut seen_caret = false;
+        let max_text_lines = MAX_INPUT_LINES;
+
+        let (total_visual, caret_visual_line) = if is_placeholder {
+            (1usize, 0usize)
+        } else {
+            self.count_visual_lines_with_caret(safe_width, self.input.cursor)
+        };
+
+        let max_scroll = total_visual.saturating_sub(max_text_lines);
+        if self.input_scroll_offset == usize::MAX {
+            self.input_scroll_offset = max_scroll;
+        } else {
+            self.input_scroll_offset = self.input_scroll_offset.clamp(0, max_scroll);
+        }
+        if !is_placeholder && !self.input_scroll_manual {
+            if caret_visual_line < self.input_scroll_offset {
+                self.input_scroll_offset = caret_visual_line;
+            } else if caret_visual_line >= self.input_scroll_offset + max_text_lines {
+                self.input_scroll_offset = caret_visual_line.saturating_sub(max_text_lines - 1);
+            }
+        }
+        self.input_scroll_offset = self.input_scroll_offset.clamp(0, max_scroll);
+
+        let skip = self.input_scroll_offset;
+        let visible_end = skip + max_text_lines;
+        let mut visual_lines = Vec::with_capacity(max_text_lines);
 
         let input_char_width = |ch: char| {
             if ch == INPUT_CARET_MARKER {
@@ -1556,83 +1340,225 @@ impl ReplTuiState {
             }
         };
 
-        for (logical_idx, line) in lines_data.into_iter().enumerate() {
-            let offset = if logical_idx == 0 { 2 } else { 0 };
-            let first_line_width = safe_width.saturating_sub(offset);
-
-            if line.is_empty() {
-                visual_lines.push((logical_idx == 0, String::new()));
-                continue;
+        if is_placeholder {
+            let mut lines_data = placeholder_text
+                .split('\n')
+                .map(ToOwned::to_owned)
+                .collect::<Vec<_>>();
+            if lines_data.is_empty() {
+                lines_data.push(String::new());
             }
 
-            let mut current = String::new();
-            let mut w = 0;
-            let mut is_first_chunk = true;
+            for (logical_idx, line) in lines_data.into_iter().enumerate() {
+                let offset = if logical_idx == 0 { 2 } else { 0 };
+                let first_line_width = safe_width.saturating_sub(offset);
 
-            for c in line.chars() {
-                let char_width = input_char_width(c);
-                let target = if is_first_chunk {
-                    first_line_width
-                } else {
-                    safe_width
-                };
-                if !current.is_empty() && w + char_width > target {
-                    if !is_placeholder && !seen_caret && current.contains(INPUT_CARET_MARKER) {
-                        caret_row_idx = visual_lines.len();
-                        seen_caret = true;
+                if line.is_empty() {
+                    if visual_lines.len() < max_text_lines {
+                        visual_lines.push((logical_idx == 0, String::new()));
                     }
-                    visual_lines.push((logical_idx == 0 && is_first_chunk, current));
-                    current = String::new();
-                    w = 0;
-                    is_first_chunk = false;
+                    continue;
                 }
 
-                current.push(c);
-                w += char_width;
+                let mut current = String::new();
+                let mut w = 0;
+                let mut is_first_chunk = true;
 
-                if w >= target && !current.is_empty() {
-                    if !is_placeholder && !seen_caret && current.contains(INPUT_CARET_MARKER) {
-                        caret_row_idx = visual_lines.len();
-                        seen_caret = true;
+                for c in line.chars() {
+                    let char_width = input_char_width(c);
+                    let target = if is_first_chunk {
+                        first_line_width
+                    } else {
+                        safe_width
+                    };
+                    if !current.is_empty() && w + char_width > target {
+                        if visual_lines.len() < max_text_lines {
+                            visual_lines.push((logical_idx == 0 && is_first_chunk, current));
+                        }
+                        current = String::new();
+                        w = 0;
+                        is_first_chunk = false;
                     }
-                    visual_lines.push((logical_idx == 0 && is_first_chunk, current));
-                    current = String::new();
-                    w = 0;
-                    is_first_chunk = false;
-                }
-            }
-            if !current.is_empty() {
-                if !is_placeholder && !seen_caret && current.contains(INPUT_CARET_MARKER) {
-                    caret_row_idx = visual_lines.len();
-                    seen_caret = true;
-                }
-                visual_lines.push((logical_idx == 0 && is_first_chunk, current));
-            }
-        }
 
-        let max_text_lines = MAX_INPUT_LINES;
-        let total_visual = visual_lines.len();
-        let max_scroll = total_visual.saturating_sub(max_text_lines);
-        if self.input_scroll_offset == usize::MAX {
-            self.input_scroll_offset = max_scroll;
+                    current.push(c);
+                    w += char_width;
+
+                    if w >= target && !current.is_empty() {
+                        if visual_lines.len() < max_text_lines {
+                            visual_lines.push((logical_idx == 0 && is_first_chunk, current));
+                        }
+                        current = String::new();
+                        w = 0;
+                        is_first_chunk = false;
+                    }
+                }
+                if !current.is_empty() && visual_lines.len() < max_text_lines {
+                    visual_lines.push((logical_idx == 0 && is_first_chunk, current));
+                }
+                if visual_lines.len() >= max_text_lines {
+                    break;
+                }
+            }
         } else {
-            self.input_scroll_offset = self.input_scroll_offset.clamp(0, max_scroll);
-        }
-        if !is_placeholder && seen_caret && !self.input_scroll_manual {
-            if caret_row_idx < self.input_scroll_offset {
-                self.input_scroll_offset = caret_row_idx;
-            } else if caret_row_idx >= self.input_scroll_offset + max_text_lines {
-                self.input_scroll_offset = caret_row_idx.saturating_sub(max_text_lines - 1);
+            let mut visual_line_idx = 0usize;
+            let mut char_cursor = 0usize;
+            let caret_char_idx = self.input.cursor;
+            let mut parts = self.input.text.split('\n').peekable();
+            let mut logical_idx = 0usize;
+
+            'outer: while let Some(line) = parts.next() {
+                let has_more = parts.peek().is_some();
+                let offset = if logical_idx == 0 { 2 } else { 0 };
+                let first_line_width = safe_width.saturating_sub(offset);
+                let mut current = String::new();
+                let mut w = 0usize;
+                let mut is_first_chunk = true;
+
+                let push_current =
+                    |current: &mut String,
+                     is_first_chunk: bool,
+                     visual_line_idx: &mut usize,
+                     visual_lines: &mut Vec<(bool, String)>| {
+                        if *visual_line_idx >= skip && *visual_line_idx < visible_end {
+                            visual_lines.push((
+                                logical_idx == 0 && is_first_chunk,
+                                std::mem::take(current),
+                            ));
+                        } else {
+                            current.clear();
+                        }
+                        *visual_line_idx += 1;
+                    };
+
+                let push_char =
+                    |c: char,
+                     current: &mut String,
+                     w: &mut usize,
+                     is_first_chunk: &mut bool,
+                     visual_line_idx: &mut usize,
+                     visual_lines: &mut Vec<(bool, String)>| {
+                        let char_width = input_char_width(c);
+                        let target = if *is_first_chunk {
+                            first_line_width
+                        } else {
+                            safe_width
+                        };
+
+                        if !current.is_empty() && *w + char_width > target {
+                            push_current(current, *is_first_chunk, visual_line_idx, visual_lines);
+                            *w = 0;
+                            *is_first_chunk = false;
+                        }
+
+                        current.push(c);
+                        *w += char_width;
+
+                        if *w >= target && !current.is_empty() {
+                            push_current(current, *is_first_chunk, visual_line_idx, visual_lines);
+                            *w = 0;
+                            *is_first_chunk = false;
+                        }
+                    };
+
+                if line.is_empty() {
+                    if char_cursor == caret_char_idx {
+                        push_char(
+                            INPUT_CARET_MARKER,
+                            &mut current,
+                            &mut w,
+                            &mut is_first_chunk,
+                            &mut visual_line_idx,
+                            &mut visual_lines,
+                        );
+                    }
+
+                    if current.is_empty() {
+                        if visual_line_idx >= skip && visual_line_idx < visible_end {
+                            visual_lines.push((logical_idx == 0, String::new()));
+                        }
+                        visual_line_idx += 1;
+                    } else {
+                        push_current(
+                            &mut current,
+                            is_first_chunk,
+                            &mut visual_line_idx,
+                            &mut visual_lines,
+                        );
+                    }
+
+                    if visual_line_idx >= visible_end {
+                        break;
+                    }
+                } else {
+                    for c in line.chars() {
+                        if char_cursor == caret_char_idx {
+                            push_char(
+                                INPUT_CARET_MARKER,
+                                &mut current,
+                                &mut w,
+                                &mut is_first_chunk,
+                                &mut visual_line_idx,
+                                &mut visual_lines,
+                            );
+                            if visual_line_idx >= visible_end {
+                                break 'outer;
+                            }
+                        }
+
+                        push_char(
+                            c,
+                            &mut current,
+                            &mut w,
+                            &mut is_first_chunk,
+                            &mut visual_line_idx,
+                            &mut visual_lines,
+                        );
+                        char_cursor += 1;
+
+                        if visual_line_idx >= visible_end {
+                            break 'outer;
+                        }
+                    }
+
+                    if char_cursor == caret_char_idx {
+                        push_char(
+                            INPUT_CARET_MARKER,
+                            &mut current,
+                            &mut w,
+                            &mut is_first_chunk,
+                            &mut visual_line_idx,
+                            &mut visual_lines,
+                        );
+                    }
+
+                    if !current.is_empty() {
+                        push_current(
+                            &mut current,
+                            is_first_chunk,
+                            &mut visual_line_idx,
+                            &mut visual_lines,
+                        );
+                    }
+
+                    if visual_line_idx >= visible_end {
+                        break;
+                    }
+                }
+
+                if has_more {
+                    char_cursor += 1;
+                }
+
+                logical_idx += 1;
             }
         }
-        self.input_scroll_offset = self.input_scroll_offset.clamp(0, max_scroll);
 
         // Compute char-index range for each visual line using the original
         // input text so embedded `\n` separators keep their real char indices.
         let visual_ranges: Vec<(usize, usize)> = if is_placeholder {
             vec![(0, 0); visual_lines.len()]
         } else {
-            let vis = self.visual_line_info(safe_width);
+            let vis = self.visual_line_info_capped(safe_width, skip + max_text_lines + 1);
             vis.iter()
                 .enumerate()
                 .map(|(idx, &(start, _, _))| {
@@ -1648,13 +1574,7 @@ impl ReplTuiState {
                 .collect()
         };
 
-        let skip = self.input_scroll_offset;
-        let sliced = visual_lines
-            .into_iter()
-            .skip(skip)
-            .take(max_text_lines)
-            .collect::<Vec<_>>();
-        let total_sliced = sliced.len();
+        let total_sliced = visual_lines.len();
         let mut cursor_pos: Option<(u16, u16)> = None;
 
         let text_style = if is_placeholder {
@@ -1664,17 +1584,11 @@ impl ReplTuiState {
         } else {
             Style::default()
         };
-        let mask_style = text_style.add_modifier(Modifier::DIM | Modifier::ITALIC);
-        let mask_char_ranges = if is_placeholder {
-            Vec::new()
-        } else {
-            self.compute_mask_char_ranges()
-        };
 
         let mut render_lines = Vec::new();
         render_lines.push(Line::from(""));
 
-        for (i, (has_prompt, row)) in sliced.into_iter().enumerate() {
+        for (i, (has_prompt, row)) in visual_lines.into_iter().enumerate() {
             let mut spans: Vec<Span<'static>> = Vec::new();
 
             if has_prompt {
@@ -1727,51 +1641,22 @@ impl ReplTuiState {
                             .take(row_sel_end.saturating_sub(row_sel_start))
                             .collect();
                         let after_s: String = full.chars().skip(row_sel_end).collect();
-                        Self::push_input_text_spans(
-                            &mut spans,
-                            &before_s,
-                            line_start,
-                            text_style,
-                            mask_style,
-                            &mask_char_ranges,
-                        );
-                        if !selected_s.is_empty() {
-                            let sel_mask_style =
-                                sel_style.add_modifier(Modifier::DIM | Modifier::ITALIC);
-                            Self::push_input_text_spans(
-                                &mut spans,
-                                &selected_s,
-                                line_start + row_sel_start,
-                                sel_style,
-                                sel_mask_style,
-                                &mask_char_ranges,
-                            );
+                        if !before_s.is_empty() {
+                            spans.push(Span::styled(before_s, text_style));
                         }
-                        Self::push_input_text_spans(
-                            &mut spans,
-                            &after_s,
-                            line_start + row_sel_end,
-                            text_style,
-                            mask_style,
-                            &mask_char_ranges,
-                        );
+                        if !selected_s.is_empty() {
+                            spans.push(Span::styled(selected_s, sel_style));
+                        }
+                        if !after_s.is_empty() {
+                            spans.push(Span::styled(after_s, text_style));
+                        }
                     } else {
-                        Self::push_input_text_spans(
-                            &mut spans,
-                            &left,
-                            line_start,
-                            text_style,
-                            mask_style,
-                            &mask_char_ranges,
-                        );
-                        Self::push_input_text_spans(
-                            &mut spans,
-                            &right,
-                            line_start + left.chars().count(),
-                            text_style,
-                            mask_style,
-                            &mask_char_ranges,
-                        );
+                        if !left.is_empty() {
+                            spans.push(Span::styled(left.clone(), text_style));
+                        }
+                        if !right.is_empty() {
+                            spans.push(Span::styled(right.clone(), text_style));
+                        }
                     }
                     if left.is_empty() {
                         cursor_pos = Some((u16::try_from(i + 1).unwrap_or(1), prompt_width));
@@ -1791,43 +1676,17 @@ impl ReplTuiState {
                         .take(row_sel_end - row_sel_start)
                         .collect();
                     let after: String = row.chars().skip(row_sel_end).collect();
-                    Self::push_input_text_spans(
-                        &mut spans,
-                        &before,
-                        line_start,
-                        text_style,
-                        mask_style,
-                        &mask_char_ranges,
-                    );
-                    if !selected.is_empty() {
-                        let sel_mask_style =
-                            sel_style.add_modifier(Modifier::DIM | Modifier::ITALIC);
-                        Self::push_input_text_spans(
-                            &mut spans,
-                            &selected,
-                            line_start + row_sel_start,
-                            sel_style,
-                            sel_mask_style,
-                            &mask_char_ranges,
-                        );
+                    if !before.is_empty() {
+                        spans.push(Span::styled(before, text_style));
                     }
-                    Self::push_input_text_spans(
-                        &mut spans,
-                        &after,
-                        line_start + row_sel_end,
-                        text_style,
-                        mask_style,
-                        &mask_char_ranges,
-                    );
-                } else {
-                    Self::push_input_text_spans(
-                        &mut spans,
-                        &row,
-                        line_start,
-                        text_style,
-                        mask_style,
-                        &mask_char_ranges,
-                    );
+                    if !selected.is_empty() {
+                        spans.push(Span::styled(selected, sel_style));
+                    }
+                    if !after.is_empty() {
+                        spans.push(Span::styled(after, text_style));
+                    }
+                } else if !row.is_empty() {
+                    spans.push(Span::styled(row, text_style));
                 }
             } else {
                 // No active selection — plain rendering (existing logic).
@@ -1846,40 +1705,20 @@ impl ReplTuiState {
                     } else {
                         0
                     };
-                    let left_char_len = left.chars().count();
                     if left.is_empty() {
                         cursor_pos = Some((u16::try_from(i + 1).unwrap_or(1), prompt_width));
                     } else {
                         let left_width = text_display_width(&left);
-                        Self::push_input_text_spans(
-                            &mut spans,
-                            &left,
-                            line_start,
-                            text_style,
-                            mask_style,
-                            &mask_char_ranges,
-                        );
+                        spans.push(Span::styled(left, text_style));
                         let cursor_col =
                             prompt_width + u16::try_from(left_width).unwrap_or(u16::MAX);
                         cursor_pos = Some((u16::try_from(i + 1).unwrap_or(1), cursor_col));
                     }
-                    Self::push_input_text_spans(
-                        &mut spans,
-                        &right,
-                        line_start + left_char_len,
-                        text_style,
-                        mask_style,
-                        &mask_char_ranges,
-                    );
-                } else {
-                    Self::push_input_text_spans(
-                        &mut spans,
-                        &row,
-                        line_start,
-                        text_style,
-                        mask_style,
-                        &mask_char_ranges,
-                    );
+                    if !right.is_empty() {
+                        spans.push(Span::styled(right, text_style));
+                    }
+                } else if !row.is_empty() {
+                    spans.push(Span::styled(row, text_style));
                 }
             }
             render_lines.push(Line::from(spans));
@@ -3385,7 +3224,7 @@ fn run_loop(
                             if state.input_selection.is_some() =>
                         {
                             // Copy selected text to clipboard.
-                            if let Some(text) = state.selected_input_text_expanded() {
+                            if let Some(text) = state.selected_input_text_string() {
                                 if let Ok(mut cb) = arboard::Clipboard::new() {
                                     let _ = cb.set_text(text);
                                 }
@@ -3521,7 +3360,7 @@ fn run_loop(
                         && key.modifiers.contains(KeyModifiers::CONTROL))
                         || (key.code == KeyCode::Insert && key.modifiers == KeyModifiers::CONTROL))
                 {
-                    if let Some(text) = state.selected_input_text_expanded() {
+                    if let Some(text) = state.selected_input_text_string() {
                         if let Ok(mut cb) = arboard::Clipboard::new() {
                             let _ = cb.set_text(text);
                         }
@@ -3978,7 +3817,7 @@ fn run_loop(
                         }
 
                         let raw_line = std::mem::take(&mut state.input.text);
-                        let line = expand_masks(&raw_line, &state.input.pastes);
+                        let line = raw_line;
                         state.reset_input();
                         state.input_scroll_offset = 0;
                         state.clear_input_history();
@@ -4138,12 +3977,8 @@ mod tests {
     use ratatui::style::Color;
     use ratatui::text::Line;
 
-    use super::{
-        count_lines, expand_masks, format_paste_placeholder, normalize_pasted_text,
-        should_mask_paste, PasteEntry, ReplTuiState, ToolCallStatus, TranscriptEntry,
-    };
+    use super::{normalize_pasted_text, ReplTuiState, ToolCallStatus, TranscriptEntry};
 
-    /// Smallest valid `ReplTuiState` for paste-masking unit tests.
     fn test_state() -> ReplTuiState {
         ReplTuiState::new()
     }
@@ -4154,23 +3989,6 @@ mod tests {
         assert_eq!(normalize_pasted_text("a\rb"), "a\nb");
         assert_eq!(normalize_pasted_text("a\r\nb\rc"), "a\nb\nc");
         assert_eq!(normalize_pasted_text("plain"), "plain");
-    }
-
-    #[test]
-    fn count_lines_counts_newlines_plus_one() {
-        assert_eq!(count_lines(""), 1);
-        assert_eq!(count_lines("one"), 1);
-        assert_eq!(count_lines("a\nb"), 2);
-        assert_eq!(count_lines("a\nb\nc"), 3);
-        assert_eq!(count_lines("trailing\n"), 2);
-    }
-
-    #[test]
-    fn should_mask_paste_uses_byte_threshold() {
-        assert!(!should_mask_paste(""));
-        assert!(!should_mask_paste(&"x".repeat(149)));
-        assert!(should_mask_paste(&"x".repeat(150)));
-        assert!(should_mask_paste(&"x".repeat(10_000)));
     }
 
     // ── paste-newline suppression e2e tests ───────────────────────────────────
@@ -4209,7 +4027,7 @@ mod tests {
         let mut s = test_state();
         // Open a suppression window that expired 1 ms ago.
         s.selection.suppress_paste_until =
-            Some(std::time::Instant::now() - std::time::Duration::from_millis(1));
+            std::time::Instant::now().checked_sub(std::time::Duration::from_millis(1));
         assert!(
             !s.paste_enter_is_suppressed(KeyCode::Enter),
             "Enter must not be suppressed once the window has expired"
@@ -4230,27 +4048,16 @@ mod tests {
     }
 
     #[test]
-    fn multiline_paste_below_byte_threshold_is_not_masked() {
-        // "a\nb" is 3 bytes — far below the 150-byte threshold, so it is
-        // inserted raw (no mask placeholder).  Suppression is not handle_paste_event's
-        // responsibility — callers (bracketed paste / Ctrl+V) arm it explicitly.
+    fn handle_paste_event_inserts_multiline_text_directly() {
         let mut s = test_state();
         s.handle_paste_event("a\nb");
-        assert!(
-            !s.input.text.contains("[#1 Pasted"),
-            "short multi-line paste must not be masked"
-        );
+        assert_eq!(s.input.text, "a\nb");
         assert!(s.input.text.contains('\n'), "newline must appear in input");
     }
 
     #[test]
     fn paste_burst_helpers_buffer_then_flush_through_handle_paste_event() {
-        // Simulates a raw-keystroke paste from terminals that don't deliver
-        // `Event::Paste`.  We push chars into the burst buffer directly and
-        // verify that flush routes them through handle_paste_event so the
-        // long-paste mask applies.
         let mut s = test_state();
-        // Push a 200-char "paste" with a newline in the middle.
         for ch in "a".repeat(99).chars() {
             s.paste_burst_chars.push(ch);
         }
@@ -4260,16 +4067,9 @@ mod tests {
         }
         assert_eq!(s.paste_burst_chars.len(), 200);
         s.flush_paste_burst();
-        // Buffer is drained.
         assert!(s.paste_burst_chars.is_empty());
-        // Length ≥ 150 → masked (text shows the placeholder, not raw chars).
-        assert!(
-            s.input.text.contains("[#1 Pasted"),
-            "burst above threshold must flush through the mask path"
-        );
-        // CRITICAL: the burst flush must NOT arm suppression — doing so would
-        // eat the next paste characters arriving in the 100 ms window, which
-        // is exactly the truncation regression we're guarding against.
+        assert_eq!(s.input.text.len(), 200);
+        assert!(s.input.text.contains('\n'));
         assert!(
             s.selection.suppress_paste_until.is_none(),
             "burst flush must not arm post-paste suppression"
@@ -4278,7 +4078,7 @@ mod tests {
 
     /// End-to-end simulation of the event loop's paste-burst handling for the
     /// concrete regression we're fixing: a multi-line paste arriving as raw
-    /// keystrokes (Windows Terminal + ConPTY bypassing `Event::Paste`).
+    /// keystrokes (Windows Terminal + `ConPTY` bypassing `Event::Paste`).
     ///
     /// This walks through the exact sequence of state mutations the event-loop
     /// handlers (`KeyCode::Char(c)`, `KeyCode::Enter`) would perform on each
@@ -4319,43 +4119,21 @@ mod tests {
         s.flush_paste_burst();
 
         // Full multi-line text now in input.text; no auto-send happened.
-        assert_eq!(s.input.text, "ab\ncd",
-            "all pasted content should land in input.text, with the newline preserved");
-        assert!(s.paste_burst_chars.is_empty(),
-            "burst buffer drained after flush");
+        assert_eq!(
+            s.input.text, "ab\ncd",
+            "all pasted content should land in input.text, with the newline preserved"
+        );
+        assert!(
+            s.paste_burst_chars.is_empty(),
+            "burst buffer drained after flush"
+        );
         // CRITICAL: post-paste suppression must NOT be armed by the burst flush.
         // If it were, the 100 ms window would eat subsequent paste characters,
         // truncating long multi-line pastes (the bug this regression covers).
-        assert!(s.selection.suppress_paste_until.is_none(),
-            "burst flush must not arm Enter suppression");
-    }
-
-    /// E2E: long keystroke-paste hits the mask threshold via the burst flush.
-    /// Verifies that masking works for terminals that don't deliver
-    /// `Event::Paste` — the entire raison d'être of restoring the burst path.
-    #[test]
-    fn paste_burst_e2e_long_keystroke_paste_is_masked() {
-        let mut s = test_state();
-        let big = "x".repeat(200);
-        let mut chars = big.chars();
-
-        // First char inserted directly (no prior key to detect burst from).
-        s.insert_input_char(chars.next().unwrap());
-        s.last_key_time = Some(std::time::Instant::now());
-
-        // Remaining 199 chars accumulate in the burst buffer.
-        for c in chars {
-            s.paste_burst_chars.push(c);
-        }
-        // Auto-flush at burst idle.
-        s.flush_paste_burst();
-
-        // The 199-char burst above the 150-byte threshold → masked.
-        assert!(s.input.text.contains("[#1 Pasted"),
-            "burst above threshold should flush through the mask path");
-        // Single PasteEntry recorded with the full 199-char content.
-        assert_eq!(s.input.pastes.len(), 1);
-        assert_eq!(s.input.pastes[0].content.len(), 199);
+        assert!(
+            s.selection.suppress_paste_until.is_none(),
+            "burst flush must not arm Enter suppression"
+        );
     }
 
     /// Regression test for paste-truncation bug: when a slow render cycle
@@ -4412,22 +4190,27 @@ mod tests {
         s.paste_burst_chars.push('x');
 
         // Recent key → don't flush yet (burst may continue).
-        s.last_key_time = Some(now - std::time::Duration::from_millis(5));
+        s.last_key_time = now.checked_sub(std::time::Duration::from_millis(5));
         let should_flush_recent = !s.paste_burst_chars.is_empty()
             && s.last_key_time.is_some_and(|t| {
-                t.elapsed() > std::time::Duration::from_millis(
-                    super::ReplTuiState::PASTE_BURST_THRESHOLD_MS,
-                )
+                t.elapsed()
+                    > std::time::Duration::from_millis(
+                        super::ReplTuiState::PASTE_BURST_THRESHOLD_MS,
+                    )
             });
-        assert!(!should_flush_recent, "must not flush while burst is still active");
+        assert!(
+            !should_flush_recent,
+            "must not flush while burst is still active"
+        );
 
         // Idle past threshold → flush.
-        s.last_key_time = Some(now - std::time::Duration::from_millis(100));
+        s.last_key_time = now.checked_sub(std::time::Duration::from_millis(100));
         let should_flush_idle = !s.paste_burst_chars.is_empty()
             && s.last_key_time.is_some_and(|t| {
-                t.elapsed() > std::time::Duration::from_millis(
-                    super::ReplTuiState::PASTE_BURST_THRESHOLD_MS,
-                )
+                t.elapsed()
+                    > std::time::Duration::from_millis(
+                        super::ReplTuiState::PASTE_BURST_THRESHOLD_MS,
+                    )
             });
         assert!(should_flush_idle, "must flush once the burst has gone idle");
     }
@@ -4457,7 +4240,10 @@ mod tests {
         s.input.cursor = 5;
         s.input.byte_cursor = 5;
         s.flush_paste_burst();
-        assert_eq!(s.input.text, "hello", "empty buffer flush must not modify text");
+        assert_eq!(
+            s.input.text, "hello",
+            "empty buffer flush must not modify text"
+        );
     }
 
     #[test]
@@ -4467,17 +4253,16 @@ mod tests {
         // No previous key recorded → not in burst.
         assert!(!s.in_paste_burst(now));
         // Previous key within threshold → in burst.
-        s.last_key_time = Some(now - std::time::Duration::from_millis(10));
+        s.last_key_time = now.checked_sub(std::time::Duration::from_millis(10));
         assert!(s.in_paste_burst(now));
         // Previous key beyond threshold → not in burst.
-        s.last_key_time = Some(now - std::time::Duration::from_millis(100));
+        s.last_key_time = now.checked_sub(std::time::Duration::from_millis(100));
         assert!(!s.in_paste_burst(now));
     }
 
     #[test]
     fn crlf_paste_normalises_to_lf_in_input() {
-        // normalize_pasted_text converts \r\n → \n so masking / display
-        // logic only ever has to consider \n.
+        // normalize_pasted_text converts \r\n → \n so the input always stores LF.
         let mut s = test_state();
         s.handle_paste_event("line1\r\nline2");
         assert!(
@@ -4487,364 +4272,6 @@ mod tests {
         assert!(
             !s.input.text.contains('\r'),
             "raw \\r should not survive normalisation"
-        );
-    }
-
-    #[test]
-    fn format_paste_placeholder_matches_format() {
-        assert_eq!(format_paste_placeholder(1, 1), "[#1 Pasted ~1 lines]");
-        assert_eq!(format_paste_placeholder(42, 137), "[#42 Pasted ~137 lines]");
-    }
-
-    #[test]
-    fn expand_masks_substitutes_original_content() {
-        let pastes = vec![
-            PasteEntry {
-                id: 1,
-                placeholder: "[#1 Pasted ~3 lines]".to_string(),
-                content: "alpha\nbeta\ngamma".to_string(),
-            },
-            PasteEntry {
-                id: 2,
-                placeholder: "[#2 Pasted ~2 lines]".to_string(),
-                content: "x\ny".to_string(),
-            },
-        ];
-        let visible = "hi [#1 Pasted ~3 lines] and [#2 Pasted ~2 lines] ok";
-        assert_eq!(
-            expand_masks(visible, &pastes),
-            "hi alpha\nbeta\ngamma and x\ny ok"
-        );
-    }
-
-    #[test]
-    fn expand_masks_is_idempotent_for_no_pastes() {
-        assert_eq!(expand_masks("plain text", &[]), "plain text");
-    }
-
-    #[test]
-    fn submit_expands_masks_before_dispatch() {
-        let mut s = test_state();
-        s.insert_input_str("please summarise: ");
-        let body = "x".repeat(600);
-        s.insert_paste_mask(&body);
-
-        // Simulate the submit-path text-extraction logic.
-        let raw_line = std::mem::take(&mut s.input.text);
-        let line = expand_masks(&raw_line, &s.input.pastes);
-
-        assert!(line.contains(&body));
-        assert!(!line.contains("[#1 Pasted"));
-    }
-
-    #[test]
-    fn snapshot_roundtrip_preserves_pastes() {
-        let mut s = test_state();
-        s.input.text = "hello [#1 Pasted ~3 lines] world".to_string();
-        s.input.cursor = s.input.text.chars().count();
-        s.resync_byte_cursor();
-        s.input.pastes.push(PasteEntry {
-            id: 1,
-            placeholder: "[#1 Pasted ~3 lines]".to_string(),
-            content: "line1\nline2\nline3".to_string(),
-        });
-        s.input.next_paste_id = 2;
-
-        let snap = s.current_input_snapshot();
-        s.input.text.clear();
-        s.input.pastes.clear();
-        s.input.next_paste_id = 1;
-        s.apply_input_snapshot(snap);
-
-        assert_eq!(s.input.text, "hello [#1 Pasted ~3 lines] world");
-        assert_eq!(s.input.pastes.len(), 1);
-        assert_eq!(s.input.pastes[0].content, "line1\nline2\nline3");
-        assert_eq!(s.input.next_paste_id, 2);
-    }
-
-    #[test]
-    fn insert_paste_mask_inserts_placeholder_and_records_entry() {
-        let mut s = test_state();
-        s.input.text = "prefix ".to_string();
-        s.input.cursor = s.input.text.chars().count();
-        s.resync_byte_cursor();
-
-        let content = "line1\nline2\nline3\n".repeat(40); // > 500 bytes, many lines
-        s.insert_paste_mask(&content);
-
-        assert_eq!(s.input.pastes.len(), 1);
-        let entry = &s.input.pastes[0];
-        assert_eq!(entry.id, 1);
-        assert!(entry.placeholder.starts_with("[#1 Pasted ~"));
-        assert_eq!(entry.content, content);
-        assert!(s.input.text.starts_with("prefix "));
-        assert!(s.input.text.contains(&entry.placeholder));
-        // Trailing space appended after the placeholder.
-        assert!(s.input.text.ends_with(' '));
-        // Cursor sits past the trailing space.
-        assert_eq!(s.input.cursor, s.input.text.chars().count());
-        assert_eq!(s.input.byte_cursor, s.input.text.len());
-        assert_eq!(s.input.next_paste_id, 2);
-    }
-
-    #[test]
-    fn insert_paste_mask_increments_id_for_consecutive_pastes() {
-        let mut s = test_state();
-        let big = "x".repeat(600);
-        s.insert_paste_mask(&big);
-        s.insert_paste_mask(&big);
-        assert_eq!(s.input.pastes.len(), 2);
-        assert_eq!(s.input.pastes[0].id, 1);
-        assert_eq!(s.input.pastes[1].id, 2);
-        assert!(s.input.text.contains("[#1 Pasted"));
-        assert!(s.input.text.contains("[#2 Pasted"));
-    }
-
-    #[test]
-    fn compute_mask_ranges_finds_all_placeholders() {
-        let mut s = test_state();
-        let big = "x".repeat(600);
-        s.insert_paste_mask(&big);
-        s.insert_input_str(" middle ");
-        s.insert_paste_mask(&big);
-
-        let ranges = s.compute_mask_ranges();
-        assert_eq!(ranges.len(), 2);
-        // Ranges sorted by start position.
-        assert!(ranges[0].1.start < ranges[1].1.start);
-        // Each range slices to exactly the placeholder string.
-        assert_eq!(
-            &s.input.text[ranges[0].1.clone()],
-            s.input.pastes[ranges[0].0].placeholder
-        );
-    }
-
-    #[test]
-    fn mask_containing_returns_none_at_boundaries_or_outside() {
-        let mut s = test_state();
-        let big = "x".repeat(600);
-        s.insert_paste_mask(&big);
-        let ranges = s.compute_mask_ranges();
-        let r = ranges[0].1.clone();
-
-        assert!(ReplTuiState::mask_containing(r.start, &ranges).is_none());
-        assert!(ReplTuiState::mask_containing(r.end, &ranges).is_none());
-        assert!(ReplTuiState::mask_containing(r.start + 1, &ranges).is_some());
-        assert!(ReplTuiState::mask_containing(r.start + 5, &ranges).is_some());
-    }
-
-    #[test]
-    fn next_paste_id_resets_to_one_after_submit() {
-        let mut s = test_state();
-        s.insert_paste_mask(&"x".repeat(600));
-        s.insert_paste_mask(&"y".repeat(600));
-        assert_eq!(s.input.next_paste_id, 3);
-
-        // Simulate submit-path reset (mirrors the production code).
-        let raw_line = std::mem::take(&mut s.input.text);
-        let _line = expand_masks(&raw_line, &s.input.pastes);
-        s.input.pastes.clear();
-        s.input.next_paste_id = 1;
-
-        assert!(s.input.pastes.is_empty());
-        assert_eq!(s.input.next_paste_id, 1);
-
-        // A fresh paste should now get id #1 again.
-        s.insert_paste_mask(&"z".repeat(600));
-        assert_eq!(s.input.pastes[0].id, 1);
-    }
-
-    #[test]
-    fn up_arrow_into_mask_snaps_to_mask_start() {
-        let mut s = test_state();
-        // Build a multi-line input so up-arrow has somewhere to go.
-        s.insert_input_str("first line\n");
-        s.insert_paste_mask(&"y".repeat(600));
-        // Cursor is past the trailing space after the placeholder; up-arrow from
-        // here lands on the previous (first) line if mask isn't on its own line,
-        // OR if the mask spans where up would land, it must snap to mask start.
-        // Position cursor at the END of the input text and press up.
-        s.move_input_cursor_up();
-
-        // After up, byte_cursor should not fall strictly inside the mask.
-        let ranges = s.compute_mask_ranges();
-        for (_, r) in &ranges {
-            assert!(
-                !(s.input.byte_cursor > r.start && s.input.byte_cursor < r.end),
-                "cursor should not land strictly inside a mask after up-arrow"
-            );
-        }
-    }
-
-    #[test]
-    fn down_arrow_into_mask_snaps_to_mask_end() {
-        let mut s = test_state();
-        s.insert_input_str("first line\n");
-        s.insert_paste_mask(&"y".repeat(600));
-        // Move cursor up to the first line, then back down — it should not land
-        // inside the mask either way.
-        s.move_input_cursor_up();
-        s.move_input_cursor_down();
-
-        let ranges = s.compute_mask_ranges();
-        for (_, r) in &ranges {
-            assert!(
-                !(s.input.byte_cursor > r.start && s.input.byte_cursor < r.end),
-                "cursor should not land strictly inside a mask after up+down round-trip"
-            );
-        }
-    }
-
-    #[test]
-    fn paste_while_cursor_inside_mask_snaps_first() {
-        let mut s = test_state();
-        s.insert_paste_mask(&"a".repeat(600));
-        let ranges = s.compute_mask_ranges();
-        let r = ranges[0].1.clone();
-        // Place cursor strictly inside the first mask.
-        s.input.byte_cursor = r.start + 3;
-        s.input.cursor = s.input.text[..r.start + 3].chars().count();
-
-        s.insert_paste_mask(&"b".repeat(600));
-
-        // Both masks present, neither nested.
-        let ranges = s.compute_mask_ranges();
-        assert_eq!(ranges.len(), 2);
-        assert!(ranges[0].1.end <= ranges[1].1.start);
-    }
-
-    #[test]
-    fn large_paste_event_creates_mask_not_raw_text() {
-        let mut s = test_state();
-        let big = "y".repeat(600);
-        s.handle_paste_event(&big);
-
-        assert!(s.input.text.contains("[#1 Pasted ~"));
-        assert!(!s.input.text.contains(&big));
-        assert_eq!(s.input.pastes.len(), 1);
-    }
-
-    #[test]
-    fn small_paste_event_inserts_raw_text() {
-        let mut s = test_state();
-        let small = "short paste".to_string();
-        s.handle_paste_event(&small);
-
-        assert_eq!(s.input.text, "short paste");
-        assert!(s.input.pastes.is_empty());
-    }
-
-    #[test]
-    fn crlf_paste_normalises_to_lf_in_stored_content() {
-        let mut s = test_state();
-        let mut crlf = "a\r\n".repeat(300);
-        crlf.push_str("end");
-        s.handle_paste_event(&crlf);
-
-        assert_eq!(s.input.pastes.len(), 1);
-        assert!(!s.input.pastes[0].content.contains('\r'));
-        assert!(s.input.pastes[0].content.contains('\n'));
-    }
-
-    #[test]
-    fn left_arrow_at_mask_end_snaps_to_mask_start() {
-        let mut s = test_state();
-        s.insert_paste_mask(&"x".repeat(600));
-        let ranges = s.compute_mask_ranges();
-        let r = ranges[0].1.clone();
-
-        // Position cursor exactly at mask end (it currently sits past the trailing space).
-        s.input.byte_cursor = r.end;
-        s.input.cursor = s.input.text[..r.end].chars().count();
-
-        s.move_input_cursor_left();
-
-        assert_eq!(s.input.byte_cursor, r.start);
-        assert_eq!(s.input.cursor, s.input.text[..r.start].chars().count());
-    }
-
-    #[test]
-    fn right_arrow_at_mask_start_snaps_to_mask_end() {
-        let mut s = test_state();
-        s.insert_input_str("hi ");
-        s.insert_paste_mask(&"x".repeat(600));
-        let ranges = s.compute_mask_ranges();
-        let r = ranges[0].1.clone();
-
-        s.input.byte_cursor = r.start;
-        s.input.cursor = s.input.text[..r.start].chars().count();
-
-        s.move_input_cursor_right();
-
-        assert_eq!(s.input.byte_cursor, r.end);
-    }
-
-    #[test]
-    fn compute_mask_ranges_skips_orphaned_entries() {
-        // If a placeholder is no longer present in `text` (e.g. after manual edits
-        // that removed it without going through atomic delete), the entry is
-        // silently skipped.
-        let mut s = test_state();
-        s.input.pastes.push(PasteEntry {
-            id: 1,
-            placeholder: "[#1 Pasted ~5 lines]".to_string(),
-            content: "x".repeat(600),
-        });
-        // text is empty — no occurrences of the placeholder.
-        let ranges = s.compute_mask_ranges();
-        assert!(ranges.is_empty());
-    }
-
-    #[test]
-    fn compute_mask_char_ranges_handles_multibyte_prefix() {
-        let mut s = test_state();
-        // Multi-byte prefix shifts byte positions relative to char positions.
-        s.insert_input_str("héllo ");
-        s.insert_paste_mask(&"x".repeat(600));
-
-        let byte_ranges = s.compute_mask_ranges();
-        let char_ranges = s.compute_mask_char_ranges();
-        assert_eq!(char_ranges.len(), 1);
-
-        let (c_start, c_end) = char_ranges[0];
-        let r = &byte_ranges[0].1;
-        assert_eq!(c_start, s.input.text[..r.start].chars().count());
-        assert_eq!(c_end, s.input.text[..r.end].chars().count());
-        // Placeholder is ASCII so char-length equals byte-length within the range.
-        assert_eq!(c_end - c_start, r.end - r.start);
-    }
-
-    #[test]
-    fn input_render_styles_mask_as_dim_italic() {
-        use ratatui::style::Modifier;
-
-        let mut s = test_state();
-        s.insert_input_str("hi ");
-        s.insert_paste_mask(&"x".repeat(600));
-
-        let (_h, lines, _max_scroll, _cursor) = s.calculate_input_dimensions(80, "model");
-        // First line is a blank padding; the input row is at index 1.
-        let input_line = &lines[1];
-        let mut found_mask_span = false;
-        for span in &input_line.spans {
-            if span.content.contains("[#1 Pasted") {
-                let mods = span.style.add_modifier;
-                assert!(
-                    mods.contains(Modifier::DIM) && mods.contains(Modifier::ITALIC),
-                    "mask span missing DIM/ITALIC modifiers (got {mods:?}) for content {:?}",
-                    span.content
-                );
-                found_mask_span = true;
-            }
-        }
-        assert!(
-            found_mask_span,
-            "expected at least one span carrying the placeholder text, got spans {:?}",
-            input_line
-                .spans
-                .iter()
-                .map(|s| s.content.as_ref())
-                .collect::<Vec<_>>()
         );
     }
 
@@ -5099,6 +4526,24 @@ mod tests {
     }
 
     #[test]
+    fn calculate_input_dimensions_limits_large_paste_to_viewport_lines() {
+        let mut state = ReplTuiState::new();
+        state.input.text = (0..1000)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        state.input.cursor = state.input.text.chars().count();
+        state.resync_byte_cursor();
+
+        let (_, render_lines, max_scroll, cursor_pos) =
+            state.calculate_input_dimensions(20, "model");
+
+        assert!(render_lines.len() <= super::MAX_INPUT_LINES + 3);
+        assert!(max_scroll > 0);
+        assert!(cursor_pos.is_some());
+    }
+
+    #[test]
     fn select_all_input_marks_entire_buffer() {
         let mut state = ReplTuiState::new();
         state.input.text = "ab\ncd".to_string();
@@ -5112,19 +4557,16 @@ mod tests {
     }
 
     #[test]
-    fn copy_selection_yanks_expanded_content() {
+    fn copy_selection_yanks_raw_content() {
         let mut s = test_state();
-        s.insert_input_str("a ");
-        s.insert_paste_mask(&"z".repeat(600));
-        s.insert_input_str(" b");
+        s.insert_input_str("a zzz b");
 
         // Select the whole input.
         let total = s.input.text.chars().count();
         s.input_selection = Some((0, total));
 
-        let yanked = s.selected_input_text_expanded().unwrap();
-        assert!(yanked.contains(&"z".repeat(600)));
-        assert!(!yanked.contains("[#1 Pasted"));
+        let yanked = s.selected_input_text_string().unwrap();
+        assert_eq!(yanked, "a zzz b");
     }
 
     #[test]
@@ -5358,44 +4800,6 @@ mod tests {
             .join("\n");
 
         assert!(content.contains("Update available: v9.9.9 (you have v1.0.0)"));
-    }
-
-    #[test]
-    fn backspace_at_mask_end_deletes_entire_mask() {
-        let mut s = test_state();
-        s.insert_input_str("hi ");
-        let big = "y".repeat(600);
-        s.insert_paste_mask(&big);
-        // Cursor sits past the trailing space.  Move it back one char to land on
-        // mask end (the boundary between placeholder and the trailing space).
-        let trailing_space_byte = s.input.byte_cursor - 1;
-        s.input.byte_cursor = trailing_space_byte;
-        s.input.cursor -= 1;
-
-        let before_len = s.input.text.len();
-        s.backspace_input_char();
-
-        assert!(!s.input.text.contains("[#1 Pasted"));
-        assert!(s.input.text.len() < before_len);
-        assert!(s.input.pastes.is_empty());
-        // Trailing separator space is deleted atomically with the mask.
-        assert_eq!(s.input.text, "hi ");
-    }
-
-    #[test]
-    fn delete_at_mask_start_deletes_entire_mask() {
-        let mut s = test_state();
-        s.insert_paste_mask(&"y".repeat(600));
-        // Position cursor at mask start.
-        let ranges = s.compute_mask_ranges();
-        let r = ranges[0].1.clone();
-        s.input.byte_cursor = r.start;
-        s.input.cursor = s.input.text[..r.start].chars().count();
-
-        s.delete_input_char();
-
-        assert!(!s.input.text.contains("[#1 Pasted"));
-        assert!(s.input.pastes.is_empty());
     }
 
     #[test]

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -4261,6 +4261,115 @@ mod tests {
         assert!(s.paste_enter_is_suppressed(KeyCode::Enter));
     }
 
+    /// End-to-end simulation of the event loop's paste-burst handling for the
+    /// concrete regression we're fixing: a multi-line paste arriving as raw
+    /// keystrokes (Windows Terminal + ConPTY bypassing `Event::Paste`).
+    ///
+    /// This walks through the exact sequence of state mutations the event-loop
+    /// handlers (`KeyCode::Char(c)`, `KeyCode::Enter`) would perform on each
+    /// arriving key event, then asserts the final input state contains the
+    /// full multi-line text and that no auto-submit was triggered.
+    #[test]
+    fn paste_burst_e2e_multi_line_keystroke_paste_does_not_auto_send() {
+        let mut s = test_state();
+        let now = std::time::Instant::now();
+        let burst = std::time::Duration::from_millis(2);
+
+        // Char 'a' — first keystroke, no prior key → inserted directly.
+        s.last_key_time = Some(now);
+        s.insert_input_char('a');
+
+        // Char 'b' arrives 2 ms later — in burst, accumulate.
+        let t_b = now + burst;
+        assert!(s.in_paste_burst(t_b));
+        s.paste_burst_chars.push('b');
+        s.last_key_time = Some(t_b);
+
+        // Enter arrives 2 ms later — in burst → push '\n' to buffer, NO submit.
+        // (This is the regression: previously this triggered a send of "ab".)
+        let t_enter = t_b + burst;
+        assert!(s.in_paste_burst(t_enter));
+        s.paste_burst_chars.push('\n');
+        s.last_key_time = Some(t_enter);
+
+        // Chars 'c', 'd' — still in burst, accumulate.
+        let t_c = t_enter + burst;
+        s.paste_burst_chars.push('c');
+        s.last_key_time = Some(t_c);
+        let t_d = t_c + burst;
+        s.paste_burst_chars.push('d');
+        s.last_key_time = Some(t_d);
+
+        // Burst goes idle — top-of-loop auto-flush fires.
+        s.flush_paste_burst();
+
+        // Full multi-line text now in input.text; no auto-send happened.
+        assert_eq!(s.input.text, "ab\ncd",
+            "all pasted content should land in input.text, with the newline preserved");
+        assert!(s.paste_burst_chars.is_empty(),
+            "burst buffer drained after flush");
+        assert!(s.paste_enter_is_suppressed(KeyCode::Enter),
+            "newline routed through handle_paste_event arms Enter suppression");
+    }
+
+    /// E2E: long keystroke-paste hits the mask threshold via the burst flush.
+    /// Verifies that masking works for terminals that don't deliver
+    /// `Event::Paste` — the entire raison d'être of restoring the burst path.
+    #[test]
+    fn paste_burst_e2e_long_keystroke_paste_is_masked() {
+        let mut s = test_state();
+        let big = "x".repeat(200);
+        let mut chars = big.chars();
+
+        // First char inserted directly (no prior key to detect burst from).
+        s.insert_input_char(chars.next().unwrap());
+        s.last_key_time = Some(std::time::Instant::now());
+
+        // Remaining 199 chars accumulate in the burst buffer.
+        for c in chars {
+            s.paste_burst_chars.push(c);
+        }
+        // Auto-flush at burst idle.
+        s.flush_paste_burst();
+
+        // The 199-char burst above the 150-byte threshold → masked.
+        assert!(s.input.text.contains("[#1 Pasted"),
+            "burst above threshold should flush through the mask path");
+        // Single PasteEntry recorded with the full 199-char content.
+        assert_eq!(s.input.pastes.len(), 1);
+        assert_eq!(s.input.pastes[0].content.len(), 199);
+    }
+
+    /// E2E: the periodic auto-flush condition.  Verifies the predicate the
+    /// event loop uses at the top of each tick — burst is flushed only when
+    /// both the buffer is non-empty AND the last key is older than the threshold.
+    #[test]
+    fn paste_burst_e2e_auto_flush_condition_only_fires_when_idle() {
+        let mut s = test_state();
+        let now = std::time::Instant::now();
+        s.paste_burst_chars.push('x');
+
+        // Recent key → don't flush yet (burst may continue).
+        s.last_key_time = Some(now - std::time::Duration::from_millis(5));
+        let should_flush_recent = !s.paste_burst_chars.is_empty()
+            && s.last_key_time.is_some_and(|t| {
+                t.elapsed() > std::time::Duration::from_millis(
+                    super::ReplTuiState::PASTE_BURST_THRESHOLD_MS,
+                )
+            });
+        assert!(!should_flush_recent, "must not flush while burst is still active");
+
+        // Idle past threshold → flush.
+        s.last_key_time = Some(now - std::time::Duration::from_millis(100));
+        let should_flush_idle = !s.paste_burst_chars.is_empty()
+            && s.last_key_time.is_some_and(|t| {
+                t.elapsed() > std::time::Duration::from_millis(
+                    super::ReplTuiState::PASTE_BURST_THRESHOLD_MS,
+                )
+            });
+        assert!(should_flush_idle, "must flush once the burst has gone idle");
+    }
+
     #[test]
     fn paste_burst_flush_below_threshold_inserts_raw_with_suppression() {
         // Short burst with newline → not masked, but newline triggers suppression.

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -1576,15 +1576,13 @@ impl ReplTuiState {
             }
         }
 
-        // Compute char-index range for each visual line using the original
-        // input text so embedded `\n` separators keep their real char indices.
-        let visual_ranges: Vec<(usize, usize)> = if is_placeholder {
-            vec![(0, 0); visual_lines.len()]
+        // Only needed when a selection is active; line_start/line_end are
+        // consumed exclusively in the input_selection branch below.
+        let visual_ranges: Vec<(usize, usize)> = if is_placeholder
+            || self.input_selection.is_none()
+        {
+            Vec::new()
         } else {
-            // Fast path: if vis_cache is warm (populated by a navigation event),
-            // slice the needed entries directly — O(1).
-            // Cold path (e.g. right after paste, before any navigation): fall back
-            // to the early-exit capped scan — O(chars up to skip+max_text_lines).
             let vis = if self.vis_cache_width == safe_width {
                 if let Some(ref cached) = self.vis_cache {
                     cached.clone()

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -619,8 +619,16 @@ impl ReplTuiState {
         self.input.text.get(sel_start..sel_end)
     }
 
+    /// Returns the currently selected input slice with paste masks expanded back
+    /// to their original content.  Used by clipboard copy/cut so the OS clipboard
+    /// receives real text, not the placeholder.
+    fn selected_input_text_expanded(&self) -> Option<String> {
+        let raw = self.selected_input_text()?.to_string();
+        Some(expand_masks(&raw, &self.input.pastes))
+    }
+
     fn cut_input_selection_text(&mut self) -> Option<String> {
-        let text = self.selected_input_text()?.to_string();
+        let text = self.selected_input_text_expanded()?;
         self.record_input_undo_snapshot();
         self.delete_selection_range();
         Some(text)
@@ -3094,13 +3102,9 @@ fn run_loop(
                             if state.input_selection.is_some() =>
                         {
                             // Copy selected text to clipboard.
-                            if let Some((a, b)) = state.input_selection {
-                                let sel_start = state.input_char_to_byte(a);
-                                let sel_end = state.input_char_to_byte(b);
-                                if let Some(text) = state.input.text.get(sel_start..sel_end) {
-                                    if let Ok(mut cb) = arboard::Clipboard::new() {
-                                        let _ = cb.set_text(text.to_string());
-                                    }
+                            if let Some(text) = state.selected_input_text_expanded() {
+                                if let Ok(mut cb) = arboard::Clipboard::new() {
+                                    let _ = cb.set_text(text);
                                 }
                             }
                             state.input_selection = None;
@@ -3220,9 +3224,9 @@ fn run_loop(
                         && key.modifiers.contains(KeyModifiers::CONTROL))
                         || (key.code == KeyCode::Insert && key.modifiers == KeyModifiers::CONTROL))
                 {
-                    if let Some(text) = state.selected_input_text() {
+                    if let Some(text) = state.selected_input_text_expanded() {
                         if let Ok(mut cb) = arboard::Clipboard::new() {
-                            let _ = cb.set_text(text.to_string());
+                            let _ = cb.set_text(text);
                         }
                     }
                     state.input_selection = None;
@@ -4395,6 +4399,22 @@ mod tests {
 
         assert_eq!(state.input_selection, Some((0, 5)));
         assert_eq!(state.input.cursor, 5);
+    }
+
+    #[test]
+    fn copy_selection_yanks_expanded_content() {
+        let mut s = test_state();
+        s.insert_input_str("a ");
+        s.insert_paste_mask(&"z".repeat(600));
+        s.insert_input_str(" b");
+
+        // Select the whole input.
+        let total = s.input.text.chars().count();
+        s.input_selection = Some((0, total));
+
+        let yanked = s.selected_input_text_expanded().unwrap();
+        assert!(yanked.contains(&"z".repeat(600)));
+        assert!(!yanked.contains("[#1 Pasted"));
     }
 
     #[test]

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -54,14 +54,18 @@ pub(super) const SLASH_OVERLAY_VISIBLE_ITEMS: usize = 7;
 pub(super) const SLASH_OVERLAY_HINT_TEXT: &str =
     "Up/Down move  Enter accept  Tab complete  Esc close";
 
-fn normalize_pasted_text(text: &str) -> String {
-    text.replace("\r\n", "\n").replace('\r', "\n")
+fn normalize_pasted_text(text: &str) -> std::borrow::Cow<'_, str> {
+    if text.as_bytes().contains(&b'\r') {
+        std::borrow::Cow::Owned(text.replace("\r\n", "\n").replace('\r', "\n"))
+    } else {
+        std::borrow::Cow::Borrowed(text)
+    }
 }
 
 fn read_clipboard_text() -> Option<String> {
     let mut clipboard = arboard::Clipboard::new().ok()?;
     let text = clipboard.get_text().ok()?;
-    Some(normalize_pasted_text(&text))
+    Some(normalize_pasted_text(&text).into_owned())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -973,6 +977,46 @@ impl ReplTuiState {
                 }
                 total += 1;
             } else {
+                if part.is_ascii() {
+                    let len = part.len();
+
+                    let caret_at_end = caret_char_idx == char_cursor + len;
+                    let (n_visual, ends_on_wrap_boundary) = if len <= first_cap {
+                        (1usize, len == first_cap)
+                    } else {
+                        let remaining = len - first_cap;
+                        let full_tail_chunks = remaining / safe_width;
+                        let tail_remainder = remaining % safe_width;
+                        (
+                            1 + full_tail_chunks + usize::from(tail_remainder > 0),
+                            tail_remainder == 0,
+                        )
+                    };
+
+                    if !caret_found
+                        && caret_char_idx >= char_cursor
+                        && caret_char_idx <= char_cursor + len
+                    {
+                        let offset = caret_char_idx - char_cursor;
+                        caret_line = if offset < first_cap {
+                            total
+                        } else {
+                            total + 1 + (offset - first_cap) / safe_width
+                        };
+                        caret_found = true;
+                    }
+
+                    total += n_visual + usize::from(caret_at_end && ends_on_wrap_boundary);
+                    char_cursor += len;
+
+                    if has_more {
+                        char_cursor += 1;
+                    }
+
+                    logical_idx += 1;
+                    continue;
+                }
+
                 let mut col = 0usize;
                 let mut is_first_chunk = true;
                 let mut has_chars = false;
@@ -1494,6 +1538,25 @@ impl ReplTuiState {
                             *is_first_chunk = false;
                         }
                     };
+
+                if !line.is_empty() && line.is_ascii() {
+                    let len = line.len();
+                    let n_visual = if len <= first_line_width {
+                        1usize
+                    } else {
+                        1 + (len - first_line_width).div_ceil(safe_width)
+                    };
+
+                    if visual_line_idx + n_visual <= skip {
+                        visual_line_idx += n_visual;
+                        char_cursor += len;
+                        if has_more {
+                            char_cursor += 1;
+                        }
+                        logical_idx += 1;
+                        continue 'outer;
+                    }
+                }
 
                 if line.is_empty() {
                     if char_cursor == caret_char_idx {
@@ -4037,6 +4100,108 @@ mod tests {
         assert_eq!(normalize_pasted_text("a\rb"), "a\nb");
         assert_eq!(normalize_pasted_text("a\r\nb\rc"), "a\nb\nc");
         assert_eq!(normalize_pasted_text("plain"), "plain");
+    }
+
+    #[test]
+    fn normalize_pasted_text_borrows_clean_input() {
+        assert!(matches!(
+            normalize_pasted_text("plain"),
+            std::borrow::Cow::Borrowed("plain")
+        ));
+    }
+
+    fn count_visual_lines_with_caret_baseline(
+        text: &str,
+        safe_width: usize,
+        caret_char_idx: usize,
+    ) -> (usize, usize) {
+        let mut total = 0usize;
+        let mut caret_line = 0usize;
+        let mut char_cursor = 0usize;
+        let mut caret_found = false;
+        let mut parts = text.split('\n').peekable();
+        let mut logical_idx = 0usize;
+
+        while let Some(part) = parts.next() {
+            let has_more = parts.peek().is_some();
+            let first_cap = safe_width.saturating_sub(if logical_idx == 0 { 2 } else { 0 });
+
+            if part.is_empty() {
+                if !caret_found && char_cursor == caret_char_idx {
+                    caret_line = total;
+                    caret_found = true;
+                }
+                total += 1;
+            } else {
+                let mut col = 0usize;
+                let mut is_first_chunk = true;
+                let mut has_chars = false;
+
+                for c in part.chars() {
+                    if !caret_found && char_cursor == caret_char_idx {
+                        caret_line = total;
+                        caret_found = true;
+                    }
+
+                    let target = if is_first_chunk { first_cap } else { safe_width };
+                    let cw = super::char_display_width(c);
+
+                    if has_chars && col + cw > target {
+                        total += 1;
+                        col = 0;
+                        is_first_chunk = false;
+                    }
+
+                    col += cw;
+                    char_cursor += 1;
+                    has_chars = true;
+
+                    if col >= target {
+                        total += 1;
+                        col = 0;
+                        is_first_chunk = false;
+                        has_chars = false;
+                    }
+                }
+
+                if !caret_found && char_cursor == caret_char_idx {
+                    caret_line = total;
+                    caret_found = true;
+                }
+
+                if has_chars || char_cursor == caret_char_idx {
+                    total += 1;
+                }
+            }
+
+            if has_more {
+                char_cursor += 1;
+            }
+
+            logical_idx += 1;
+        }
+
+        if !caret_found {
+            caret_line = total.saturating_sub(1);
+        }
+
+        (total.max(1), caret_line)
+    }
+
+    #[test]
+    fn count_visual_lines_with_caret_matches_baseline_for_ascii_wraps() {
+        let mut state = ReplTuiState::new();
+        let safe_width = 8;
+        state.input.text = "abcdefghijk\nlmnopqrstuv\nxyz\n123456\nabcdefghi".to_string();
+        let caret_limit = state.input.text.chars().count();
+
+        for caret in 0..=caret_limit {
+            let expected =
+                count_visual_lines_with_caret_baseline(&state.input.text, safe_width, caret);
+            let actual = state.count_visual_lines_with_caret(safe_width, caret);
+
+            assert_eq!(actual, expected, "caret {caret}");
+        }
     }
 
     // ── paste-newline suppression e2e tests ───────────────────────────────────

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -679,6 +679,21 @@ impl ReplTuiState {
         self.delete_selection_range();
         self.clamp_input_cursor();
 
+        // Edge case: if cursor is strictly inside any existing mask, snap to the
+        // nearer boundary before inserting.  Prevents the placeholder from being
+        // inserted mid-placeholder which would break later text.find lookups for
+        // the first mask.
+        let ranges = self.compute_mask_ranges();
+        if let Some(r) = self.mask_containing(self.input.byte_cursor, &ranges) {
+            let snap_to = if self.input.byte_cursor - r.start < r.end - self.input.byte_cursor {
+                r.start
+            } else {
+                r.end
+            };
+            self.input.byte_cursor = snap_to;
+            self.input.cursor = self.input.text[..snap_to].chars().count();
+        }
+
         let id = self.input.next_paste_id;
         self.input.next_paste_id = self.input.next_paste_id.saturating_add(1);
         let placeholder = format_paste_placeholder(id, count_lines(raw));
@@ -4198,6 +4213,24 @@ mod tests {
         assert!(s.mask_containing(r.end, &ranges).is_none());
         assert!(s.mask_containing(r.start + 1, &ranges).is_some());
         assert!(s.mask_containing(r.start + 5, &ranges).is_some());
+    }
+
+    #[test]
+    fn paste_while_cursor_inside_mask_snaps_first() {
+        let mut s = test_state();
+        s.insert_paste_mask(&"a".repeat(600));
+        let ranges = s.compute_mask_ranges();
+        let r = ranges[0].1.clone();
+        // Place cursor strictly inside the first mask.
+        s.input.byte_cursor = r.start + 3;
+        s.input.cursor = s.input.text[..r.start + 3].chars().count();
+
+        s.insert_paste_mask(&"b".repeat(600));
+
+        // Both masks present, neither nested.
+        let ranges = s.compute_mask_ranges();
+        assert_eq!(ranges.len(), 2);
+        assert!(ranges[0].1.end <= ranges[1].1.start);
     }
 
     #[test]

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -643,6 +643,42 @@ impl ReplTuiState {
         self.input_scroll_offset = usize::MAX;
     }
 
+    /// Insert a paste as an atomic masked token.
+    ///
+    /// The pasted text has already been normalised by the caller.  This method:
+    ///   1. Records an undo snapshot.
+    ///   2. Generates a `[#N Pasted ~K lines]` placeholder and appends a trailing
+    ///      space so subsequent typing doesn't visually fuse with the mask.
+    ///   3. Stores the original content in `pastes` for later expansion on submit
+    ///      or clipboard yank.
+    fn insert_paste_mask(&mut self, raw: &str) {
+        self.input_scroll_manual = false;
+        if raw.is_empty() {
+            return;
+        }
+        self.record_input_undo_snapshot();
+        self.delete_selection_range();
+        self.clamp_input_cursor();
+
+        let id = self.input.next_paste_id;
+        self.input.next_paste_id = self.input.next_paste_id.saturating_add(1);
+        let placeholder = format_paste_placeholder(id, count_lines(raw));
+        let to_insert = format!("{placeholder} ");
+
+        self.input.text.insert_str(self.input.byte_cursor, &to_insert);
+        let char_count = to_insert.chars().count();
+        self.input.cursor = self.input.cursor.saturating_add(char_count);
+        self.input.byte_cursor = self.input.byte_cursor.saturating_add(to_insert.len());
+        self.input.preferred_col = None;
+        self.input_scroll_offset = usize::MAX;
+
+        self.input.pastes.push(PasteEntry {
+            id,
+            placeholder,
+            content: raw.to_string(),
+        });
+    }
+
     fn backspace_input_char(&mut self) {
         self.input_scroll_manual = false;
         let had_selection = self.input_selection.is_some();
@@ -3774,6 +3810,44 @@ mod tests {
         assert_eq!(s.input.pastes.len(), 1);
         assert_eq!(s.input.pastes[0].content, "line1\nline2\nline3");
         assert_eq!(s.input.next_paste_id, 2);
+    }
+
+    #[test]
+    fn insert_paste_mask_inserts_placeholder_and_records_entry() {
+        let mut s = test_state();
+        s.input.text = "prefix ".to_string();
+        s.input.cursor = s.input.text.chars().count();
+        s.resync_byte_cursor();
+
+        let content = "line1\nline2\nline3\n".repeat(40); // > 500 bytes, many lines
+        s.insert_paste_mask(&content);
+
+        assert_eq!(s.input.pastes.len(), 1);
+        let entry = &s.input.pastes[0];
+        assert_eq!(entry.id, 1);
+        assert!(entry.placeholder.starts_with("[#1 Pasted ~"));
+        assert_eq!(entry.content, content);
+        assert!(s.input.text.starts_with("prefix "));
+        assert!(s.input.text.contains(&entry.placeholder));
+        // Trailing space appended after the placeholder.
+        assert!(s.input.text.ends_with(' '));
+        // Cursor sits past the trailing space.
+        assert_eq!(s.input.cursor, s.input.text.chars().count());
+        assert_eq!(s.input.byte_cursor, s.input.text.len());
+        assert_eq!(s.input.next_paste_id, 2);
+    }
+
+    #[test]
+    fn insert_paste_mask_increments_id_for_consecutive_pastes() {
+        let mut s = test_state();
+        let big = "x".repeat(600);
+        s.insert_paste_mask(&big);
+        s.insert_paste_mask(&big);
+        assert_eq!(s.input.pastes.len(), 2);
+        assert_eq!(s.input.pastes[0].id, 1);
+        assert_eq!(s.input.pastes[1].id, 2);
+        assert!(s.input.text.contains("[#1 Pasted"));
+        assert!(s.input.text.contains("[#2 Pasted"));
     }
 
     fn assert_matching_lengths(items: &[ratatui::widgets::ListItem<'static>], text: &[String]) {

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -946,6 +946,88 @@ impl ReplTuiState {
         lines
     }
 
+    /// Counts total visual lines and locates the caret's visual line index in a
+    /// single O(n) pass with **no heap allocation**.  Used by
+    /// `calculate_input_dimensions` so the render path never triggers the
+    /// allocating `visual_line_info` scan.
+    fn count_visual_lines_with_caret(
+        &self,
+        safe_width: usize,
+        caret_char_idx: usize,
+    ) -> (usize, usize) {
+        let mut total = 0usize;
+        let mut caret_line = 0usize;
+        let mut char_cursor = 0usize;
+        let mut caret_found = false;
+        let mut parts = self.input.text.split('\n').peekable();
+        let mut logical_idx = 0usize;
+
+        while let Some(part) = parts.next() {
+            let has_more = parts.peek().is_some();
+            let first_cap = safe_width.saturating_sub(if logical_idx == 0 { 2 } else { 0 });
+
+            if part.is_empty() {
+                if !caret_found && char_cursor == caret_char_idx {
+                    caret_line = total;
+                    caret_found = true;
+                }
+                total += 1;
+            } else {
+                let mut col = 0usize;
+                let mut is_first_chunk = true;
+                let mut has_chars = false;
+
+                for c in part.chars() {
+                    if !caret_found && char_cursor == caret_char_idx {
+                        caret_line = total;
+                        caret_found = true;
+                    }
+
+                    let target = if is_first_chunk { first_cap } else { safe_width };
+                    let cw = char_display_width(c);
+
+                    if has_chars && col + cw > target {
+                        total += 1;
+                        col = 0;
+                        is_first_chunk = false;
+                    }
+
+                    col += cw;
+                    char_cursor += 1;
+                    has_chars = true;
+
+                    if col >= target {
+                        total += 1;
+                        col = 0;
+                        is_first_chunk = false;
+                        has_chars = false;
+                    }
+                }
+
+                if !caret_found && char_cursor == caret_char_idx {
+                    caret_line = total;
+                    caret_found = true;
+                }
+
+                if has_chars || char_cursor == caret_char_idx {
+                    total += 1;
+                }
+            }
+
+            if has_more {
+                char_cursor += 1;
+            }
+
+            logical_idx += 1;
+        }
+
+        if !caret_found {
+            caret_line = total.saturating_sub(1);
+        }
+
+        (total.max(1), caret_line)
+    }
+
     fn move_input_cursor_up(&mut self) {
         self.move_input_cursor_up_inner();
     }
@@ -1248,19 +1330,10 @@ impl ReplTuiState {
         let safe_width = width.saturating_sub(5).max(5) as usize;
         let max_text_lines = MAX_INPUT_LINES;
 
-        let vis_for_count = if is_placeholder {
-            Vec::new()
+        let (total_visual, caret_visual_line) = if is_placeholder {
+            (1usize, 0usize)
         } else {
-            self.visual_line_info(safe_width)
-        };
-        let total_visual = vis_for_count.len().max(1);
-        let caret_cursor = self.input.cursor;
-        let caret_visual_line = if is_placeholder || vis_for_count.is_empty() {
-            0
-        } else {
-            vis_for_count
-                .partition_point(|(s, _, _)| *s <= caret_cursor)
-                .saturating_sub(1)
+            self.count_visual_lines_with_caret(safe_width, self.input.cursor)
         };
 
         let max_scroll = total_visual.saturating_sub(max_text_lines);
@@ -1508,7 +1581,19 @@ impl ReplTuiState {
         let visual_ranges: Vec<(usize, usize)> = if is_placeholder {
             vec![(0, 0); visual_lines.len()]
         } else {
-            let vis = self.visual_line_info_capped(safe_width, skip + max_text_lines + 1);
+            // Fast path: if vis_cache is warm (populated by a navigation event),
+            // slice the needed entries directly — O(1).
+            // Cold path (e.g. right after paste, before any navigation): fall back
+            // to the early-exit capped scan — O(chars up to skip+max_text_lines).
+            let vis = if self.vis_cache_width == safe_width {
+                if let Some(ref cached) = self.vis_cache {
+                    cached.clone()
+                } else {
+                    self.visual_line_info_capped(safe_width, skip + max_text_lines + 1)
+                }
+            } else {
+                self.visual_line_info_capped(safe_width, skip + max_text_lines + 1)
+            };
             vis.iter()
                 .enumerate()
                 .map(|(idx, &(start, _, _))| {

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -87,6 +87,12 @@ fn format_paste_placeholder(id: u32, line_count: usize) -> String {
 /// Replace each paste mask's placeholder with its original content.  Used at
 /// submit time so the model receives the full pasted text, and at clipboard
 /// yank time so copying the input bar produces the original content.
+///
+/// Known limitation: if the user manually types text that exactly matches a
+/// live placeholder (e.g. `[#1 Pasted ~5 lines]` character-for-character), that
+/// typed text will also be replaced with the paste content.  This is rare in
+/// practice — the per-prompt `#N` index and the specific bracket+tilde format
+/// make accidental collisions unlikely.
 fn expand_masks(text: &str, pastes: &[PasteEntry]) -> String {
     let mut out = text.to_string();
     for p in pastes {
@@ -684,7 +690,7 @@ impl ReplTuiState {
         // inserted mid-placeholder which would break later text.find lookups for
         // the first mask.
         let ranges = self.compute_mask_ranges();
-        if let Some(r) = self.mask_containing(self.input.byte_cursor, &ranges) {
+        if let Some(r) = Self::mask_containing(self.input.byte_cursor, &ranges) {
             let snap_to = if self.input.byte_cursor - r.start < r.end - self.input.byte_cursor {
                 r.start
             } else {
@@ -782,7 +788,6 @@ impl ReplTuiState {
     /// position is at a boundary or outside any mask.  Boundaries are valid cursor
     /// positions; only interior positions need to be snapped.
     fn mask_containing(
-        &self,
         byte_pos: usize,
         ranges: &[(usize, std::ops::Range<usize>)],
     ) -> Option<std::ops::Range<usize>> {
@@ -937,7 +942,7 @@ impl ReplTuiState {
         self.input_scroll_offset = usize::MAX;
         // Atomic-mask snap: if we landed strictly inside any mask, jump to its start.
         let ranges = self.compute_mask_ranges();
-        if let Some(r) = self.mask_containing(self.input.byte_cursor, &ranges) {
+        if let Some(r) = Self::mask_containing(self.input.byte_cursor, &ranges) {
             self.input.byte_cursor = r.start;
             self.input.cursor = self.input.text[..r.start].chars().count();
         }
@@ -962,7 +967,7 @@ impl ReplTuiState {
         self.input_scroll_offset = usize::MAX;
         // Atomic-mask snap: if we landed strictly inside any mask, jump to its end.
         let ranges = self.compute_mask_ranges();
-        if let Some(r) = self.mask_containing(self.input.byte_cursor, &ranges) {
+        if let Some(r) = Self::mask_containing(self.input.byte_cursor, &ranges) {
             self.input.byte_cursor = r.end;
             self.input.cursor = self.input.text[..r.end].chars().count();
         }
@@ -1065,7 +1070,7 @@ impl ReplTuiState {
         self.move_input_cursor_up_inner();
         // Atomic-mask snap: up = treat like left = snap to start.
         let ranges = self.compute_mask_ranges();
-        if let Some(r) = self.mask_containing(self.input.byte_cursor, &ranges) {
+        if let Some(r) = Self::mask_containing(self.input.byte_cursor, &ranges) {
             self.input.byte_cursor = r.start;
             self.input.cursor = self.input.text[..r.start].chars().count();
         }
@@ -1140,7 +1145,7 @@ impl ReplTuiState {
         self.move_input_cursor_down_inner();
         // Atomic-mask snap: down = treat like right = snap to end.
         let ranges = self.compute_mask_ranges();
-        if let Some(r) = self.mask_containing(self.input.byte_cursor, &ranges) {
+        if let Some(r) = Self::mask_containing(self.input.byte_cursor, &ranges) {
             self.input.byte_cursor = r.end;
             self.input.cursor = self.input.text[..r.end].chars().count();
         }
@@ -4209,10 +4214,72 @@ mod tests {
         let ranges = s.compute_mask_ranges();
         let r = ranges[0].1.clone();
 
-        assert!(s.mask_containing(r.start, &ranges).is_none());
-        assert!(s.mask_containing(r.end, &ranges).is_none());
-        assert!(s.mask_containing(r.start + 1, &ranges).is_some());
-        assert!(s.mask_containing(r.start + 5, &ranges).is_some());
+        assert!(ReplTuiState::mask_containing(r.start, &ranges).is_none());
+        assert!(ReplTuiState::mask_containing(r.end, &ranges).is_none());
+        assert!(ReplTuiState::mask_containing(r.start + 1, &ranges).is_some());
+        assert!(ReplTuiState::mask_containing(r.start + 5, &ranges).is_some());
+    }
+
+    #[test]
+    fn next_paste_id_resets_to_one_after_submit() {
+        let mut s = test_state();
+        s.insert_paste_mask(&"x".repeat(600));
+        s.insert_paste_mask(&"y".repeat(600));
+        assert_eq!(s.input.next_paste_id, 3);
+
+        // Simulate submit-path reset (mirrors the production code).
+        let raw_line = std::mem::take(&mut s.input.text);
+        let _line = expand_masks(&raw_line, &s.input.pastes);
+        s.input.pastes.clear();
+        s.input.next_paste_id = 1;
+
+        assert!(s.input.pastes.is_empty());
+        assert_eq!(s.input.next_paste_id, 1);
+
+        // A fresh paste should now get id #1 again.
+        s.insert_paste_mask(&"z".repeat(600));
+        assert_eq!(s.input.pastes[0].id, 1);
+    }
+
+    #[test]
+    fn up_arrow_into_mask_snaps_to_mask_start() {
+        let mut s = test_state();
+        // Build a multi-line input so up-arrow has somewhere to go.
+        s.insert_input_str("first line\n");
+        s.insert_paste_mask(&"y".repeat(600));
+        // Cursor is past the trailing space after the placeholder; up-arrow from
+        // here lands on the previous (first) line if mask isn't on its own line,
+        // OR if the mask spans where up would land, it must snap to mask start.
+        // Position cursor at the END of the input text and press up.
+        s.move_input_cursor_up();
+
+        // After up, byte_cursor should not fall strictly inside the mask.
+        let ranges = s.compute_mask_ranges();
+        for (_, r) in &ranges {
+            assert!(
+                !(s.input.byte_cursor > r.start && s.input.byte_cursor < r.end),
+                "cursor should not land strictly inside a mask after up-arrow"
+            );
+        }
+    }
+
+    #[test]
+    fn down_arrow_into_mask_snaps_to_mask_end() {
+        let mut s = test_state();
+        s.insert_input_str("first line\n");
+        s.insert_paste_mask(&"y".repeat(600));
+        // Move cursor up to the first line, then back down — it should not land
+        // inside the mask either way.
+        s.move_input_cursor_up();
+        s.move_input_cursor_down();
+
+        let ranges = s.compute_mask_ranges();
+        for (_, r) in &ranges {
+            assert!(
+                !(s.input.byte_cursor > r.start && s.input.byte_cursor < r.end),
+                "cursor should not land strictly inside a mask after up+down round-trip"
+            );
+        }
     }
 
     #[test]

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -165,6 +165,11 @@ struct InputEditorState {
     /// when the cursor is set directly (clamp / `set_line_col`).
     byte_cursor: usize,
     preferred_col: Option<usize>,
+    /// Active paste masks, in insertion order.  Empty when no pastes are masked.
+    pastes: Vec<PasteEntry>,
+    /// Monotonically increases as masks are inserted within one prompt; reset to
+    /// 1 on submit, clear, or new-prompt boundary.
+    next_paste_id: u32,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -173,6 +178,19 @@ struct InputUndoSnapshot {
     cursor: usize,
     preferred_col: Option<usize>,
     selection: Option<(usize, usize)>,
+    pastes: Vec<PasteEntry>,
+    next_paste_id: u32,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct PasteEntry {
+    /// 1-based, per-prompt index. Resets to 1 on submit / clear.
+    id: u32,
+    /// Visible placeholder, e.g. "[#1 Pasted ~42 lines]".
+    /// Uniqueness is guaranteed by `id`, so `text.find(&placeholder)` is safe.
+    placeholder: String,
+    /// Original pasted content (after newline normalisation).
+    content: String,
 }
 
 #[derive(Default)]
@@ -281,6 +299,8 @@ impl ReplTuiState {
                 cursor: 0,
                 byte_cursor: 0,
                 preferred_col: None,
+                pastes: Vec::new(),
+                next_paste_id: 1,
             },
             status_line: String::new(),
             busy: false,
@@ -417,6 +437,8 @@ impl ReplTuiState {
             cursor: self.input.cursor,
             preferred_col: self.input.preferred_col,
             selection: self.input_selection,
+            pastes: self.input.pastes.clone(),
+            next_paste_id: self.input.next_paste_id,
         }
     }
 
@@ -427,6 +449,8 @@ impl ReplTuiState {
         self.input.preferred_col = snapshot.preferred_col;
         self.input_selection = snapshot.selection;
         self.input_click_anchor = None;
+        self.input.pastes = snapshot.pastes;
+        self.input.next_paste_id = snapshot.next_paste_id;
         self.resync_byte_cursor();
         self.input_scroll_offset = usize::MAX;
     }
@@ -3666,7 +3690,37 @@ mod tests {
     use ratatui::style::Color;
     use ratatui::text::Line;
 
-    use super::{ReplTuiState, ToolCallStatus, TranscriptEntry};
+    use super::{PasteEntry, ReplTuiState, ToolCallStatus, TranscriptEntry};
+
+    /// Smallest valid `ReplTuiState` for paste-masking unit tests.
+    fn test_state() -> ReplTuiState {
+        ReplTuiState::new()
+    }
+
+    #[test]
+    fn snapshot_roundtrip_preserves_pastes() {
+        let mut s = test_state();
+        s.input.text = "hello [#1 Pasted ~3 lines] world".to_string();
+        s.input.cursor = s.input.text.chars().count();
+        s.resync_byte_cursor();
+        s.input.pastes.push(PasteEntry {
+            id: 1,
+            placeholder: "[#1 Pasted ~3 lines]".to_string(),
+            content: "line1\nline2\nline3".to_string(),
+        });
+        s.input.next_paste_id = 2;
+
+        let snap = s.current_input_snapshot();
+        s.input.text.clear();
+        s.input.pastes.clear();
+        s.input.next_paste_id = 1;
+        s.apply_input_snapshot(snap);
+
+        assert_eq!(s.input.text, "hello [#1 Pasted ~3 lines] world");
+        assert_eq!(s.input.pastes.len(), 1);
+        assert_eq!(s.input.pastes[0].content, "line1\nline2\nline3");
+        assert_eq!(s.input.next_paste_id, 2);
+    }
 
     fn assert_matching_lengths(items: &[ratatui::widgets::ListItem<'static>], text: &[String]) {
         assert_eq!(items.len(), text.len());

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -1787,6 +1787,11 @@ impl ReplTuiState {
     }
 
     fn refresh_slash_overlay(&mut self) {
+        if !self.input.text.trim_start().starts_with('/') {
+            self.slash_overlay = None;
+            self.last_slash_overlay_rect = None;
+            return;
+        }
         let trimmed = self.input.text.trim();
         if !trimmed.starts_with('/') || trimmed.contains(char::is_whitespace) {
             self.slash_overlay = None;

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -84,6 +84,17 @@ fn format_paste_placeholder(id: u32, line_count: usize) -> String {
     format!("[#{id} Pasted ~{line_count} lines]")
 }
 
+/// Replace each paste mask's placeholder with its original content.  Used at
+/// submit time so the model receives the full pasted text, and at clipboard
+/// yank time so copying the input bar produces the original content.
+fn expand_masks(text: &str, pastes: &[PasteEntry]) -> String {
+    let mut out = text.to_string();
+    for p in pastes {
+        out = out.replace(&p.placeholder, &p.content);
+    }
+    out
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum AppUiState {
     WelcomeMode,
@@ -3674,11 +3685,14 @@ fn run_loop(
                             }
                         }
 
-                        let line = std::mem::take(&mut state.input.text);
+                        let raw_line = std::mem::take(&mut state.input.text);
+                        let line = expand_masks(&raw_line, &state.input.pastes);
                         state.input.cursor = 0;
                         state.input.byte_cursor = 0;
                         state.input.preferred_col = None;
                         state.input_scroll_offset = 0;
+                        state.input.pastes.clear();
+                        state.input.next_paste_id = 1;
                         state.clear_input_history();
                         let trimmed = line.trim().to_string();
                         state.refresh_slash_overlay();
@@ -3861,8 +3875,8 @@ mod tests {
     use ratatui::text::Line;
 
     use super::{
-        count_lines, format_paste_placeholder, normalize_pasted_text, should_mask_paste,
-        PasteEntry, ReplTuiState, ToolCallStatus, TranscriptEntry,
+        count_lines, expand_masks, format_paste_placeholder, normalize_pasted_text,
+        should_mask_paste, PasteEntry, ReplTuiState, ToolCallStatus, TranscriptEntry,
     };
 
     /// Smallest valid `ReplTuiState` for paste-masking unit tests.
@@ -3899,6 +3913,47 @@ mod tests {
     fn format_paste_placeholder_matches_format() {
         assert_eq!(format_paste_placeholder(1, 1), "[#1 Pasted ~1 lines]");
         assert_eq!(format_paste_placeholder(42, 137), "[#42 Pasted ~137 lines]");
+    }
+
+    #[test]
+    fn expand_masks_substitutes_original_content() {
+        let pastes = vec![
+            PasteEntry {
+                id: 1,
+                placeholder: "[#1 Pasted ~3 lines]".to_string(),
+                content: "alpha\nbeta\ngamma".to_string(),
+            },
+            PasteEntry {
+                id: 2,
+                placeholder: "[#2 Pasted ~2 lines]".to_string(),
+                content: "x\ny".to_string(),
+            },
+        ];
+        let visible = "hi [#1 Pasted ~3 lines] and [#2 Pasted ~2 lines] ok";
+        assert_eq!(
+            expand_masks(visible, &pastes),
+            "hi alpha\nbeta\ngamma and x\ny ok"
+        );
+    }
+
+    #[test]
+    fn expand_masks_is_idempotent_for_no_pastes() {
+        assert_eq!(expand_masks("plain text", &[]), "plain text");
+    }
+
+    #[test]
+    fn submit_expands_masks_before_dispatch() {
+        let mut s = test_state();
+        s.insert_input_str("please summarise: ");
+        let body = "x".repeat(600);
+        s.insert_paste_mask(&body);
+
+        // Simulate the submit-path text-extraction logic.
+        let raw_line = std::mem::take(&mut s.input.text);
+        let line = expand_masks(&raw_line, &s.input.pastes);
+
+        assert!(line.contains(&body));
+        assert!(!line.contains("[#1 Pasted"));
     }
 
     #[test]

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -838,6 +838,12 @@ impl ReplTuiState {
         self.input.cursor -= 1;
         self.input.preferred_col = None;
         self.input_scroll_offset = usize::MAX;
+        // Atomic-mask snap: if we landed strictly inside any mask, jump to its start.
+        let ranges = self.compute_mask_ranges();
+        if let Some(r) = self.mask_containing(self.input.byte_cursor, &ranges) {
+            self.input.byte_cursor = r.start;
+            self.input.cursor = self.input.text[..r.start].chars().count();
+        }
     }
 
     fn move_input_cursor_right(&mut self) {
@@ -857,6 +863,12 @@ impl ReplTuiState {
         self.input.cursor += 1;
         self.input.preferred_col = None;
         self.input_scroll_offset = usize::MAX;
+        // Atomic-mask snap: if we landed strictly inside any mask, jump to its end.
+        let ranges = self.compute_mask_ranges();
+        if let Some(r) = self.mask_containing(self.input.byte_cursor, &ranges) {
+            self.input.byte_cursor = r.end;
+            self.input.cursor = self.input.text[..r.end].chars().count();
+        }
     }
 
     fn move_input_cursor_home(&mut self) {
@@ -953,6 +965,16 @@ impl ReplTuiState {
     }
 
     fn move_input_cursor_up(&mut self) {
+        self.move_input_cursor_up_inner();
+        // Atomic-mask snap: up = treat like left = snap to start.
+        let ranges = self.compute_mask_ranges();
+        if let Some(r) = self.mask_containing(self.input.byte_cursor, &ranges) {
+            self.input.byte_cursor = r.start;
+            self.input.cursor = self.input.text[..r.start].chars().count();
+        }
+    }
+
+    fn move_input_cursor_up_inner(&mut self) {
         // Fall back to logical-line navigation until the widget width is known
         // (first render hasn't happened yet).
         if self.input_area_width == 0 {
@@ -1018,6 +1040,16 @@ impl ReplTuiState {
     }
 
     fn move_input_cursor_down(&mut self) {
+        self.move_input_cursor_down_inner();
+        // Atomic-mask snap: down = treat like right = snap to end.
+        let ranges = self.compute_mask_ranges();
+        if let Some(r) = self.mask_containing(self.input.byte_cursor, &ranges) {
+            self.input.byte_cursor = r.end;
+            self.input.cursor = self.input.text[..r.end].chars().count();
+        }
+    }
+
+    fn move_input_cursor_down_inner(&mut self) {
         // Fall back to logical-line navigation until the widget width is known.
         if self.input_area_width == 0 {
             self.move_input_cursor_down_logical();
@@ -3963,6 +3995,39 @@ mod tests {
         assert_eq!(s.input.pastes.len(), 1);
         assert!(!s.input.pastes[0].content.contains('\r'));
         assert!(s.input.pastes[0].content.contains('\n'));
+    }
+
+    #[test]
+    fn left_arrow_at_mask_end_snaps_to_mask_start() {
+        let mut s = test_state();
+        s.insert_paste_mask(&"x".repeat(600));
+        let ranges = s.compute_mask_ranges();
+        let r = ranges[0].1.clone();
+
+        // Position cursor exactly at mask end (it currently sits past the trailing space).
+        s.input.byte_cursor = r.end;
+        s.input.cursor = s.input.text[..r.end].chars().count();
+
+        s.move_input_cursor_left();
+
+        assert_eq!(s.input.byte_cursor, r.start);
+        assert_eq!(s.input.cursor, s.input.text[..r.start].chars().count());
+    }
+
+    #[test]
+    fn right_arrow_at_mask_start_snaps_to_mask_end() {
+        let mut s = test_state();
+        s.insert_input_str("hi ");
+        s.insert_paste_mask(&"x".repeat(600));
+        let ranges = s.compute_mask_ranges();
+        let r = ranges[0].1.clone();
+
+        s.input.byte_cursor = r.start;
+        s.input.cursor = s.input.text[..r.start].chars().count();
+
+        s.move_input_cursor_right();
+
+        assert_eq!(s.input.byte_cursor, r.end);
     }
 
     #[test]

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -215,6 +215,11 @@ pub(super) struct ReplTuiState {
     /// Cached width (columns) of the input widget from the last render pass.
     /// Used by cursor up/down to compute soft-wrap boundaries.
     pub(super) input_area_width: u16,
+    /// Cached result of `visual_line_info` for the current self.input.text.
+    /// None means stale; recomputed on next access.
+    vis_cache: Option<Vec<(usize, usize, bool)>>,
+    /// The `safe_width` at which `vis_cache` was last computed.
+    vis_cache_width: usize,
     input: InputEditorState,
     status_line: String,
     pub(super) busy: bool,
@@ -276,6 +281,8 @@ impl ReplTuiState {
             input_selection: None,
             input_click_anchor: None,
             input_area_width: 0,
+            vis_cache: None,
+            vis_cache_width: 0,
             input: InputEditorState {
                 text: String::new(),
                 cursor: 0,
@@ -418,6 +425,7 @@ impl ReplTuiState {
     fn apply_input_snapshot(&mut self, snapshot: InputUndoSnapshot) {
         self.input_scroll_manual = false;
         self.input.text = snapshot.text;
+        self.vis_cache = None;
         self.input.cursor = snapshot.cursor.min(self.input_char_len());
         self.input.preferred_col = snapshot.preferred_col;
         self.input_selection = snapshot.selection;
@@ -446,6 +454,7 @@ impl ReplTuiState {
 
     fn reset_input(&mut self) {
         self.input.text.clear();
+        self.vis_cache = None;
         self.input.cursor = 0;
         self.input.byte_cursor = 0;
         self.input.preferred_col = None;
@@ -484,6 +493,7 @@ impl ReplTuiState {
             return;
         }
         self.input.text.replace_range(del_start..bc, "");
+        self.vis_cache = None;
         self.input.byte_cursor = del_start;
         self.input.cursor = self.input.text[..del_start].chars().count();
         self.input.preferred_col = None;
@@ -554,6 +564,7 @@ impl ReplTuiState {
             self.input
                 .text
                 .replace_range(self.input.byte_cursor..end_byte, "");
+            self.vis_cache = None;
             self.input.preferred_col = None;
             self.input_scroll_offset = usize::MAX;
             true
@@ -586,6 +597,7 @@ impl ReplTuiState {
         self.delete_selection_range();
         self.clamp_input_cursor();
         self.input.text.insert(self.input.byte_cursor, ch);
+        self.vis_cache = None;
         self.input.cursor = self.input.cursor.saturating_add(1);
         self.input.byte_cursor = self.input.byte_cursor.saturating_add(ch.len_utf8());
         self.input.preferred_col = None;
@@ -601,6 +613,7 @@ impl ReplTuiState {
         self.delete_selection_range();
         self.clamp_input_cursor();
         self.input.text.insert_str(self.input.byte_cursor, text);
+        self.vis_cache = None;
         let char_count = text.chars().count();
         self.input.cursor = self.input.cursor.saturating_add(char_count);
         self.input.byte_cursor = self.input.byte_cursor.saturating_add(text.len());
@@ -695,6 +708,7 @@ impl ReplTuiState {
         let start = prev_byte;
         let end = self.input.byte_cursor;
         self.input.text.replace_range(start..end, "");
+        self.vis_cache = None;
         self.input.cursor -= 1;
         self.input.byte_cursor = start;
         self.input.preferred_col = None;
@@ -720,6 +734,7 @@ impl ReplTuiState {
         self.input
             .text
             .replace_range(self.input.byte_cursor..end, "");
+        self.vis_cache = None;
         self.input.preferred_col = None;
         self.input_scroll_offset = usize::MAX;
     }
@@ -841,8 +856,16 @@ impl ReplTuiState {
     ///
     /// Callers use `starts_paragraph` instead of re-scanning the text with
     /// `chars().nth()` to check for a trailing `\n` at a line boundary.
-    fn visual_line_info(&self, safe_width: usize) -> Vec<(usize, usize, bool)> {
-        self.visual_line_info_capped(safe_width, usize::MAX)
+    fn visual_line_info(&mut self, safe_width: usize) -> Vec<(usize, usize, bool)> {
+        if self.vis_cache_width == safe_width {
+            if let Some(ref cached) = self.vis_cache {
+                return cached.clone();
+            }
+        }
+        let vis = self.visual_line_info_capped(safe_width, usize::MAX);
+        self.vis_cache_width = safe_width;
+        self.vis_cache = Some(vis.clone());
+        vis
     }
 
     fn visual_line_info_capped(
@@ -921,88 +944,6 @@ impl ReplTuiState {
             logical_idx += 1;
         }
         lines
-    }
-
-    fn count_visual_lines_with_caret(
-        &self,
-        safe_width: usize,
-        caret_char_idx: usize,
-    ) -> (usize, usize) {
-        let mut total = 0usize;
-        let mut caret_line = 0usize;
-        let mut char_cursor = 0usize;
-        let mut caret_found = false;
-        let mut parts = self.input.text.split('\n').peekable();
-        let mut logical_idx = 0usize;
-
-        while let Some(part) = parts.next() {
-            let has_more = parts.peek().is_some();
-            let first_cap = safe_width.saturating_sub(if logical_idx == 0 { 2 } else { 0 });
-
-            if part.is_empty() {
-                if !caret_found && char_cursor == caret_char_idx {
-                    caret_line = total;
-                    caret_found = true;
-                }
-                total += 1;
-            } else {
-                let mut col = 0usize;
-                let mut is_first_chunk = true;
-                let mut has_chars = false;
-
-                for c in part.chars() {
-                    if !caret_found && char_cursor == caret_char_idx {
-                        caret_line = total;
-                        caret_found = true;
-                    }
-
-                    let target = if is_first_chunk {
-                        first_cap
-                    } else {
-                        safe_width
-                    };
-                    let cw = char_display_width(c);
-
-                    if has_chars && col + cw > target {
-                        total += 1;
-                        col = 0;
-                        is_first_chunk = false;
-                    }
-
-                    col += cw;
-                    char_cursor += 1;
-                    has_chars = true;
-
-                    if col >= target {
-                        total += 1;
-                        col = 0;
-                        is_first_chunk = false;
-                        has_chars = false;
-                    }
-                }
-
-                if !caret_found && char_cursor == caret_char_idx {
-                    caret_line = total;
-                    caret_found = true;
-                }
-
-                if has_chars || char_cursor == caret_char_idx {
-                    total += 1;
-                }
-            }
-
-            if has_more {
-                char_cursor += 1;
-            }
-
-            logical_idx += 1;
-        }
-
-        if !caret_found {
-            caret_line = total.saturating_sub(1);
-        }
-
-        (total.max(1), caret_line)
     }
 
     fn move_input_cursor_up(&mut self) {
@@ -1160,7 +1101,7 @@ impl ReplTuiState {
     /// Convert a mouse position (row, col) relative to the input widget into
     /// a character index in `input.text`.  Returns `None` if the position
     /// falls outside the text bounds.
-    fn char_index_at_mouse(&self, widget_row: usize, widget_col: usize) -> Option<usize> {
+    fn char_index_at_mouse(&mut self, widget_row: usize, widget_col: usize) -> Option<usize> {
         if widget_row == 0 {
             return None;
         }
@@ -1307,10 +1248,19 @@ impl ReplTuiState {
         let safe_width = width.saturating_sub(5).max(5) as usize;
         let max_text_lines = MAX_INPUT_LINES;
 
-        let (total_visual, caret_visual_line) = if is_placeholder {
-            (1usize, 0usize)
+        let vis_for_count = if is_placeholder {
+            Vec::new()
         } else {
-            self.count_visual_lines_with_caret(safe_width, self.input.cursor)
+            self.visual_line_info(safe_width)
+        };
+        let total_visual = vis_for_count.len().max(1);
+        let caret_cursor = self.input.cursor;
+        let caret_visual_line = if is_placeholder || vis_for_count.is_empty() {
+            0
+        } else {
+            vis_for_count
+                .partition_point(|(s, _, _)| *s <= caret_cursor)
+                .saturating_sub(1)
         };
 
         let max_scroll = total_visual.saturating_sub(max_text_lines);
@@ -3805,6 +3755,7 @@ fn run_loop(
                                     state.record_input_undo_snapshot();
                                     state.input.text = selected;
                                     state.input.text.push(' ');
+                                    state.vis_cache = None;
                                     state.input.cursor = state.input.text.chars().count();
                                     state.resync_byte_cursor();
                                     state.input.preferred_col = None;
@@ -3895,6 +3846,7 @@ fn run_loop(
                             state.record_input_undo_snapshot();
                             state.input.text = selected;
                             state.input.text.push(' ');
+                            state.vis_cache = None;
                             state.input.cursor = state.input.text.chars().count();
                             state.input.preferred_col = None;
                             state.input_scroll_offset = usize::MAX;
@@ -3911,6 +3863,7 @@ fn run_loop(
                                 state.record_input_undo_snapshot();
                                 state.input.text.clone_from(&matches[0]);
                                 state.input.text.push(' ');
+                                state.vis_cache = None;
                                 state.input.cursor = state.input.text.chars().count();
                                 state.input.preferred_col = None;
                                 state.input_scroll_offset = usize::MAX;

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -679,6 +679,18 @@ impl ReplTuiState {
         });
     }
 
+    /// Single entry point for any pasted text, regardless of source (bracketed
+    /// paste, Ctrl+V, Shift+Insert).  Normalises newlines and either masks the
+    /// paste (>= threshold) or inserts it raw.
+    fn handle_paste_event(&mut self, raw: &str) {
+        let normalised = normalize_pasted_text(raw);
+        if should_mask_paste(&normalised) {
+            self.insert_paste_mask(&normalised);
+        } else {
+            self.insert_input_str(&normalised);
+        }
+    }
+
     /// Locate every active paste mask's current byte range in `self.input.text`.
     ///
     /// Returns `(paste_index, byte_range)` pairs sorted by `byte_range.start`.
@@ -3043,7 +3055,7 @@ fn run_loop(
                 // Bracketed paste supersedes any ongoing burst accumulation
                 state.paste_buffer = None;
                 state.last_key_time = None;
-                state.insert_input_str(&normalize_pasted_text(&text));
+                state.handle_paste_event(&text);
                 state.wake_input_caret();
                 state.refresh_slash_overlay();
             }
@@ -3084,7 +3096,7 @@ fn run_loop(
                     state.paste_buffer = None;
                     state.last_key_time = None;
                     if let Some(text) = read_clipboard_text() {
-                        state.insert_input_str(&text);
+                        state.handle_paste_event(&text);
                         state.wake_input_caret();
                         state.refresh_slash_overlay();
                     }
@@ -3918,6 +3930,39 @@ mod tests {
         assert!(s.mask_containing(r.end, &ranges).is_none());
         assert!(s.mask_containing(r.start + 1, &ranges).is_some());
         assert!(s.mask_containing(r.start + 5, &ranges).is_some());
+    }
+
+    #[test]
+    fn large_paste_event_creates_mask_not_raw_text() {
+        let mut s = test_state();
+        let big = "y".repeat(600);
+        s.handle_paste_event(&big);
+
+        assert!(s.input.text.contains("[#1 Pasted ~"));
+        assert!(!s.input.text.contains(&big));
+        assert_eq!(s.input.pastes.len(), 1);
+    }
+
+    #[test]
+    fn small_paste_event_inserts_raw_text() {
+        let mut s = test_state();
+        let small = "short paste".to_string();
+        s.handle_paste_event(&small);
+
+        assert_eq!(s.input.text, "short paste");
+        assert!(s.input.pastes.is_empty());
+    }
+
+    #[test]
+    fn crlf_paste_normalises_to_lf_in_stored_content() {
+        let mut s = test_state();
+        let mut crlf = "a\r\n".repeat(300);
+        crlf.push_str("end");
+        s.handle_paste_event(&crlf);
+
+        assert_eq!(s.input.pastes.len(), 1);
+        assert!(!s.input.pastes[0].content.contains('\r'));
+        assert!(s.input.pastes[0].content.contains('\n'));
     }
 
     #[test]

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -740,6 +740,23 @@ impl ReplTuiState {
         if self.delete_selection_range() {
             return;
         }
+        // Atomic-mask deletion: cursor at a mask's end byte -> drop whole mask.
+        if !had_selection {
+            let ranges = self.compute_mask_ranges();
+            if let Some((idx, r)) = ranges
+                .iter()
+                .find(|(_, r)| r.end == self.input.byte_cursor)
+                .map(|(i, r)| (*i, r.clone()))
+            {
+                self.input.text.replace_range(r.clone(), "");
+                self.input.pastes.remove(idx);
+                self.input.byte_cursor = r.start;
+                self.input.cursor = self.input.text[..r.start].chars().count();
+                self.input.preferred_col = None;
+                self.input_scroll_offset = usize::MAX;
+                return;
+            }
+        }
         // Find byte-offset of the character before cursor
         let prev_byte = if self.input.byte_cursor > 0 {
             // Walk backwards from byte_cursor to the previous char boundary
@@ -771,6 +788,22 @@ impl ReplTuiState {
         self.record_input_undo_snapshot();
         if self.delete_selection_range() {
             return;
+        }
+        // Atomic-mask deletion: cursor at a mask's start byte -> drop whole mask.
+        if !had_selection {
+            let ranges = self.compute_mask_ranges();
+            if let Some((idx, r)) = ranges
+                .iter()
+                .find(|(_, r)| r.start == self.input.byte_cursor)
+                .map(|(i, r)| (*i, r.clone()))
+            {
+                self.input.text.replace_range(r.clone(), "");
+                self.input.pastes.remove(idx);
+                // byte_cursor stays at r.start; char cursor stays the same.
+                self.input.preferred_col = None;
+                self.input_scroll_offset = usize::MAX;
+                return;
+            }
         }
         // Find byte-offset of the character after cursor
         let bytes = self.input.text.as_bytes();
@@ -4540,6 +4573,44 @@ mod tests {
             .join("\n");
 
         assert!(content.contains("Update available: v9.9.9 (you have v1.0.0)"));
+    }
+
+    #[test]
+    fn backspace_at_mask_end_deletes_entire_mask() {
+        let mut s = test_state();
+        s.insert_input_str("hi ");
+        let big = "y".repeat(600);
+        s.insert_paste_mask(&big);
+        // Cursor sits past the trailing space.  Move it back one char to land on
+        // mask end (the boundary between placeholder and the trailing space).
+        let trailing_space_byte = s.input.byte_cursor - 1;
+        s.input.byte_cursor = trailing_space_byte;
+        s.input.cursor -= 1;
+
+        let before_len = s.input.text.len();
+        s.backspace_input_char();
+
+        assert!(!s.input.text.contains("[#1 Pasted"));
+        assert!(s.input.text.len() < before_len);
+        assert!(s.input.pastes.is_empty());
+        // "hi " + trailing space that originally followed the (now-deleted) mask.
+        assert_eq!(s.input.text, "hi  ");
+    }
+
+    #[test]
+    fn delete_at_mask_start_deletes_entire_mask() {
+        let mut s = test_state();
+        s.insert_paste_mask(&"y".repeat(600));
+        // Position cursor at mask start.
+        let ranges = s.compute_mask_ranges();
+        let r = ranges[0].1.clone();
+        s.input.byte_cursor = r.start;
+        s.input.cursor = s.input.text[..r.start].chars().count();
+
+        s.delete_input_char();
+
+        assert!(!s.input.text.contains("[#1 Pasted"));
+        assert!(s.input.pastes.is_empty());
     }
 
     #[test]

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -294,6 +294,14 @@ pub(super) struct ReplTuiState {
     spinner_deadline: Instant,
     pub(super) typewriter: TypewriterState,
     pub(super) selection: SelectionState,
+    /// Accumulator for chars/newlines arriving faster than a human can type
+    /// (≤ 30 ms apart). Flushed via `handle_paste_event` so masking and the
+    /// paste-newline suppression window apply uniformly even on terminals that
+    /// deliver pastes as raw keystrokes instead of `Event::Paste`.
+    paste_burst_chars: Vec<char>,
+    /// Timestamp of the most-recent `KeyCode::Char` or `KeyCode::Enter` event.
+    /// Used to decide whether the next keystroke is part of the same burst.
+    last_key_time: Option<Instant>,
     input_undo_stack: Vec<InputUndoSnapshot>,
     input_redo_stack: Vec<InputUndoSnapshot>,
     last_esc_at: Option<Instant>,
@@ -355,6 +363,8 @@ impl ReplTuiState {
                 chars: VecDeque::new(),
                 live: String::new(),
             },
+            paste_burst_chars: Vec::new(),
+            last_key_time: None,
             selection: SelectionState::default(),
             input_undo_stack: Vec::new(),
             input_redo_stack: Vec::new(),
@@ -762,6 +772,30 @@ impl ReplTuiState {
         } else {
             self.insert_input_str(&normalised);
         }
+    }
+
+    /// Maximum gap (ms) between consecutive keystrokes considered a paste burst.
+    /// Human typing at 150 WPM averages ≈ 80 ms/char; 30 ms is well below
+    /// what any human can sustain.
+    const PASTE_BURST_THRESHOLD_MS: u64 = 30;
+
+    /// True if the previous key event arrived within the paste-burst threshold.
+    fn in_paste_burst(&self, now: Instant) -> bool {
+        self.last_key_time.is_some_and(|t| {
+            now.duration_since(t) <= Duration::from_millis(Self::PASTE_BURST_THRESHOLD_MS)
+        })
+    }
+
+    /// If the burst accumulator has any chars, drain it into the input via
+    /// `handle_paste_event` (which applies masking and newline suppression).
+    /// Called when the burst ends, or before any non-burst-compatible key.
+    fn flush_paste_burst(&mut self) {
+        if self.paste_burst_chars.is_empty() {
+            return;
+        }
+        let chars = std::mem::take(&mut self.paste_burst_chars);
+        let text: String = chars.iter().collect();
+        self.handle_paste_event(&text);
     }
 
     /// Returns true if `key_code` should be suppressed because a paste that
@@ -3024,6 +3058,16 @@ fn run_loop(
     }
 
     loop {
+        // Flush paste-burst buffer when the burst has been idle longer than
+        // the threshold — covers pastes that end without a subsequent key.
+        if !state.paste_burst_chars.is_empty()
+            && state.last_key_time.is_some_and(|t| {
+                t.elapsed() > Duration::from_millis(ReplTuiState::PASTE_BURST_THRESHOLD_MS)
+            })
+        {
+            state.flush_paste_burst();
+        }
+
         state.drain_events(ui_rx);
         state.reconcile_child_view_mode();
 
@@ -3363,6 +3407,9 @@ fn run_loop(
                     continue;
                 }
 
+                // Bracketed paste supersedes any in-flight burst accumulation.
+                state.flush_paste_burst();
+                state.last_key_time = None;
                 state.handle_paste_event(&text);
                 state.wake_input_caret();
                 state.refresh_slash_overlay();
@@ -3373,6 +3420,14 @@ fn run_loop(
                     state.selection.suppress_paste_until =
                         Some(Instant::now() + Duration::from_millis(150));
                     continue;
+                }
+                // Any key that isn't bare Char/Enter ends a paste burst — flush
+                // the buffer here so command handlers (Ctrl-A/Z/Y/W/C/X, etc.)
+                // see a consistent input state.
+                if !matches!(key.code, KeyCode::Char(_) | KeyCode::Enter)
+                    || !key.modifiers.is_empty()
+                {
+                    state.flush_paste_burst();
                 }
                 if state
                     .selection
@@ -3393,6 +3448,9 @@ fn run_loop(
                         || (key.code == KeyCode::Insert
                             && key.modifiers.contains(KeyModifiers::SHIFT)))
                 {
+                    // Manual paste supersedes any in-flight burst accumulation.
+                    state.flush_paste_burst();
+                    state.last_key_time = None;
                     if let Some(text) = read_clipboard_text() {
                         state.handle_paste_event(&text);
                         state.wake_input_caret();
@@ -3833,10 +3891,25 @@ fn run_loop(
                 match key.code {
                     KeyCode::Enter if key.modifiers.contains(KeyModifiers::SHIFT) => {
                         state.insert_input_char('\n');
+                        state.last_key_time = Some(Instant::now());
                         state.wake_input_caret();
                         state.refresh_slash_overlay();
                     }
                     KeyCode::Enter => {
+                        // Paste-burst Enter: if the previous keystroke arrived
+                        // within the burst threshold, treat this Enter as a
+                        // pasted `\n` (accumulate, don't submit).  Handles
+                        // terminals that deliver pastes as raw keystrokes
+                        // instead of `Event::Paste`.
+                        let now = Instant::now();
+                        if state.in_paste_burst(now) {
+                            state.paste_burst_chars.push('\n');
+                            state.last_key_time = Some(now);
+                            state.wake_input_caret();
+                            continue;
+                        }
+                        state.flush_paste_burst();
+                        state.last_key_time = Some(now);
                         // Child tab resume (check before parent pause)
                         if state.child_tab_panel.active_tab_is_paused() {
                             if let Some(child_id) = state.child_tab_panel.active_child_id() {
@@ -3912,11 +3985,18 @@ fn run_loop(
                     }
                     KeyCode::Char('j') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                         state.insert_input_char('\n');
+                        state.last_key_time = Some(Instant::now());
                         state.wake_input_caret();
                         state.refresh_slash_overlay();
                     }
                     KeyCode::Char(c) => {
-                        state.insert_input_char(c);
+                        let now = Instant::now();
+                        if state.in_paste_burst(now) || !state.paste_burst_chars.is_empty() {
+                            state.paste_burst_chars.push(c);
+                        } else {
+                            state.insert_input_char(c);
+                        }
+                        state.last_key_time = Some(now);
                         state.wake_input_caret();
                         state.refresh_slash_overlay();
                     }
@@ -4151,6 +4231,75 @@ mod tests {
             s.paste_enter_is_suppressed(KeyCode::Enter),
             "Enter must still be suppressed even though paste was not masked"
         );
+    }
+
+    #[test]
+    fn paste_burst_helpers_buffer_then_flush_through_handle_paste_event() {
+        // Simulates a raw-keystroke paste from terminals that don't deliver
+        // `Event::Paste`.  We push chars into the burst buffer directly and
+        // verify that flush routes them through handle_paste_event — meaning
+        // the long-paste mask and newline suppression both apply.
+        let mut s = test_state();
+        // Push a 200-char "paste" with a newline in the middle.
+        for ch in "a".repeat(99).chars() {
+            s.paste_burst_chars.push(ch);
+        }
+        s.paste_burst_chars.push('\n');
+        for ch in "b".repeat(100).chars() {
+            s.paste_burst_chars.push(ch);
+        }
+        assert_eq!(s.paste_burst_chars.len(), 200);
+        s.flush_paste_burst();
+        // Buffer is drained.
+        assert!(s.paste_burst_chars.is_empty());
+        // Length ≥ 150 → masked (text shows the placeholder, not raw chars).
+        assert!(
+            s.input.text.contains("[#1 Pasted"),
+            "burst above threshold must flush through the mask path"
+        );
+        // Newline in burst content triggers the Enter-suppression window.
+        assert!(s.paste_enter_is_suppressed(KeyCode::Enter));
+    }
+
+    #[test]
+    fn paste_burst_flush_below_threshold_inserts_raw_with_suppression() {
+        // Short burst with newline → not masked, but newline triggers suppression.
+        let mut s = test_state();
+        for ch in "ab\ncd".chars() {
+            s.paste_burst_chars.push(ch);
+        }
+        s.flush_paste_burst();
+        assert!(s.paste_burst_chars.is_empty());
+        assert!(!s.input.text.contains("[#1 Pasted"));
+        assert_eq!(s.input.text, "ab\ncd");
+        assert!(
+            s.paste_enter_is_suppressed(KeyCode::Enter),
+            "newline in burst content must still arm Enter suppression"
+        );
+    }
+
+    #[test]
+    fn flush_paste_burst_is_a_noop_when_buffer_is_empty() {
+        let mut s = test_state();
+        s.input.text = "hello".to_string();
+        s.input.cursor = 5;
+        s.input.byte_cursor = 5;
+        s.flush_paste_burst();
+        assert_eq!(s.input.text, "hello", "empty buffer flush must not modify text");
+    }
+
+    #[test]
+    fn in_paste_burst_respects_threshold() {
+        let mut s = test_state();
+        let now = std::time::Instant::now();
+        // No previous key recorded → not in burst.
+        assert!(!s.in_paste_burst(now));
+        // Previous key within threshold → in burst.
+        s.last_key_time = Some(now - std::time::Duration::from_millis(10));
+        assert!(s.in_paste_burst(now));
+        // Previous key beyond threshold → not in burst.
+        s.last_key_time = Some(now - std::time::Duration::from_millis(100));
+        assert!(!s.in_paste_burst(now));
     }
 
     #[test]

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -495,6 +495,82 @@ impl ReplTuiState {
         self.input_redo_stack.clear();
     }
 
+    /// Reset all input editor fields atomically. Ensures `text`, cursors,
+    /// `pastes`, and `next_paste_id` always move together so no stale mask
+    /// entries survive a prompt boundary.
+    fn reset_input(&mut self) {
+        self.input.text.clear();
+        self.input.cursor = 0;
+        self.input.byte_cursor = 0;
+        self.input.preferred_col = None;
+        self.input.pastes.clear();
+        self.input.next_paste_id = 1;
+    }
+
+    /// Ctrl-W: delete backward to the previous word boundary, treating each
+    /// paste mask as a single atomic unit (stops at the mask boundary rather
+    /// than scanning inside it).
+    fn word_backspace(&mut self) {
+        self.input_scroll_manual = false;
+        self.clamp_input_cursor();
+        if self.input.cursor == 0 {
+            return;
+        }
+        self.record_input_undo_snapshot();
+        if self.delete_selection_range() {
+            return;
+        }
+        let ranges = self.compute_mask_ranges();
+        // Cursor at a mask's end → delete the whole mask atom (same as backspace).
+        if let Some((idx, r)) = ranges
+            .iter()
+            .find(|(_, r)| r.end == self.input.byte_cursor)
+            .map(|(i, r)| (*i, r.clone()))
+        {
+            let del_end = if self.input.text.len() > r.end
+                && self.input.text.as_bytes()[r.end] == b' '
+            {
+                r.end + 1
+            } else {
+                r.end
+            };
+            self.input.text.replace_range(r.start..del_end, "");
+            self.input.pastes.remove(idx);
+            self.input.byte_cursor = r.start;
+            self.input.cursor = self.input.text[..r.start].chars().count();
+            self.input.preferred_col = None;
+            self.input_scroll_offset = usize::MAX;
+            return;
+        }
+        // Walk backward: skip trailing whitespace, then skip word chars.
+        // Stop at any mask-end boundary so masks are deleted atomically.
+        let bc = self.input.byte_cursor;
+        let chars_before: Vec<(usize, char)> = self.input.text[..bc].char_indices().collect();
+        let mut i = chars_before.len();
+        while i > 0 && chars_before[i - 1].1.is_whitespace() {
+            i -= 1;
+        }
+        while i > 0 {
+            let (byte_pos, ch) = chars_before[i - 1];
+            if ch.is_whitespace() {
+                break;
+            }
+            if ranges.iter().any(|(_, r)| r.end == byte_pos) {
+                break;
+            }
+            i -= 1;
+        }
+        let del_start = if i < chars_before.len() { chars_before[i].0 } else { bc };
+        if del_start == bc {
+            return;
+        }
+        self.input.text.replace_range(del_start..bc, "");
+        self.input.byte_cursor = del_start;
+        self.input.cursor = self.input.text[..del_start].chars().count();
+        self.input.preferred_col = None;
+        self.input_scroll_offset = usize::MAX;
+    }
+
     fn undo_input_edit(&mut self) -> bool {
         let Some(snapshot) = self.input_undo_stack.pop() else {
             return false;
@@ -650,7 +726,7 @@ impl ReplTuiState {
         }
 
         let id = self.input.next_paste_id;
-        self.input.next_paste_id = self.input.next_paste_id.saturating_add(1);
+        self.input.next_paste_id += 1;
         let placeholder = format_paste_placeholder(id, count_lines(raw));
         let to_insert = format!("{placeholder} ");
 
@@ -686,7 +762,7 @@ impl ReplTuiState {
     /// Because placeholders include a unique per-prompt `#N` index, `str::find`
     /// returns at most one position per placeholder; no overlap handling needed.
     /// Orphaned entries (placeholder absent from text) are silently skipped.
-    pub(super) fn compute_mask_ranges(&self) -> Vec<(usize, std::ops::Range<usize>)> {
+    fn compute_mask_ranges(&self) -> Vec<(usize, std::ops::Range<usize>)> {
         let mut out: Vec<(usize, std::ops::Range<usize>)> = self
             .input
             .pastes
@@ -712,8 +788,8 @@ impl ReplTuiState {
         if byte_ranges.is_empty() {
             return Vec::new();
         }
-        // Build a (byte_offset, char_index) map in one pass to avoid scanning
-        // the string per range.  Sentinel at the end maps text.len() -> char_count.
+        // Build a sorted (byte_offset, char_index) table in one pass; then use
+        // binary search per range — O(n) build, O(log n) per lookup.
         let text = &self.input.text;
         let mut byte_to_char: Vec<(usize, usize)> =
             text.char_indices().enumerate().map(|(ci, (bi, _))| (bi, ci)).collect();
@@ -721,10 +797,8 @@ impl ReplTuiState {
         byte_to_char.push((text.len(), total_chars));
 
         let lookup = |byte_pos: usize| -> usize {
-            byte_to_char
-                .iter()
-                .find(|(bi, _)| *bi >= byte_pos)
-                .map_or(total_chars, |(_, ci)| *ci)
+            let idx = byte_to_char.partition_point(|(bi, _)| *bi < byte_pos);
+            byte_to_char.get(idx).map_or(total_chars, |(_, ci)| *ci)
         };
 
         byte_ranges
@@ -758,7 +832,8 @@ impl ReplTuiState {
         if self.delete_selection_range() {
             return;
         }
-        // Atomic-mask deletion: cursor at a mask's end byte -> drop whole mask.
+        // Atomic-mask deletion: cursor at a mask's end byte -> drop whole mask
+        // plus its trailing separator space.
         if !had_selection {
             let ranges = self.compute_mask_ranges();
             if let Some((idx, r)) = ranges
@@ -766,7 +841,14 @@ impl ReplTuiState {
                 .find(|(_, r)| r.end == self.input.byte_cursor)
                 .map(|(i, r)| (*i, r.clone()))
             {
-                self.input.text.replace_range(r.clone(), "");
+                let del_end = if self.input.text.len() > r.end
+                    && self.input.text.as_bytes()[r.end] == b' '
+                {
+                    r.end + 1
+                } else {
+                    r.end
+                };
+                self.input.text.replace_range(r.start..del_end, "");
                 self.input.pastes.remove(idx);
                 self.input.byte_cursor = r.start;
                 self.input.cursor = self.input.text[..r.start].chars().count();
@@ -807,7 +889,8 @@ impl ReplTuiState {
         if self.delete_selection_range() {
             return;
         }
-        // Atomic-mask deletion: cursor at a mask's start byte -> drop whole mask.
+        // Atomic-mask deletion: cursor at a mask's start byte -> drop whole mask
+        // plus its trailing separator space.
         if !had_selection {
             let ranges = self.compute_mask_ranges();
             if let Some((idx, r)) = ranges
@@ -815,7 +898,14 @@ impl ReplTuiState {
                 .find(|(_, r)| r.start == self.input.byte_cursor)
                 .map(|(i, r)| (*i, r.clone()))
             {
-                self.input.text.replace_range(r.clone(), "");
+                let del_end = if self.input.text.len() > r.end
+                    && self.input.text.as_bytes()[r.end] == b' '
+                {
+                    r.end + 1
+                } else {
+                    r.end
+                };
+                self.input.text.replace_range(r.start..del_end, "");
                 self.input.pastes.remove(idx);
                 // byte_cursor stays at r.start; char cursor stays the same.
                 self.input.preferred_col = None;
@@ -1583,7 +1673,16 @@ impl ReplTuiState {
                             &mask_char_ranges,
                         );
                         if !selected_s.is_empty() {
-                            spans.push(Span::styled(selected_s, sel_style));
+                            let sel_mask_style =
+                                sel_style.add_modifier(Modifier::DIM | Modifier::ITALIC);
+                            Self::push_input_text_spans(
+                                &mut spans,
+                                &selected_s,
+                                line_start + row_sel_start,
+                                sel_style,
+                                sel_mask_style,
+                                &mask_char_ranges,
+                            );
                         }
                         Self::push_input_text_spans(
                             &mut spans,
@@ -1638,7 +1737,16 @@ impl ReplTuiState {
                         &mask_char_ranges,
                     );
                     if !selected.is_empty() {
-                        spans.push(Span::styled(selected, sel_style));
+                        let sel_mask_style =
+                            sel_style.add_modifier(Modifier::DIM | Modifier::ITALIC);
+                        Self::push_input_text_spans(
+                            &mut spans,
+                            &selected,
+                            line_start + row_sel_start,
+                            sel_style,
+                            sel_mask_style,
+                            &mask_char_ranges,
+                        );
                     }
                     Self::push_input_text_spans(
                         &mut spans,
@@ -3310,6 +3418,16 @@ fn run_loop(
                     continue;
                 }
 
+                if state.active_modal.is_none()
+                    && key.code == KeyCode::Char('w')
+                    && key.modifiers.contains(KeyModifiers::CONTROL)
+                {
+                    state.word_backspace();
+                    state.wake_input_caret();
+                    state.refresh_slash_overlay();
+                    continue;
+                }
+
                 // Copy input selection (Ctrl+C / Ctrl+Insert).
                 if state.active_modal.is_none()
                     && state.input_selection.is_some()
@@ -3731,9 +3849,7 @@ fn run_loop(
                             }
                             state.exit = true;
                             state.persist_on_exit = true;
-                            state.input.text.clear();
-                            state.input.cursor = 0;
-                            state.input.byte_cursor = 0;
+                            state.reset_input();
                             continue;
                         }
                         if state.busy {
@@ -3762,12 +3878,8 @@ fn run_loop(
 
                         let raw_line = std::mem::take(&mut state.input.text);
                         let line = expand_masks(&raw_line, &state.input.pastes);
-                        state.input.cursor = 0;
-                        state.input.byte_cursor = 0;
-                        state.input.preferred_col = None;
+                        state.reset_input();
                         state.input_scroll_offset = 0;
-                        state.input.pastes.clear();
-                        state.input.next_paste_id = 1;
                         state.clear_input_history();
                         let trimmed = line.trim().to_string();
                         state.refresh_slash_overlay();
@@ -4840,8 +4952,8 @@ mod tests {
         assert!(!s.input.text.contains("[#1 Pasted"));
         assert!(s.input.text.len() < before_len);
         assert!(s.input.pastes.is_empty());
-        // "hi " + trailing space that originally followed the (now-deleted) mask.
-        assert_eq!(s.input.text, "hi  ");
+        // Trailing separator space is deleted atomically with the mask.
+        assert_eq!(s.input.text, "hi ");
     }
 
     #[test]

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -755,23 +755,31 @@ impl ReplTuiState {
     }
 
     /// Single entry point for any pasted text, regardless of source (bracketed
-    /// paste, Ctrl+V, Shift+Insert).  Normalises newlines and either masks the
-    /// paste (>= threshold) or inserts it raw.
+    /// paste, Ctrl+V, Shift+Insert, burst flush).  Normalises newlines and
+    /// either masks the paste (>= threshold) or inserts it raw.
     ///
-    /// If the paste contains newlines, a 100 ms suppression window is opened so
-    /// that stray `KeyCode::Enter` events emitted by some terminals for each `\n`
-    /// in the pasted text are discarded rather than triggering an accidental send.
+    /// Note: this does NOT set `suppress_paste_until` — that suppression is
+    /// only appropriate for the bracketed-paste / Ctrl+V paths (where stray
+    /// Enter events from the terminal can follow a paste).  The burst-flush
+    /// path manages newlines via its own in-burst check on `KeyCode::Enter`,
+    /// and adding suppression there would eat subsequent paste characters.
+    /// Callers that need post-paste suppression set it themselves.
     fn handle_paste_event(&mut self, raw: &str) {
         let normalised = normalize_pasted_text(raw);
-        if normalised.contains('\n') {
-            self.selection.suppress_paste_until =
-                Some(Instant::now() + Duration::from_millis(100));
-        }
         if should_mask_paste(&normalised) {
             self.insert_paste_mask(&normalised);
         } else {
             self.insert_input_str(&normalised);
         }
+    }
+
+    /// Arm the post-paste suppression window used by the bracketed-paste and
+    /// Ctrl+V paths.  Stray `KeyCode::Enter` events that some terminals emit
+    /// for each `\n` in a paste are discarded for the next 100 ms so they
+    /// don't trigger an accidental send.
+    fn arm_paste_enter_suppression(&mut self) {
+        self.selection.suppress_paste_until =
+            Some(Instant::now() + Duration::from_millis(100));
     }
 
     /// Maximum gap (ms) between consecutive keystrokes considered a paste burst.
@@ -3411,6 +3419,9 @@ fn run_loop(
                 state.flush_paste_burst();
                 state.last_key_time = None;
                 state.handle_paste_event(&text);
+                if text.contains('\n') {
+                    state.arm_paste_enter_suppression();
+                }
                 state.wake_input_caret();
                 state.refresh_slash_overlay();
             }
@@ -3453,6 +3464,9 @@ fn run_loop(
                     state.last_key_time = None;
                     if let Some(text) = read_clipboard_text() {
                         state.handle_paste_event(&text);
+                        if text.contains('\n') {
+                            state.arm_paste_enter_suppression();
+                        }
                         state.wake_input_caret();
                         state.refresh_slash_overlay();
                     }
@@ -4162,31 +4176,31 @@ mod tests {
     // ── paste-newline suppression e2e tests ───────────────────────────────────
 
     #[test]
-    fn paste_with_newline_opens_suppression_window() {
+    fn arm_paste_enter_suppression_opens_suppression_window() {
         let mut s = test_state();
         assert!(s.selection.suppress_paste_until.is_none());
-        s.handle_paste_event("line1\nline2");
+        s.arm_paste_enter_suppression();
         assert!(
             s.selection.suppress_paste_until.is_some(),
-            "a multi-line paste must open a suppression window"
+            "arming must open the suppression window"
         );
         assert!(
             s.paste_enter_is_suppressed(KeyCode::Enter),
-            "Enter must be suppressed immediately after a multi-line paste"
+            "Enter must be suppressed once the window is armed"
         );
     }
 
     #[test]
-    fn paste_without_newline_does_not_open_suppression_window() {
+    fn handle_paste_event_does_not_arm_suppression() {
+        // Suppression is armed by the bracketed-paste / Ctrl+V call sites only,
+        // never by handle_paste_event itself.  This guarantees the burst-flush
+        // path (which also goes through handle_paste_event) doesn't accidentally
+        // suppress subsequent paste keystrokes.
         let mut s = test_state();
-        s.handle_paste_event("single line");
+        s.handle_paste_event("line1\nline2");
         assert!(
             s.selection.suppress_paste_until.is_none(),
-            "a single-line paste must not open any suppression window"
-        );
-        assert!(
-            !s.paste_enter_is_suppressed(KeyCode::Enter),
-            "Enter must not be suppressed after a single-line paste"
+            "handle_paste_event must not arm suppression on its own"
         );
     }
 
@@ -4205,7 +4219,7 @@ mod tests {
     #[test]
     fn suppression_covers_enter_tab_backspace_and_chars_not_other_keys() {
         let mut s = test_state();
-        s.handle_paste_event("hello\nworld");
+        s.arm_paste_enter_suppression();
         assert!(s.paste_enter_is_suppressed(KeyCode::Enter));
         assert!(s.paste_enter_is_suppressed(KeyCode::Tab));
         assert!(s.paste_enter_is_suppressed(KeyCode::Backspace));
@@ -4216,10 +4230,10 @@ mod tests {
     }
 
     #[test]
-    fn multiline_paste_below_byte_threshold_is_not_masked_but_enter_is_suppressed() {
+    fn multiline_paste_below_byte_threshold_is_not_masked() {
         // "a\nb" is 3 bytes — far below the 150-byte threshold, so it is
-        // inserted raw (no mask placeholder).  The suppression window must still
-        // be opened so the terminal's stray Enter for the \n is discarded.
+        // inserted raw (no mask placeholder).  Suppression is not handle_paste_event's
+        // responsibility — callers (bracketed paste / Ctrl+V) arm it explicitly.
         let mut s = test_state();
         s.handle_paste_event("a\nb");
         assert!(
@@ -4227,18 +4241,14 @@ mod tests {
             "short multi-line paste must not be masked"
         );
         assert!(s.input.text.contains('\n'), "newline must appear in input");
-        assert!(
-            s.paste_enter_is_suppressed(KeyCode::Enter),
-            "Enter must still be suppressed even though paste was not masked"
-        );
     }
 
     #[test]
     fn paste_burst_helpers_buffer_then_flush_through_handle_paste_event() {
         // Simulates a raw-keystroke paste from terminals that don't deliver
         // `Event::Paste`.  We push chars into the burst buffer directly and
-        // verify that flush routes them through handle_paste_event — meaning
-        // the long-paste mask and newline suppression both apply.
+        // verify that flush routes them through handle_paste_event so the
+        // long-paste mask applies.
         let mut s = test_state();
         // Push a 200-char "paste" with a newline in the middle.
         for ch in "a".repeat(99).chars() {
@@ -4257,8 +4267,13 @@ mod tests {
             s.input.text.contains("[#1 Pasted"),
             "burst above threshold must flush through the mask path"
         );
-        // Newline in burst content triggers the Enter-suppression window.
-        assert!(s.paste_enter_is_suppressed(KeyCode::Enter));
+        // CRITICAL: the burst flush must NOT arm suppression — doing so would
+        // eat the next paste characters arriving in the 100 ms window, which
+        // is exactly the truncation regression we're guarding against.
+        assert!(
+            s.selection.suppress_paste_until.is_none(),
+            "burst flush must not arm post-paste suppression"
+        );
     }
 
     /// End-to-end simulation of the event loop's paste-burst handling for the
@@ -4308,8 +4323,11 @@ mod tests {
             "all pasted content should land in input.text, with the newline preserved");
         assert!(s.paste_burst_chars.is_empty(),
             "burst buffer drained after flush");
-        assert!(s.paste_enter_is_suppressed(KeyCode::Enter),
-            "newline routed through handle_paste_event arms Enter suppression");
+        // CRITICAL: post-paste suppression must NOT be armed by the burst flush.
+        // If it were, the 100 ms window would eat subsequent paste characters,
+        // truncating long multi-line pastes (the bug this regression covers).
+        assert!(s.selection.suppress_paste_until.is_none(),
+            "burst flush must not arm Enter suppression");
     }
 
     /// E2E: long keystroke-paste hits the mask threshold via the burst flush.
@@ -4338,6 +4356,50 @@ mod tests {
         // Single PasteEntry recorded with the full 199-char content.
         assert_eq!(s.input.pastes.len(), 1);
         assert_eq!(s.input.pastes[0].content.len(), 199);
+    }
+
+    /// Regression test for paste-truncation bug: when a slow render cycle
+    /// causes the top-of-loop auto-flush to fire MID-paste, the flush must
+    /// not arm `suppress_paste_until` — otherwise the 100 ms window eats the
+    /// remaining paste characters and the user sees a truncated input.
+    ///
+    /// Concrete symptom that motivated this test: pasting a ~300-byte Rust
+    /// test function only showed the first ~26 characters in the input bar.
+    #[test]
+    fn paste_burst_mid_paste_flush_does_not_eat_subsequent_keystrokes() {
+        let mut s = test_state();
+        let t0 = std::time::Instant::now();
+
+        // First "half" of the paste accumulates in the burst buffer.
+        for ch in "    #[test]\n    fn render_".chars() {
+            s.paste_burst_chars.push(ch);
+        }
+        s.last_key_time = Some(t0);
+
+        // Simulate the top-of-loop auto-flush firing because a slow render
+        // cycle pushed last_key_time past the burst threshold.
+        // (In real life this happens when a draw cycle blocks > 30 ms.)
+        s.flush_paste_burst();
+
+        // The flushed text is now in input.text.  Buffer drained.
+        assert!(s.input.text.starts_with("    #[test]\n    fn render_"));
+        assert!(s.paste_burst_chars.is_empty());
+
+        // CRITICAL: suppression window must NOT be armed.  The next
+        // paste-burst keystroke (the 't' from "tool_call_...") MUST NOT
+        // be suppressed.
+        assert!(
+            s.selection.suppress_paste_until.is_none(),
+            "mid-paste flush must not arm suppression — that's the bug"
+        );
+        assert!(
+            !s.paste_enter_is_suppressed(KeyCode::Char('t')),
+            "subsequent paste chars must not be eaten by a suppression window"
+        );
+        assert!(
+            !s.paste_enter_is_suppressed(KeyCode::Enter),
+            "subsequent Enter (handled by burst path) must not be suppressed by handle_paste_event"
+        );
     }
 
     /// E2E: the periodic auto-flush condition.  Verifies the predicate the
@@ -4371,8 +4433,9 @@ mod tests {
     }
 
     #[test]
-    fn paste_burst_flush_below_threshold_inserts_raw_with_suppression() {
-        // Short burst with newline → not masked, but newline triggers suppression.
+    fn paste_burst_flush_below_threshold_inserts_raw_without_arming_suppression() {
+        // Short burst with newline → not masked, and suppression is NOT armed
+        // (burst path manages its own newlines via the Enter-in-burst handler).
         let mut s = test_state();
         for ch in "ab\ncd".chars() {
             s.paste_burst_chars.push(ch);
@@ -4382,8 +4445,8 @@ mod tests {
         assert!(!s.input.text.contains("[#1 Pasted"));
         assert_eq!(s.input.text, "ab\ncd");
         assert!(
-            s.paste_enter_is_suppressed(KeyCode::Enter),
-            "newline in burst content must still arm Enter suppression"
+            s.selection.suppress_paste_until.is_none(),
+            "burst flush must not arm post-paste suppression"
         );
     }
 
@@ -4412,14 +4475,18 @@ mod tests {
     }
 
     #[test]
-    fn crlf_paste_also_opens_suppression_window() {
-        // normalize_pasted_text converts \r\n → \n; the suppression check runs
-        // on the normalised text so CRLF pastes are covered too.
+    fn crlf_paste_normalises_to_lf_in_input() {
+        // normalize_pasted_text converts \r\n → \n so masking / display
+        // logic only ever has to consider \n.
         let mut s = test_state();
         s.handle_paste_event("line1\r\nline2");
         assert!(
-            s.paste_enter_is_suppressed(KeyCode::Enter),
-            "CRLF paste must open the suppression window after normalisation"
+            s.input.text.contains('\n'),
+            "CRLF should be normalised to LF in input.text"
+        );
+        assert!(
+            !s.input.text.contains('\r'),
+            "raw \\r should not survive normalisation"
         );
     }
 

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -679,6 +679,43 @@ impl ReplTuiState {
         });
     }
 
+    /// Locate every active paste mask's current byte range in `self.input.text`.
+    ///
+    /// Returns `(paste_index, byte_range)` pairs sorted by `byte_range.start`.
+    /// Because placeholders include a unique per-prompt `#N` index, `str::find`
+    /// returns at most one position per placeholder; no overlap handling needed.
+    /// Orphaned entries (placeholder absent from text) are silently skipped.
+    fn compute_mask_ranges(&self) -> Vec<(usize, std::ops::Range<usize>)> {
+        let mut out: Vec<(usize, std::ops::Range<usize>)> = self
+            .input
+            .pastes
+            .iter()
+            .enumerate()
+            .filter_map(|(i, p)| {
+                self.input
+                    .text
+                    .find(&p.placeholder)
+                    .map(|s| (i, s..s + p.placeholder.len()))
+            })
+            .collect();
+        out.sort_by_key(|(_, r)| r.start);
+        out
+    }
+
+    /// Returns the mask range that strictly contains `byte_pos`, or `None` if the
+    /// position is at a boundary or outside any mask.  Boundaries are valid cursor
+    /// positions; only interior positions need to be snapped.
+    fn mask_containing(
+        &self,
+        byte_pos: usize,
+        ranges: &[(usize, std::ops::Range<usize>)],
+    ) -> Option<std::ops::Range<usize>> {
+        ranges
+            .iter()
+            .find(|(_, r)| byte_pos > r.start && byte_pos < r.end)
+            .map(|(_, r)| r.clone())
+    }
+
     fn backspace_input_char(&mut self) {
         self.input_scroll_manual = false;
         let had_selection = self.input_selection.is_some();
@@ -3848,6 +3885,55 @@ mod tests {
         assert_eq!(s.input.pastes[1].id, 2);
         assert!(s.input.text.contains("[#1 Pasted"));
         assert!(s.input.text.contains("[#2 Pasted"));
+    }
+
+    #[test]
+    fn compute_mask_ranges_finds_all_placeholders() {
+        let mut s = test_state();
+        let big = "x".repeat(600);
+        s.insert_paste_mask(&big);
+        s.insert_input_str(" middle ");
+        s.insert_paste_mask(&big);
+
+        let ranges = s.compute_mask_ranges();
+        assert_eq!(ranges.len(), 2);
+        // Ranges sorted by start position.
+        assert!(ranges[0].1.start < ranges[1].1.start);
+        // Each range slices to exactly the placeholder string.
+        assert_eq!(
+            &s.input.text[ranges[0].1.clone()],
+            s.input.pastes[ranges[0].0].placeholder
+        );
+    }
+
+    #[test]
+    fn mask_containing_returns_none_at_boundaries_or_outside() {
+        let mut s = test_state();
+        let big = "x".repeat(600);
+        s.insert_paste_mask(&big);
+        let ranges = s.compute_mask_ranges();
+        let r = ranges[0].1.clone();
+
+        assert!(s.mask_containing(r.start, &ranges).is_none());
+        assert!(s.mask_containing(r.end, &ranges).is_none());
+        assert!(s.mask_containing(r.start + 1, &ranges).is_some());
+        assert!(s.mask_containing(r.start + 5, &ranges).is_some());
+    }
+
+    #[test]
+    fn compute_mask_ranges_skips_orphaned_entries() {
+        // If a placeholder is no longer present in `text` (e.g. after manual edits
+        // that removed it without going through atomic delete), the entry is
+        // silently skipped.
+        let mut s = test_state();
+        s.input.pastes.push(PasteEntry {
+            id: 1,
+            placeholder: "[#1 Pasted ~5 lines]".to_string(),
+            content: "x".repeat(600),
+        });
+        // text is empty — no occurrences of the placeholder.
+        let ranges = s.compute_mask_ranges();
+        assert!(ranges.is_empty());
     }
 
     fn assert_matching_lengths(items: &[ratatui::widgets::ListItem<'static>], text: &[String]) {

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -65,7 +65,7 @@ fn read_clipboard_text() -> Option<String> {
 }
 
 /// Mask any paste at or above this byte length.
-const PASTE_MASK_THRESHOLD_BYTES: usize = 500;
+const PASTE_MASK_THRESHOLD_BYTES: usize = 150;
 
 /// Count logical lines in `text` by physical newline count plus one.  O(n) byte
 /// scan, no UTF-8 decoding — `\n` is ASCII so this is safe on any UTF-8 string.
@@ -747,13 +747,34 @@ impl ReplTuiState {
     /// Single entry point for any pasted text, regardless of source (bracketed
     /// paste, Ctrl+V, Shift+Insert).  Normalises newlines and either masks the
     /// paste (>= threshold) or inserts it raw.
+    ///
+    /// If the paste contains newlines, a 100 ms suppression window is opened so
+    /// that stray `KeyCode::Enter` events emitted by some terminals for each `\n`
+    /// in the pasted text are discarded rather than triggering an accidental send.
     fn handle_paste_event(&mut self, raw: &str) {
         let normalised = normalize_pasted_text(raw);
+        if normalised.contains('\n') {
+            self.selection.suppress_paste_until =
+                Some(Instant::now() + Duration::from_millis(100));
+        }
         if should_mask_paste(&normalised) {
             self.insert_paste_mask(&normalised);
         } else {
             self.insert_input_str(&normalised);
         }
+    }
+
+    /// Returns true if `key_code` should be suppressed because a paste that
+    /// contained newlines was processed recently.  Used by the event loop and
+    /// by tests to verify suppression without running the full event loop.
+    fn paste_enter_is_suppressed(&self, key_code: KeyCode) -> bool {
+        self.selection
+            .suppress_paste_until
+            .is_some_and(|deadline| Instant::now() <= deadline)
+            && matches!(
+                key_code,
+                KeyCode::Char(_) | KeyCode::Enter | KeyCode::Tab | KeyCode::Backspace
+            )
     }
 
     /// Locate every active paste mask's current byte range in `self.input.text`.
@@ -3347,14 +3368,7 @@ fn run_loop(
                 state.refresh_slash_overlay();
             }
             Event::Key(key) if key.kind == KeyEventKind::Press => {
-                let suppress_paste_key = state
-                    .selection
-                    .suppress_paste_until
-                    .is_some_and(|deadline| Instant::now() <= deadline)
-                    && matches!(
-                        key.code,
-                        KeyCode::Char(_) | KeyCode::Enter | KeyCode::Tab | KeyCode::Backspace
-                    );
+                let suppress_paste_key = state.paste_enter_is_suppressed(key.code);
                 if suppress_paste_key {
                     state.selection.suppress_paste_until =
                         Some(Instant::now() + Duration::from_millis(150));
@@ -4026,6 +4040,7 @@ mod tests {
     use crate::tui::auth_modal::{AuthModal, AuthModalStep, ProviderKind};
     use crate::tui::repl_render::{line_to_plain_text, render_tool_call_lines, wrap_ansi_line};
     use crate::tui::ReplTuiEvent;
+    use crossterm::event::KeyCode;
     use ratatui::style::Color;
     use ratatui::text::Line;
 
@@ -4059,9 +4074,95 @@ mod tests {
     #[test]
     fn should_mask_paste_uses_byte_threshold() {
         assert!(!should_mask_paste(""));
-        assert!(!should_mask_paste(&"x".repeat(499)));
-        assert!(should_mask_paste(&"x".repeat(500)));
+        assert!(!should_mask_paste(&"x".repeat(149)));
+        assert!(should_mask_paste(&"x".repeat(150)));
         assert!(should_mask_paste(&"x".repeat(10_000)));
+    }
+
+    // ── paste-newline suppression e2e tests ───────────────────────────────────
+
+    #[test]
+    fn paste_with_newline_opens_suppression_window() {
+        let mut s = test_state();
+        assert!(s.selection.suppress_paste_until.is_none());
+        s.handle_paste_event("line1\nline2");
+        assert!(
+            s.selection.suppress_paste_until.is_some(),
+            "a multi-line paste must open a suppression window"
+        );
+        assert!(
+            s.paste_enter_is_suppressed(KeyCode::Enter),
+            "Enter must be suppressed immediately after a multi-line paste"
+        );
+    }
+
+    #[test]
+    fn paste_without_newline_does_not_open_suppression_window() {
+        let mut s = test_state();
+        s.handle_paste_event("single line");
+        assert!(
+            s.selection.suppress_paste_until.is_none(),
+            "a single-line paste must not open any suppression window"
+        );
+        assert!(
+            !s.paste_enter_is_suppressed(KeyCode::Enter),
+            "Enter must not be suppressed after a single-line paste"
+        );
+    }
+
+    #[test]
+    fn suppression_blocks_enter_but_not_after_window_expires() {
+        let mut s = test_state();
+        // Open a suppression window that expired 1 ms ago.
+        s.selection.suppress_paste_until =
+            Some(std::time::Instant::now() - std::time::Duration::from_millis(1));
+        assert!(
+            !s.paste_enter_is_suppressed(KeyCode::Enter),
+            "Enter must not be suppressed once the window has expired"
+        );
+    }
+
+    #[test]
+    fn suppression_covers_enter_tab_backspace_and_chars_not_other_keys() {
+        let mut s = test_state();
+        s.handle_paste_event("hello\nworld");
+        assert!(s.paste_enter_is_suppressed(KeyCode::Enter));
+        assert!(s.paste_enter_is_suppressed(KeyCode::Tab));
+        assert!(s.paste_enter_is_suppressed(KeyCode::Backspace));
+        assert!(s.paste_enter_is_suppressed(KeyCode::Char('a')));
+        // Non-suppressed keys — arrow keys and Esc pass through.
+        assert!(!s.paste_enter_is_suppressed(KeyCode::Left));
+        assert!(!s.paste_enter_is_suppressed(KeyCode::Esc));
+    }
+
+    #[test]
+    fn multiline_paste_below_byte_threshold_is_not_masked_but_enter_is_suppressed() {
+        // "a\nb" is 3 bytes — far below the 150-byte threshold, so it is
+        // inserted raw (no mask placeholder).  The suppression window must still
+        // be opened so the terminal's stray Enter for the \n is discarded.
+        let mut s = test_state();
+        s.handle_paste_event("a\nb");
+        assert!(
+            !s.input.text.contains("[#1 Pasted"),
+            "short multi-line paste must not be masked"
+        );
+        assert!(s.input.text.contains('\n'), "newline must appear in input");
+        assert!(
+            s.paste_enter_is_suppressed(KeyCode::Enter),
+            "Enter must still be suppressed even though paste was not masked"
+        );
+    }
+
+    #[test]
+    fn crlf_paste_also_opens_suppression_window() {
+        // normalize_pasted_text converts \r\n → \n; the suppression check runs
+        // on the normalised text so CRLF pastes are covered too.
+        let mut s = test_state();
+        s.handle_paste_event("line1\r\nline2");
+        assert!(
+            s.paste_enter_is_suppressed(KeyCode::Enter),
+            "CRLF paste must open the suppression window after normalisation"
+        );
     }
 
     #[test]

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -294,14 +294,6 @@ pub(super) struct ReplTuiState {
     spinner_deadline: Instant,
     pub(super) typewriter: TypewriterState,
     pub(super) selection: SelectionState,
-    /// Accumulates characters arriving faster than a human can type (≤30 ms
-    /// apart) so they can be flushed as a single `insert_input_str` call instead
-    /// of being inserted one-by-one.  `None` = not currently in a burst.
-    paste_buffer: Option<(Instant, Vec<char>)>,
-    /// Timestamp of the most-recently processed `KeyCode::Char` (or `Enter`
-    /// treated as a paste newline).  Used together with `paste_buffer` above to
-    /// detect burst boundaries.
-    last_key_time: Option<Instant>,
     input_undo_stack: Vec<InputUndoSnapshot>,
     input_redo_stack: Vec<InputUndoSnapshot>,
     last_esc_at: Option<Instant>,
@@ -364,8 +356,6 @@ impl ReplTuiState {
                 live: String::new(),
             },
             selection: SelectionState::default(),
-            paste_buffer: None,
-            last_key_time: None,
             input_undo_stack: Vec::new(),
             input_redo_stack: Vec::new(),
             last_esc_at: None,
@@ -463,11 +453,6 @@ impl ReplTuiState {
         self.cursor_blink_deadline = Instant::now() + Duration::from_millis(530);
     }
 
-    /// Maximum gap (ms) between consecutive keystrokes to be considered a
-    /// paste burst.  Human typing at 120 WPM averages ≈100 ms/char, so 30 ms
-    /// cleanly separates programmatic paste from even the fastest typists.
-    const PASTE_THRESHOLD_MS: u64 = 30;
-
     fn current_input_snapshot(&self) -> InputUndoSnapshot {
         InputUndoSnapshot {
             text: self.input.text.clone(),
@@ -526,42 +511,6 @@ impl ReplTuiState {
         self.input_undo_stack.push(self.current_input_snapshot());
         self.apply_input_snapshot(snapshot);
         true
-    }
-
-    /// If a paste burst is active, flush the accumulated characters into the
-    /// input buffer by concatenating prefix + `pasted_text` + suffix directly
-    /// (avoids the O(n) `insert_str` tail-shift and `text.chars().count()`).
-    fn flush_paste_buffer(&mut self) {
-        self.input_scroll_manual = false;
-        if let Some((_, chars)) = self.paste_buffer.take() {
-            let n = chars.len();
-            if n == 0 {
-                return;
-            }
-            self.record_input_undo_snapshot();
-            self.delete_selection_range();
-            self.clamp_input_cursor();
-            let prefix = &self.input.text[..self.input.byte_cursor];
-            let suffix = &self.input.text[self.input.byte_cursor..];
-            // Compute UTF-8 byte length of pasted chars while building the
-            // replacement string — one pass instead of two.
-            let mut pasted_len = 0usize;
-            let cap = prefix.len() + suffix.len() + n; // n ≤ actual UTF-8 bytes
-            let mut text = String::with_capacity(cap);
-            text.push_str(prefix);
-            for c in chars {
-                pasted_len += c.len_utf8();
-                text.push(c);
-            }
-            text.push_str(suffix);
-            self.input.byte_cursor = self.input.byte_cursor.saturating_add(pasted_len);
-            self.input.cursor = self.input.cursor.saturating_add(n);
-            self.input.text = text;
-            self.input.preferred_col = None;
-            self.input_scroll_offset = usize::MAX;
-            self.wake_input_caret();
-            self.refresh_slash_overlay();
-        }
     }
 
     fn input_char_len(&self) -> usize {
@@ -2971,17 +2920,6 @@ fn run_loop(
             );
         }
 
-        // Auto-flush paste buffer when the burst has been idle longer than
-        // the threshold — handles the case where paste ends without a
-        // subsequent key event to trigger the flush.
-        if state.paste_buffer.is_some()
-            && state.last_key_time.is_some_and(|t| {
-                t.elapsed() > Duration::from_millis(ReplTuiState::PASTE_THRESHOLD_MS)
-            })
-        {
-            state.flush_paste_buffer();
-        }
-
         if state.exit {
             if state.persist_on_exit {
                 let mut g = cli.lock().expect("cli lock");
@@ -3296,9 +3234,6 @@ fn run_loop(
                     continue;
                 }
 
-                // Bracketed paste supersedes any ongoing burst accumulation
-                state.paste_buffer = None;
-                state.last_key_time = None;
                 state.handle_paste_event(&text);
                 state.wake_input_caret();
                 state.refresh_slash_overlay();
@@ -3336,9 +3271,6 @@ fn run_loop(
                         || (key.code == KeyCode::Insert
                             && key.modifiers.contains(KeyModifiers::SHIFT)))
                 {
-                    // Manual paste supersedes any ongoing burst accumulation
-                    state.paste_buffer = None;
-                    state.last_key_time = None;
                     if let Some(text) = read_clipboard_text() {
                         state.handle_paste_event(&text);
                         state.wake_input_caret();
@@ -3351,7 +3283,6 @@ fn run_loop(
                     && key.code == KeyCode::Char('a')
                     && key.modifiers.contains(KeyModifiers::CONTROL)
                 {
-                    state.flush_paste_buffer();
                     state.select_all_input();
                     state.wake_input_caret();
                     continue;
@@ -3361,7 +3292,6 @@ fn run_loop(
                     && key.code == KeyCode::Char('z')
                     && key.modifiers.contains(KeyModifiers::CONTROL)
                 {
-                    state.flush_paste_buffer();
                     if state.undo_input_edit() {
                         state.wake_input_caret();
                         state.refresh_slash_overlay();
@@ -3373,7 +3303,6 @@ fn run_loop(
                     && key.code == KeyCode::Char('y')
                     && key.modifiers.contains(KeyModifiers::CONTROL)
                 {
-                    state.flush_paste_buffer();
                     if state.redo_input_edit() {
                         state.wake_input_caret();
                         state.refresh_slash_overlay();
@@ -3771,33 +3700,11 @@ fn run_loop(
 
                 match key.code {
                     KeyCode::Enter if key.modifiers.contains(KeyModifiers::SHIFT) => {
-                        state.flush_paste_buffer();
                         state.insert_input_char('\n');
                         state.wake_input_caret();
                         state.refresh_slash_overlay();
                     }
                     KeyCode::Enter => {
-                        // Paste burst detection: if Enter arrives within the burst
-                        // threshold, treat it as a literal \n in the pasted text
-                        // instead of submitting.
-                        let now = Instant::now();
-                        let in_paste_burst = state.paste_buffer.is_some()
-                            && state.last_key_time.is_some_and(|t| {
-                                now.duration_since(t)
-                                    <= Duration::from_millis(ReplTuiState::PASTE_THRESHOLD_MS)
-                            });
-                        state.last_key_time = Some(now);
-                        if in_paste_burst {
-                            state
-                                .paste_buffer
-                                .get_or_insert_with(|| (now, Vec::new()))
-                                .1
-                                .push('\n');
-                            state.wake_input_caret();
-                            continue;
-                        }
-                        state.flush_paste_buffer();
-
                         // Child tab resume (check before parent pause)
                         if state.child_tab_panel.active_tab_is_paused() {
                             if let Some(child_id) = state.child_tab_panel.active_child_id() {
@@ -3878,79 +3785,50 @@ fn run_loop(
                         state.wake_input_caret();
                     }
                     KeyCode::Char('j') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                        state.flush_paste_buffer();
                         state.insert_input_char('\n');
                         state.wake_input_caret();
                         state.refresh_slash_overlay();
                     }
                     KeyCode::Char(c) => {
-                        let now = Instant::now();
-                        let is_fast = state.last_key_time.is_some_and(|t| {
-                            now.duration_since(t)
-                                <= Duration::from_millis(ReplTuiState::PASTE_THRESHOLD_MS)
-                        });
-                        state.last_key_time = Some(now);
-
-                        if is_fast {
-                            // Burst detected — accumulate into paste buffer
-                            state
-                                .paste_buffer
-                                .get_or_insert_with(|| (now, Vec::new()))
-                                .1
-                                .push(c);
-                        } else {
-                            // Normal human-paced typing — flush any lingering
-                            // paste buffer, then insert immediately.
-                            state.flush_paste_buffer();
-                            state.insert_input_char(c);
-                        }
+                        state.insert_input_char(c);
                         state.wake_input_caret();
                         state.refresh_slash_overlay();
                     }
                     KeyCode::Backspace => {
-                        state.flush_paste_buffer();
                         state.backspace_input_char();
                         state.wake_input_caret();
                         state.refresh_slash_overlay();
                     }
                     KeyCode::Delete => {
-                        state.flush_paste_buffer();
                         state.delete_input_char();
                         state.wake_input_caret();
                         state.refresh_slash_overlay();
                     }
                     KeyCode::Left => {
-                        state.flush_paste_buffer();
                         state.move_input_cursor_left();
                         state.wake_input_caret();
                     }
                     KeyCode::Right => {
-                        state.flush_paste_buffer();
                         state.move_input_cursor_right();
                         state.wake_input_caret();
                     }
                     KeyCode::Home => {
-                        state.flush_paste_buffer();
                         state.move_input_cursor_home();
                         state.wake_input_caret();
                     }
                     KeyCode::End => {
-                        state.flush_paste_buffer();
                         state.move_input_cursor_end();
                         state.wake_input_caret();
                     }
                     KeyCode::Up => {
-                        state.flush_paste_buffer();
                         state.move_input_cursor_up();
                         state.wake_input_caret();
                     }
                     KeyCode::Down => {
-                        state.flush_paste_buffer();
                         state.move_input_cursor_down();
                         state.wake_input_caret();
                     }
                     KeyCode::Tab => {
-                        state.flush_paste_buffer();
                         if state.busy || !state.input.text.trim_start().starts_with('/') {
                             continue;
                         }
@@ -3983,7 +3861,6 @@ fn run_loop(
                         }
                     }
                     KeyCode::Esc => {
-                        state.flush_paste_buffer();
                         if state.busy {
                             let now = Instant::now();
                             if state
@@ -4005,13 +3882,11 @@ fn run_loop(
                         }
                     }
                     KeyCode::PageUp => {
-                        state.flush_paste_buffer();
                         let cur = state.list_state.offset();
                         *state.list_state.offset_mut() = cur.saturating_sub(10);
                         state.follow_bottom = false;
                     }
                     KeyCode::PageDown => {
-                        state.flush_paste_buffer();
                         let max_off = state
                             .last_wrapped_len
                             .saturating_sub(state.last_view_height.max(1));

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -64,6 +64,26 @@ fn read_clipboard_text() -> Option<String> {
     Some(normalize_pasted_text(&text))
 }
 
+/// Mask any paste at or above this byte length.
+const PASTE_MASK_THRESHOLD_BYTES: usize = 500;
+
+/// Count logical lines in `text` by physical newline count plus one.  O(n) byte
+/// scan, no UTF-8 decoding — `\n` is ASCII so this is safe on any UTF-8 string.
+fn count_lines(text: &str) -> usize {
+    text.bytes().filter(|&b| b == b'\n').count() + 1
+}
+
+/// Whether a paste should be replaced by a placeholder mask.
+/// Inclusive at the threshold: returns true when `text.len() >= PASTE_MASK_THRESHOLD_BYTES`.
+fn should_mask_paste(text: &str) -> bool {
+    text.len() >= PASTE_MASK_THRESHOLD_BYTES
+}
+
+/// Format the visible placeholder for a masked paste.
+fn format_paste_placeholder(id: u32, line_count: usize) -> String {
+    format!("[#{id} Pasted ~{line_count} lines]")
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum AppUiState {
     WelcomeMode,
@@ -3690,11 +3710,45 @@ mod tests {
     use ratatui::style::Color;
     use ratatui::text::Line;
 
-    use super::{PasteEntry, ReplTuiState, ToolCallStatus, TranscriptEntry};
+    use super::{
+        count_lines, format_paste_placeholder, normalize_pasted_text, should_mask_paste,
+        PasteEntry, ReplTuiState, ToolCallStatus, TranscriptEntry,
+    };
 
     /// Smallest valid `ReplTuiState` for paste-masking unit tests.
     fn test_state() -> ReplTuiState {
         ReplTuiState::new()
+    }
+
+    #[test]
+    fn normalize_pasted_text_handles_crlf_and_cr() {
+        assert_eq!(normalize_pasted_text("a\r\nb"), "a\nb");
+        assert_eq!(normalize_pasted_text("a\rb"), "a\nb");
+        assert_eq!(normalize_pasted_text("a\r\nb\rc"), "a\nb\nc");
+        assert_eq!(normalize_pasted_text("plain"), "plain");
+    }
+
+    #[test]
+    fn count_lines_counts_newlines_plus_one() {
+        assert_eq!(count_lines(""), 1);
+        assert_eq!(count_lines("one"), 1);
+        assert_eq!(count_lines("a\nb"), 2);
+        assert_eq!(count_lines("a\nb\nc"), 3);
+        assert_eq!(count_lines("trailing\n"), 2);
+    }
+
+    #[test]
+    fn should_mask_paste_uses_byte_threshold() {
+        assert!(!should_mask_paste(""));
+        assert!(!should_mask_paste(&"x".repeat(499)));
+        assert!(should_mask_paste(&"x".repeat(500)));
+        assert!(should_mask_paste(&"x".repeat(10_000)));
+    }
+
+    #[test]
+    fn format_paste_placeholder_matches_format() {
+        assert_eq!(format_paste_placeholder(1, 1), "[#1 Pasted ~1 lines]");
+        assert_eq!(format_paste_placeholder(42, 137), "[#42 Pasted ~137 lines]");
     }
 
     #[test]

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -716,7 +716,7 @@ impl ReplTuiState {
     /// Because placeholders include a unique per-prompt `#N` index, `str::find`
     /// returns at most one position per placeholder; no overlap handling needed.
     /// Orphaned entries (placeholder absent from text) are silently skipped.
-    fn compute_mask_ranges(&self) -> Vec<(usize, std::ops::Range<usize>)> {
+    pub(super) fn compute_mask_ranges(&self) -> Vec<(usize, std::ops::Range<usize>)> {
         let mut out: Vec<(usize, std::ops::Range<usize>)> = self
             .input
             .pastes
@@ -731,6 +731,36 @@ impl ReplTuiState {
             .collect();
         out.sort_by_key(|(_, r)| r.start);
         out
+    }
+
+    /// Returns mask ranges in CHAR-index space.  Used by the input renderer to
+    /// style placeholder text (`[#N Pasted ~K lines]`) with a meta-token
+    /// modifier (dim + italic) so it visually reads as a token rather than
+    /// user-typed content.  Sorted by `start` (matches `compute_mask_ranges`).
+    fn compute_mask_char_ranges(&self) -> Vec<(usize, usize)> {
+        let byte_ranges = self.compute_mask_ranges();
+        if byte_ranges.is_empty() {
+            return Vec::new();
+        }
+        // Build a (byte_offset, char_index) map in one pass to avoid scanning
+        // the string per range.  Sentinel at the end maps text.len() -> char_count.
+        let text = &self.input.text;
+        let mut byte_to_char: Vec<(usize, usize)> =
+            text.char_indices().enumerate().map(|(ci, (bi, _))| (bi, ci)).collect();
+        let total_chars = byte_to_char.len();
+        byte_to_char.push((text.len(), total_chars));
+
+        let lookup = |byte_pos: usize| -> usize {
+            byte_to_char
+                .iter()
+                .find(|(bi, _)| *bi >= byte_pos)
+                .map_or(total_chars, |(_, ci)| *ci)
+        };
+
+        byte_ranges
+            .iter()
+            .map(|(_, r)| (lookup(r.start), lookup(r.end)))
+            .collect()
     }
 
     /// Returns the mask range that strictly contains `byte_pos`, or `None` if the
@@ -1318,6 +1348,52 @@ impl ReplTuiState {
     }
 
     #[allow(clippy::too_many_lines)]
+    /// Push spans for `text` whose characters start at absolute char index
+    /// `text_char_start` within `self.input.text`, applying `mask_style` for
+    /// any chars overlapping a mask range and `base_style` otherwise.  Mask
+    /// ranges are absolute (input-text char indices) and assumed sorted.
+    fn push_input_text_spans(
+        spans: &mut Vec<Span<'static>>,
+        text: &str,
+        text_char_start: usize,
+        base_style: Style,
+        mask_style: Style,
+        masks: &[(usize, usize)],
+    ) {
+        if text.is_empty() {
+            return;
+        }
+        if masks.is_empty() {
+            spans.push(Span::styled(text.to_string(), base_style));
+            return;
+        }
+        let chars: Vec<char> = text.chars().collect();
+        let text_char_end = text_char_start + chars.len();
+        // Find masks that overlap [text_char_start, text_char_end).
+        let mut cursor = 0usize; // char index within `text`
+        for &(m_start, m_end) in masks {
+            if m_end <= text_char_start || m_start >= text_char_end {
+                continue;
+            }
+            let local_start = m_start.saturating_sub(text_char_start);
+            let local_end = (m_end - text_char_start).min(chars.len());
+            if local_start > cursor {
+                let pre: String = chars[cursor..local_start].iter().collect();
+                spans.push(Span::styled(pre, base_style));
+            }
+            if local_end > local_start {
+                let inside: String = chars[local_start..local_end].iter().collect();
+                spans.push(Span::styled(inside, mask_style));
+            }
+            cursor = local_end;
+        }
+        if cursor < chars.len() {
+            let tail: String = chars[cursor..].iter().collect();
+            spans.push(Span::styled(tail, base_style));
+        }
+    }
+
+    #[allow(clippy::too_many_lines)]
     pub(super) fn calculate_input_dimensions(
         &mut self,
         width: u16,
@@ -1466,6 +1542,12 @@ impl ReplTuiState {
         } else {
             Style::default()
         };
+        let mask_style = text_style.add_modifier(Modifier::DIM | Modifier::ITALIC);
+        let mask_char_ranges = if is_placeholder {
+            Vec::new()
+        } else {
+            self.compute_mask_char_ranges()
+        };
 
         let mut render_lines = Vec::new();
         render_lines.push(Line::from(""));
@@ -1523,22 +1605,42 @@ impl ReplTuiState {
                             .take(row_sel_end.saturating_sub(row_sel_start))
                             .collect();
                         let after_s: String = full.chars().skip(row_sel_end).collect();
-                        if !before_s.is_empty() {
-                            spans.push(Span::styled(before_s, text_style));
-                        }
+                        Self::push_input_text_spans(
+                            &mut spans,
+                            &before_s,
+                            line_start,
+                            text_style,
+                            mask_style,
+                            &mask_char_ranges,
+                        );
                         if !selected_s.is_empty() {
                             spans.push(Span::styled(selected_s, sel_style));
                         }
-                        if !after_s.is_empty() {
-                            spans.push(Span::styled(after_s, text_style));
-                        }
+                        Self::push_input_text_spans(
+                            &mut spans,
+                            &after_s,
+                            line_start + row_sel_end,
+                            text_style,
+                            mask_style,
+                            &mask_char_ranges,
+                        );
                     } else {
-                        if !left.is_empty() {
-                            spans.push(Span::styled(left.clone(), text_style));
-                        }
-                        if !right.is_empty() {
-                            spans.push(Span::styled(right, text_style));
-                        }
+                        Self::push_input_text_spans(
+                            &mut spans,
+                            &left,
+                            line_start,
+                            text_style,
+                            mask_style,
+                            &mask_char_ranges,
+                        );
+                        Self::push_input_text_spans(
+                            &mut spans,
+                            &right,
+                            line_start + left.chars().count(),
+                            text_style,
+                            mask_style,
+                            &mask_char_ranges,
+                        );
                     }
                     if left.is_empty() {
                         cursor_pos = Some((u16::try_from(i + 1).unwrap_or(1), prompt_width));
@@ -1558,17 +1660,34 @@ impl ReplTuiState {
                         .take(row_sel_end - row_sel_start)
                         .collect();
                     let after: String = row.chars().skip(row_sel_end).collect();
-                    if !before.is_empty() {
-                        spans.push(Span::styled(before, text_style));
-                    }
+                    Self::push_input_text_spans(
+                        &mut spans,
+                        &before,
+                        line_start,
+                        text_style,
+                        mask_style,
+                        &mask_char_ranges,
+                    );
                     if !selected.is_empty() {
                         spans.push(Span::styled(selected, sel_style));
                     }
-                    if !after.is_empty() {
-                        spans.push(Span::styled(after, text_style));
-                    }
+                    Self::push_input_text_spans(
+                        &mut spans,
+                        &after,
+                        line_start + row_sel_end,
+                        text_style,
+                        mask_style,
+                        &mask_char_ranges,
+                    );
                 } else {
-                    spans.push(Span::styled(row, text_style));
+                    Self::push_input_text_spans(
+                        &mut spans,
+                        &row,
+                        line_start,
+                        text_style,
+                        mask_style,
+                        &mask_char_ranges,
+                    );
                 }
             } else {
                 // No active selection — plain rendering (existing logic).
@@ -1587,20 +1706,40 @@ impl ReplTuiState {
                     } else {
                         0
                     };
+                    let left_char_len = left.chars().count();
                     if left.is_empty() {
                         cursor_pos = Some((u16::try_from(i + 1).unwrap_or(1), prompt_width));
                     } else {
                         let left_width = text_display_width(&left);
-                        spans.push(Span::styled(left, text_style));
+                        Self::push_input_text_spans(
+                            &mut spans,
+                            &left,
+                            line_start,
+                            text_style,
+                            mask_style,
+                            &mask_char_ranges,
+                        );
                         let cursor_col =
                             prompt_width + u16::try_from(left_width).unwrap_or(u16::MAX);
                         cursor_pos = Some((u16::try_from(i + 1).unwrap_or(1), cursor_col));
                     }
-                    if !right.is_empty() {
-                        spans.push(Span::styled(right, text_style));
-                    }
+                    Self::push_input_text_spans(
+                        &mut spans,
+                        &right,
+                        line_start + left_char_len,
+                        text_style,
+                        mask_style,
+                        &mask_char_ranges,
+                    );
                 } else {
-                    spans.push(Span::styled(row, text_style));
+                    Self::push_input_text_spans(
+                        &mut spans,
+                        &row,
+                        line_start,
+                        text_style,
+                        mask_style,
+                        &mask_char_ranges,
+                    );
                 }
             }
             render_lines.push(Line::from(spans));
@@ -4136,6 +4275,59 @@ mod tests {
         // text is empty — no occurrences of the placeholder.
         let ranges = s.compute_mask_ranges();
         assert!(ranges.is_empty());
+    }
+
+    #[test]
+    fn compute_mask_char_ranges_handles_multibyte_prefix() {
+        let mut s = test_state();
+        // Multi-byte prefix shifts byte positions relative to char positions.
+        s.insert_input_str("héllo ");
+        s.insert_paste_mask(&"x".repeat(600));
+
+        let byte_ranges = s.compute_mask_ranges();
+        let char_ranges = s.compute_mask_char_ranges();
+        assert_eq!(char_ranges.len(), 1);
+
+        let (c_start, c_end) = char_ranges[0];
+        let r = &byte_ranges[0].1;
+        assert_eq!(c_start, s.input.text[..r.start].chars().count());
+        assert_eq!(c_end, s.input.text[..r.end].chars().count());
+        // Placeholder is ASCII so char-length equals byte-length within the range.
+        assert_eq!(c_end - c_start, r.end - r.start);
+    }
+
+    #[test]
+    fn input_render_styles_mask_as_dim_italic() {
+        use ratatui::style::Modifier;
+
+        let mut s = test_state();
+        s.insert_input_str("hi ");
+        s.insert_paste_mask(&"x".repeat(600));
+
+        let (_h, lines, _max_scroll, _cursor) = s.calculate_input_dimensions(80, "model");
+        // First line is a blank padding; the input row is at index 1.
+        let input_line = &lines[1];
+        let mut found_mask_span = false;
+        for span in &input_line.spans {
+            if span.content.contains("[#1 Pasted") {
+                let mods = span.style.add_modifier;
+                assert!(
+                    mods.contains(Modifier::DIM) && mods.contains(Modifier::ITALIC),
+                    "mask span missing DIM/ITALIC modifiers (got {mods:?}) for content {:?}",
+                    span.content
+                );
+                found_mask_span = true;
+            }
+        }
+        assert!(
+            found_mask_span,
+            "expected at least one span carrying the placeholder text, got spans {:?}",
+            input_line
+                .spans
+                .iter()
+                .map(|s| s.content.as_ref())
+                .collect::<Vec<_>>()
+        );
     }
 
     fn assert_matching_lengths(items: &[ratatui::widgets::ListItem<'static>], text: &[String]) {

--- a/crates/acrawl-cli/src/tui/repl_app.rs
+++ b/crates/acrawl-cli/src/tui/repl_app.rs
@@ -1332,6 +1332,16 @@ impl ReplTuiState {
 
         let (total_visual, caret_visual_line) = if is_placeholder {
             (1usize, 0usize)
+        } else if self.vis_cache_width == safe_width {
+            if let Some(ref cached) = self.vis_cache {
+                let total = cached.len().max(1);
+                let caret = cached
+                    .partition_point(|(s, _, _)| *s <= self.input.cursor)
+                    .saturating_sub(1);
+                (total, caret)
+            } else {
+                self.count_visual_lines_with_caret(safe_width, self.input.cursor)
+            }
         } else {
             self.count_visual_lines_with_caret(safe_width, self.input.cursor)
         };
@@ -1467,16 +1477,18 @@ impl ReplTuiState {
                             safe_width
                         };
 
-                        if !current.is_empty() && *w + char_width > target {
+                        if *w > 0 && *w + char_width > target {
                             push_current(current, *is_first_chunk, visual_line_idx, visual_lines);
                             *w = 0;
                             *is_first_chunk = false;
                         }
 
-                        current.push(c);
+                        if *visual_line_idx >= skip {
+                            current.push(c);
+                        }
                         *w += char_width;
 
-                        if *w >= target && !current.is_empty() {
+                        if *w >= target && *w > 0 {
                             push_current(current, *is_first_chunk, visual_line_idx, visual_lines);
                             *w = 0;
                             *is_first_chunk = false;
@@ -1554,7 +1566,7 @@ impl ReplTuiState {
                         );
                     }
 
-                    if !current.is_empty() {
+                    if !current.is_empty() || w > 0 {
                         push_current(
                             &mut current,
                             is_first_chunk,

--- a/crates/crawler/src/fetcher.rs
+++ b/crates/crawler/src/fetcher.rs
@@ -731,12 +731,20 @@ mod tests {
         // anywhere near that many bytes.
         let server = tokio::spawn(async move {
             if let Ok((mut socket, _)) = listener.accept().await {
+                use tokio::io::AsyncReadExt;
+                // Drain the request so Windows doesn't RST the connection
+                // before the client can read the response headers.
+                let mut buf = [0u8; 4096];
+                let _ = socket.read(&mut buf).await;
                 let _ = socket
                     .write_all(
                         b"HTTP/1.1 200 OK\r\nContent-Length: 999999999\r\nConnection: close\r\n\r\n",
                     )
                     .await;
-                let _ = socket.shutdown().await;
+                // Let the socket drop naturally; an immediate shutdown() sends a
+                // TCP RST on Windows, aborting the client read before it sees
+                // the Content-Length header.
+                tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
             }
         });
 


### PR DESCRIPTION
## Summary

Fixes a severe per-frame allocation bottleneck in the TUI input renderer.

calculate_input_dimensions is called on every render frame (including caret-blink ticks). It previously performed two full O(n) character scans over self.input.text on every frame:

1. **Word-wrap loop** — cloned the entire input text, split all logical lines into owned Strings, then char-by-char word-wrapped every visual line into new String objects, building O(total_visual_lines) heap allocations even when only 5 lines (MAX_INPUT_LINES) are ever displayed
2. **isual_line_info** — a second full O(n) scan to compute character-index boundaries for selection rendering

For large input text this caused perceptible lag on every render frame.

### Fix

Two new helpers + a refactored render path:

- **count_visual_lines_with_caret** — allocation-free integer-only pass that returns (total_visual, caret_visual_line) for scroll math, no strings built
- **isual_line_info_capped** — early-exit variant of isual_line_info that stops after N visual lines, so selection rendering never scans past the visible window
- **calculate_input_dimensions** refactored to two phases:
  1. Fast count (no allocs) → compute scroll offset from 	otal_visual and caret_visual_line
  2. String-building **only for the visible window** \[skip, skip + MAX_INPUT_LINES)\ — pre-viewport chars iterate with a reused buffer (current.clear()) and break early once isible_end is reached

**Result:** O(n) integer ops + O(1) allocations per frame regardless of input size.

Also fixes a pre-existing Windows-only test failure (etch_rejects_oversized_content_length) caused by an immediate shutdown() sending a TCP RST before the client could read response headers.

## Test Plan

- [x] \cargo test\ passes (all crates)
- [x] \cargo clippy --workspace --all-targets -- -D warnings\ clean
- [ ] Paste a large multi-line block — inserts instantly with no visible lag
- [ ] Cursor movement, backspace, Ctrl-W, undo/redo all work correctly after a large paste
- [ ] Scrolling through a large input with arrow keys feels responsive