### PR TITLE
fix: global output directory resolution with per-call override

### DIFF
--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -108,6 +108,10 @@ pub fn mvp_tool_specs() -> Vec<acrawl_core::ToolSpec> {
                     "filename": {
                         "type": "string",
                         "description": "Filename for the saved PNG (e.g. \"shot.png\"). Only used when save is true. Defaults to a timestamped name if omitted."
+                    },
+                    "output_dir": {
+                        "type": "string",
+                        "description": "Directory to save the screenshot in. Overrides the default output directory. Can be relative (resolved against CWD) or absolute."
                     }
                 },
                 "additionalProperties": false
@@ -236,12 +240,16 @@ pub fn mvp_tool_specs() -> Vec<acrawl_core::ToolSpec> {
                 "properties": {
                     "url": { "type": "string" },
                     "filename": { "type": "string" },
-                    "subdir": { "type": "string" }
+                    "subdir": { "type": "string" },
+                    "output_dir": {
+                        "type": "string",
+                        "description": "Directory to save the file in. Overrides the default output directory. Can be relative (resolved against CWD) or absolute."
+                    }
                 },
                 "required": ["url"],
                 "additionalProperties": false
             }),
-            instructions: Some("Downloads the resource at `url` into the output directory. Optionally specify `filename` and `subdir`."),
+            instructions: Some("Downloads the resource at `url` into the output directory. Optionally specify `filename`, `subdir`, and `output_dir`."),
         },
         ToolSpec {
             name: "page_map",

--- a/crates/agent/src/tools/save_file.rs
+++ b/crates/agent/src/tools/save_file.rs
@@ -1,4 +1,4 @@
-use std::path::{Component, Path, PathBuf};
+use std::path::{Component, Path};
 
 use serde_json::{json, Value};
 
@@ -90,8 +90,8 @@ pub async fn execute(
     let parsed = parse_input(input)?;
 
     let settings = runtime::load_settings();
-    let output_dir = runtime::settings_get_output_dir(&settings).to_string();
-    let mut target = PathBuf::from(&output_dir);
+    let override_dir = input.get("output_dir").and_then(|v| v.as_str());
+    let mut target = runtime::resolve_output_dir(&settings, override_dir);
     if let Some(ref sub) = parsed.subdir {
         target.push(sub);
     }

--- a/crates/agent/src/tools/screenshot.rs
+++ b/crates/agent/src/tools/screenshot.rs
@@ -1,4 +1,4 @@
-use std::path::{Component, Path, PathBuf};
+use std::path::{Component, Path};
 
 use base64::Engine as _;
 use serde_json::Value;
@@ -68,8 +68,9 @@ pub async fn execute(
     };
 
     let settings = runtime::load_settings();
-    let output_dir = runtime::settings_get_output_dir(&settings).to_string();
-    let target = PathBuf::from(&output_dir).join(&filename);
+    let override_dir = input.get("output_dir").and_then(|v| v.as_str());
+    let output_dir = runtime::resolve_output_dir(&settings, override_dir);
+    let target = output_dir.join(&filename);
 
     tokio::fs::create_dir_all(&output_dir)
         .await
@@ -93,6 +94,7 @@ pub async fn execute(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
     use std::sync::OnceLock;
 
     use async_trait::async_trait;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -34,10 +34,6 @@ pub(crate) use app::Provider;
 fn main() {
     // Load settings.json and set env vars consumed by child processes / the crawler.
     let settings = runtime::load_settings();
-    env::set_var(
-        "ACRAWL_OUTPUT_DIR",
-        runtime::settings_get_output_dir(&settings),
-    );
     // Only seed HEADLESS from settings when not already overridden by a parent process.
     if env::var("HEADLESS").is_err() {
         env::set_var(

--- a/crates/cli/tests/mcp_stdio.rs
+++ b/crates/cli/tests/mcp_stdio.rs
@@ -29,7 +29,6 @@ impl TestServer {
             .arg("mcp")
             .env("ACRAWL_CONFIG_HOME", &config_home)
             .env_remove("HEADLESS")
-            .env_remove("ACRAWL_OUTPUT_DIR")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -41,7 +41,7 @@ pub use observer::RuntimeObserver;
 pub use prompt::{prepend_bullets, PromptBuildError, SystemPromptBuilder};
 pub use session::{ContentBlock, ConversationMessage, MessageRole, Session, SessionError};
 pub use settings::{
-    config_home_dir, load_settings, save_settings, settings_file_path,
+    config_home_dir, load_settings, resolve_output_dir, save_settings, settings_file_path,
     settings_get_auto_compact_tokens, settings_get_compaction_llm_summarization,
     settings_get_compaction_max_summary_chars,
     settings_get_compaction_preserve_recent_messages_floor,

--- a/crates/runtime/src/settings.rs
+++ b/crates/runtime/src/settings.rs
@@ -195,6 +195,33 @@ pub fn settings_get_output_dir(s: &Settings) -> &str {
     s.output_dir.as_deref().unwrap_or("output")
 }
 
+/// Resolve the effective output directory as an absolute path.
+///
+/// If `override_dir` is provided (from a tool-call parameter), it is used directly:
+/// absolute paths as-is, relative paths resolved against the current working directory.
+///
+/// If `override_dir` is `None`, the settings-level `output_dir` is used:
+/// absolute paths as-is, relative paths resolved against `config_home_dir()` (e.g. `~/.acrawl/output`).
+#[must_use]
+pub fn resolve_output_dir(settings: &Settings, override_dir: Option<&str>) -> PathBuf {
+    if let Some(dir) = override_dir {
+        let p = PathBuf::from(dir);
+        if p.is_absolute() {
+            p
+        } else {
+            std::env::current_dir().unwrap_or_default().join(p)
+        }
+    } else {
+        let configured = settings_get_output_dir(settings);
+        let p = PathBuf::from(configured);
+        if p.is_absolute() {
+            p
+        } else {
+            core_config_home_dir().join(p)
+        }
+    }
+}
+
 /// Get `auto_compact_input_tokens` setting, with default fallback.
 #[must_use]
 pub fn settings_get_auto_compact_tokens(s: &Settings) -> u64 {
@@ -454,6 +481,54 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(settings_get_output_dir(&settings_none), "output");
+    }
+
+    #[test]
+    fn test_resolve_output_dir_override_absolute() {
+        let settings = Settings::default();
+        let abs_path = std::env::temp_dir().join("acrawl_test_abs");
+        let abs_str = abs_path.to_string_lossy().to_string();
+        let result = resolve_output_dir(&settings, Some(&abs_str));
+        assert_eq!(result, abs_path);
+    }
+
+    #[test]
+    fn test_resolve_output_dir_override_relative() {
+        let settings = Settings::default();
+        let result = resolve_output_dir(&settings, Some("local_dir"));
+        let cwd = std::env::current_dir().unwrap_or_default();
+        assert_eq!(result, cwd.join("local_dir"));
+    }
+
+    #[test]
+    fn test_resolve_output_dir_settings_absolute() {
+        let abs_path = std::env::temp_dir().join("acrawl_test_settings_abs");
+        let settings = Settings {
+            output_dir: Some(abs_path.to_string_lossy().to_string()),
+            ..Default::default()
+        };
+        let result = resolve_output_dir(&settings, None);
+        assert_eq!(result, abs_path);
+    }
+
+    #[test]
+    fn test_resolve_output_dir_settings_relative() {
+        let settings = Settings {
+            output_dir: Some("relative_out".to_string()),
+            ..Default::default()
+        };
+        let result = resolve_output_dir(&settings, None);
+        assert_eq!(result, core_config_home_dir().join("relative_out"));
+    }
+
+    #[test]
+    fn test_resolve_output_dir_default() {
+        let settings = Settings {
+            output_dir: None,
+            ..Default::default()
+        };
+        let result = resolve_output_dir(&settings, None);
+        assert_eq!(result, core_config_home_dir().join("output"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The `save_file` and `screenshot --save` tools previously resolved the default `output_dir` relative to CWD. This made output location unpredictable -- especially in MCP mode where CWD depends on how the IDE launches the server.

## Changes

1. **Remove dead `ACRAWL_OUTPUT_DIR` env var** -- was set in `main.rs` but never read by any tool.

2. **Resolve default output_dir against `config_home_dir()`** -- relative paths in `settings.json` now resolve to `~/.acrawl/output/` instead of `<CWD>/output/`. Absolute paths are unaffected.

3. **Add `output_dir` parameter to both tools** -- MCP callers can now specify an explicit output directory per tool call (relative = CWD, absolute = as-is), giving full flexibility for cross-agent workflows.

## Resolution priority

1. Tool-call `output_dir` param (explicit) -- relative resolves against CWD, absolute as-is
2. `settings.json` `output_dir` (configured) -- relative resolves against `~/.acrawl/`, absolute as-is
3. Hardcoded default -- `~/.acrawl/output/`