### PR TITLE
feat: add click_at tool for coordinate-based viewport clicks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,14 +2,14 @@
 
 ## Project
 
-`acrawl` is a native-Rust LLM-driven web crawler. A user provides a natural-language goal; the agent plans, navigates, and extracts structured data via a 20-tool toolbox (16 browser + 4 agent-control). It ships as a single binary with three modes: an interactive Ratatui TUI REPL (requires a TTY), non-interactive `prompt` (one-shot) / `--resume` (slash-command replay), and `mcp` (built-in MCP server over stdio).
+`acrawl` is a native-Rust LLM-driven web crawler. A user provides a natural-language goal; the agent plans, navigates, and extracts structured data via a 21-tool toolbox (17 browser + 4 agent-control). It ships as a single binary with three modes: an interactive Ratatui TUI REPL (requires a TTY), non-interactive `prompt` (one-shot) / `--resume` (slash-command replay), and `mcp` (built-in MCP server over stdio).
 
 ## Commands
 
 ```bash
 cargo build --release                                        # produce ./target/release/acrawl
 cargo test --workspace                                       # run full test suite (~770 tests)
-cargo test -p <crate> <test_name>                            # run a single test (e.g. -p agent mvp_tool_specs_contains_expected_20_tools)
+cargo test -p <crate> <test_name>                            # run a single test (e.g. -p agent mvp_tool_specs_contains_expected_21_tools)
 cargo clippy --workspace --all-targets -- -D warnings        # lints must be clean (workspace lints set pedantic = warn)
 cargo fmt --check                                            # format check
 
@@ -29,10 +29,10 @@ Ten crates under `crates/`, compiled with `resolver = "2"`:
 - **core** (`acrawl-core`) — shared types, traits, and error hierarchy used across the workspace. Defines `ToolSpec`, `ToolEffect`, `AssistantEvent`, `RuntimeObserver`, `ContentBlock`/`ConversationMessage`/`MessageRole`/`TokenUsage`, `ToolOutcome`, `ApiClient`/`ApiRequest`, `config_home_dir`, and `OAuthConfig`.
 - **api** — HTTP + SSE clients for Anthropic (`client.rs`), OpenAI-compatible (`openai.rs`), and Codex OAuth (`codex.rs`). `sse.rs` is the shared streaming frame parser; `types.rs` holds the Anthropic message schema. `oauth.rs` contains OAuth PKCE helpers, credential persistence, and token exchange types. `provider/registry.rs` and `provider/factory.rs` handle provider discovery and client construction.
 - **browser** — browser automation layer. `PlaywrightBridge` (CloakBrowser headless Chromium), `ExtensionBridge` (Chrome extension backend via CDP), `FetchRouter` (HTTP→browser escalation), `BrowserContext` (tab/URL state), and `WsBridgeServer` (WebSocket server for extension communication). `browser_backend.rs` defines the `BrowserBackend` trait that both bridges implement.
-- **agent** — agent orchestration and the 20-tool toolbox (16 browser + 4 agent-control). `agent.rs` drives the agent loop; `tools/` contains individual tool handlers; `manager.rs` manages sub-agent fork/join lifecycle; `prompt.rs` builds the system prompt; `state.rs` holds `CrawlState`; `url_claim.rs` coordinates URL claims across agents.
+- **agent** — agent orchestration and the 21-tool toolbox (17 browser + 4 agent-control). `agent.rs` drives the agent loop; `tools/` contains individual tool handlers; `manager.rs` manages sub-agent fork/join lifecycle; `prompt.rs` builds the system prompt; `state.rs` holds `CrawlState`; `url_claim.rs` coordinates URL claims across agents.
 - **runtime** — `ConversationRuntime` (the core turn loop), `Session` persistence, system-prompt builder, compaction, usage/pricing, `config/` subdirectory (loader, MCP config, features), and a full MCP client stack in `mcp/` (`client.rs`, `types.rs`, `server_manager.rs`, `process.rs`, `naming.rs`).
 - **render** — markdown/terminal rendering (`markdown.rs`), tool call output formatting (`tool_format.rs`), output format selection (`format.rs`), and the `OutputSink` trait + implementations (`sink.rs`) that bridge runtime events to the UI.
-- **mcp-server** — built-in MCP server (`server.rs`: JSON-RPC over stdio, 16 direct browser tools + `run_goal`) and the interactive IDE installer (`installer.rs`: `acrawl mcp install`). Supports 17 clients: Claude Code, Claude Desktop, Cursor, Windsurf, VS Code, OpenCode, Zed, TRAE, JetBrains, Gemini CLI, Qwen Code, Codex CLI, Hermes, OpenClaw, Goose, Crush, Aider.
+- **mcp-server** — built-in MCP server (`server.rs`: JSON-RPC over stdio, 17 direct browser tools + `run_goal`) and the interactive IDE installer (`installer.rs`: `acrawl mcp install`). Supports 17 clients: Claude Code, Claude Desktop, Cursor, Windsurf, VS Code, OpenCode, Zed, TRAE, JetBrains, Gemini CLI, Qwen Code, Codex CLI, Hermes, OpenClaw, Goose, Crush, Aider.
 - **tui** (`acrawl-tui`) — Ratatui terminal UI. `repl_app.rs` owns the application state; `repl_render.rs` handles rendering; `events.rs` processes input; `modals/` contains auth, model-picker, and slash-command overlay widgets.
 - **cli** — thin binary entry point (`main.rs`) + orchestration. `app/` directory owns `LiveCli` and provider code paths (`api_client.rs`, `tool_executor.rs`, `model_support.rs`, `runtime_builder.rs`, `resume.rs`). `session_mgr.rs` manages sessions; `output_sink.rs` bridges events to output; `self_update.rs` handles `acrawl update`.
 - **commands** — slash-command registry (`/help`, `/status`, `/model`, `/compact`, `/clear`, `/cost`, `/session`, `/export`, `/resume`, `/config`, `/auth`, `/headed`, `/headless`, `/extension`, `/cloakbrowser`, `/debug`, `/version`, `/exit`). Knows which commands are safe to replay in `--resume`.
@@ -42,7 +42,7 @@ Ten crates under `crates/`, compiled with `resolver = "2"`:
 1. `cli::app::LiveCli` builds a `ProviderClient` via `ProviderRegistry` from the persisted `CredentialStore` (`credentials.json`), plus a `ToolExecutor` backed by `agent::ToolRegistry`.
 2. `runtime::ConversationRuntime::run_turn` drives the loop: call `ApiClient::stream` → feed `AssistantEvent`s (text deltas, tool_use, usage, stop) → execute tools through `ToolExecutor` → append results → repeat until the model emits `MessageStop` with no tool calls or `MAX_STEPS` is hit. The runtime notifies a `RuntimeObserver` at each event (text deltas, tool calls, turn end); `OutputSink` (`StdoutSink` for non-interactive `prompt`/`--resume`, `ChannelSink` for TUI) implements this trait to bridge events to the UI.
 3. The crawler tool handlers (`crates/agent/src/tools/*.rs`) take JSON input, consult `CrawlState`, and act through a `BrowserContext` that wraps either the `FetchRouter` (reqwest HTTP path) or the `PlaywrightBridge` (headless Chromium). The router auto-escalates from HTTP to the browser when JS is needed.
-4. The optional `--allowedTools` CLI flag restricts which tools are available; `CliToolExecutor` enforces this before execution. `ToolSpec` has no permission tier — all 20 tools are unrestricted by default.
+4. The optional `--allowedTools` CLI flag restricts which tools are available; `CliToolExecutor` enforces this before execution. `ToolSpec` has no permission tier — all 21 tools are unrestricted by default.
 5. `runtime::UsageTracker` + `pricing_for_model` feed `/cost` and `/status`. `runtime::compact` watches `ACRAWL_AUTO_COMPACT_INPUT_TOKENS` (default 200k) and auto-compacts the session when the threshold trips.
 
 The CloakBrowser bridge is notable: it is a **single embedded Node script** launched as a subprocess, using CloakBrowser (not stock Playwright) for stealth browsing. The browser binary auto-downloads on first use — no separate install step needed.
@@ -75,7 +75,7 @@ Default model comes from the `default_model` field in the active provider's `Sto
 
 ## Tool surface
 
-`agent::mvp_tool_specs()` returns the canonical 20-tool list with JSON schemas and required permission. When you add or rename a tool, update `mvp_tool_specs`, add a handler in `tools/mod.rs`, and adjust the count assertion in `crates/agent/src/lib.rs` tests.
+`agent::mvp_tool_specs()` returns the canonical 21-tool list with JSON schemas and required permission. When you add or rename a tool, update `mvp_tool_specs`, add a handler in `tools/mod.rs`, and adjust the count assertion in `crates/agent/src/lib.rs` tests.
 
 ## Conventions specific to this repo
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 </p>
 
 <p align="center">
-  Single binary. No Python runtime. 20 tools. 25 LLM providers. MCP server built-in.
+  Single binary. No Python runtime. 21 tools. 25 LLM providers. MCP server built-in.
 </p>
 
 ---
@@ -34,10 +34,10 @@ acrawl is that wiring, packaged as a single Rust binary. You describe a goal; th
 - **No code required.** Describe the goal in English. The agent plans and executes.
 - **One binary, zero runtimes.** `cargo build --release` produces a self-contained executable. No Python, no Node runtime — just Rust and a Chromium download for browser automation.
 - **Smart fetching.** Static pages are served over HTTP (fast). When JavaScript or interaction is needed, acrawl detects JS framework markers (`__next_data__`, `__nuxt`, `__vue`, `ng-app`, React roots), auth redirects, and short `<noscript>` bodies — then transparently escalates to a headless browser.
-- **20 tools, not a chatbot.** The agent has real tools — navigate, click, fill forms, run JS, take screenshots, manage tabs — plus a fork/join layer to spawn parallel sub-agents across multiple browser tabs.
+- **21 tools, not a chatbot.** The agent has real tools — navigate, click, fill forms, run JS, take screenshots, manage tabs — plus a fork/join layer to spawn parallel sub-agents across multiple browser tabs.
 - **25 LLM providers.** Anthropic, OpenAI, Google Gemini, DeepSeek, AWS Bedrock, Azure OpenAI, Vertex AI, GitHub Copilot, Groq, Mistral, xAI, Cohere, Alibaba DashScope, OpenRouter, and more. Or bring your own via any OpenAI-compatible endpoint.
 - **MCP client.** Extend the agent with custom tools via [Model Context Protocol](https://modelcontextprotocol.io) servers (stdio, SSE, HTTP, WebSocket).
-- **MCP server.** `acrawl mcp` exposes all 16 browser tools plus an autonomous `run_goal` agent to any MCP-compatible client — Claude Code, Cursor, Windsurf, VS Code, Zed, JetBrains, TRAE, Gemini CLI, and more. Install with `acrawl mcp install`.
+- **MCP server.** `acrawl mcp` exposes all 17 browser tools plus an autonomous `run_goal` agent to any MCP-compatible client — Claude Code, Cursor, Windsurf, VS Code, Zed, JetBrains, TRAE, Gemini CLI, and more. Install with `acrawl mcp install`.
 
 ### How does it compare?
 
@@ -167,7 +167,7 @@ The agent spawns up to 5 concurrent sub-agents, each on its own browser tab, to 
 
 ## Features
 
-### 20-Tool Toolbox
+### 21-Tool Toolbox
 
 #### Navigation
 
@@ -184,6 +184,7 @@ The agent spawns up to 5 concurrent sub-agents, each on its own browser tab, to 
 | Tool | Description |
 |------|-------------|
 | `click` | Click an element by CSS selector. Returns `page_state` after the click. |
+| `click_at` | Click at specific viewport coordinates (x, y). Use for canvas, maps, or SVGs. Returns `page_state`. |
 | `fill_form` | Fill form fields by selector or name, with optional auto-submit. Returns `page_state`. |
 | `select_option` | Select a dropdown option by value, label, or index. Returns `page_state`. |
 | `hover` | Hover over an element to reveal tooltips or menus. Returns `page_state`. |
@@ -314,7 +315,7 @@ Use `--allowedTools` to restrict which tools the agent can invoke (comma-separat
 acrawl prompt "scrape titles" --allowedTools navigate,read_content,screenshot
 ```
 
-Omit `--allowedTools` to allow all 20 tools. Useful for locking down a crawl to read-only tools or excluding `fork`/`wait_for_subagents` when sub-agent parallelism is not desired.
+Omit `--allowedTools` to allow all 21 tools. Useful for locking down a crawl to read-only tools or excluding `fork`/`wait_for_subagents` when sub-agent parallelism is not desired.
 
 ### MCP Extensibility
 
@@ -326,10 +327,10 @@ Supported transports: **stdio**, **SSE**, **HTTP**, **WebSocket**.
 
 `acrawl mcp` starts a built-in MCP server that exposes acrawl's browser automation capabilities to external agents like Claude Code, Cursor, VS Code, Zed, JetBrains, TRAE, Gemini CLI, or any MCP-compatible client.
 
-The server provides **17 tools** in two modes:
+The server provides **18 tools** in two modes:
 
-**Direct browser tools (16)** — fine-grained control for clients that orchestrate themselves:
-`navigate`, `click`, `fill_form`, `page_map`, `read_content`, `screenshot`, `go_back`, `scroll`, `wait`, `select_option`, `execute_js`, `hover`, `press_key`, `switch_tab`, `list_resources`, `save_file`
+**Direct browser tools (17)** — fine-grained control for clients that orchestrate themselves:
+`navigate`, `click`, `click_at`, `fill_form`, `page_map`, `read_content`, `screenshot`, `go_back`, `scroll`, `wait`, `select_option`, `execute_js`, `hover`, `press_key`, `switch_tab`, `list_resources`, `save_file`
 
 **Autonomous agent (1)** — delegate a full crawl task:
 - **`run_goal`** — Execute a high-level crawl goal autonomously. The agent plans, navigates, and extracts data using its own LLM loop. Requires `~/.acrawl/credentials.json` configured with a model.
@@ -444,7 +445,7 @@ claude mcp add acrawl -- acrawl mcp
 
 The browser tools share a persistent session across calls. `run_goal` creates its own isolated agent and browser.
 
-**Requirements:** The 16 browser tools work without any configuration. `run_goal` requires `~/.acrawl/credentials.json` (via `acrawl auth`) for its internal LLM.
+**Requirements:** The 17 browser tools work without any configuration. `run_goal` requires `~/.acrawl/credentials.json` (via `acrawl auth`) for its internal LLM.
 
 ## Usage
 
@@ -550,7 +551,7 @@ flowchart LR
 ```
 
 1. The agent receives a goal and builds a multi-step plan via a [7-section system prompt](crates/crawler/src/prompt.rs) covering identity, operating procedure, data integrity, constraints, error recovery, completion protocol, and parallel exploration guidance.
-2. Each turn, it picks from its 20 tools based on what it observes on the page.
+2. Each turn, it picks from its 21 tools based on what it observes on the page.
 3. `navigate` hits the FetchRouter, which tries HTTP first and auto-escalates to a headless Chromium browser when JavaScript, auth redirects, or framework markers are detected.
 4. The browser is driven by an embedded Node.js subprocess (the PlaywrightBridge) speaking newline-delimited JSON over stdio — uses CloakBrowser for stealth browsing, not stock Playwright. Alternatively, acrawl can drive the user's real browser via a Chrome extension (`/extension` command) using CDP over a local WebSocket bridge.
 5. For multi-page tasks, the agent can `fork` child agents onto separate browser tabs, each with independent state and step budgets. `wait_for_subagents` or `done` merges results.
@@ -564,7 +565,7 @@ crates/
   core/         Shared types, traits, error hierarchy (acrawl-core)
   api/          25 provider clients (Anthropic, OpenAI, Gemini, DeepSeek, Bedrock, Azure, ...), SSE streaming
   browser/      PlaywrightBridge, ExtensionBridge, FetchRouter, BrowserContext, WsBridgeServer
-  agent/        20 tools, agent loop, sub-agent fork/join, CrawlState
+  agent/        21 tools, agent loop, sub-agent fork/join, CrawlState
   runtime/      ConversationRuntime, config, sessions, MCP client stack, OAuth PKCE
   render/       Markdown rendering, tool output formatting, OutputSink
   mcp-server/   Built-in MCP server (JSON-RPC over stdio), IDE installer

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -78,6 +78,20 @@ pub fn mvp_tool_specs() -> Vec<acrawl_core::ToolSpec> {
             instructions: Some("May trigger navigation or page changes. The response includes post-action page state (URL, title, page structure) so you can see what changed. Use navigate with a direct URL from page_map.links instead of click when possible \u{2014} it's more reliable."),
         },
         ToolSpec {
+            name: "click_at",
+            description: "Click at specific viewport coordinates (x, y). Use for canvas, maps, SVGs, or elements without stable CSS selectors",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "x": { "type": "number", "description": "X coordinate in viewport pixels" },
+                    "y": { "type": "number", "description": "Y coordinate in viewport pixels" }
+                },
+                "required": ["x", "y"],
+                "additionalProperties": false
+            }),
+            instructions: Some("Dispatches a real mouse click at the given viewport coordinates using Playwright's page.mouse.click(). Coordinates are relative to the top-left corner of the viewport. Use screenshot first to identify target positions. Prefer the selector-based 'click' tool for normal elements \u{2014} use click_at only when elements lack stable selectors (canvas drawings, interactive maps, SVG regions, coordinate-based UIs)."),
+        },
+        ToolSpec {
             name: "fill_form",
             description: "Fill a form field with a value",
             input_schema: json!({
@@ -387,13 +401,14 @@ mod tests {
     use super::mvp_tool_specs;
 
     #[test]
-    fn mvp_tool_specs_contains_expected_20_tools() {
+    fn mvp_tool_specs_contains_expected_21_tools() {
         let specs = mvp_tool_specs();
-        assert_eq!(specs.len(), 20);
+        assert_eq!(specs.len(), 21);
 
         let names: BTreeSet<_> = specs.iter().map(|spec| spec.name).collect();
-        assert_eq!(names.len(), 20, "tool names should be unique");
+        assert_eq!(names.len(), 21, "tool names should be unique");
         assert!(names.contains("navigate"));
+        assert!(names.contains("click_at"));
         assert!(names.contains("save_file"));
         assert!(names.contains("fork"));
         assert!(names.contains("wait_for_subagents"));

--- a/crates/agent/src/prompt.rs
+++ b/crates/agent/src/prompt.rs
@@ -276,7 +276,7 @@ mod tests {
     }
 
     #[test]
-    fn build_system_prompt_lists_all_20_tools() {
+    fn build_system_prompt_lists_all_tools() {
         let specs = crate::mvp_tool_specs();
         let prompt = build_system_prompt(&specs);
         let first = &prompt[0];

--- a/crates/agent/src/registry.rs
+++ b/crates/agent/src/registry.rs
@@ -10,6 +10,7 @@ pub type ToolHandler = Box<dyn Fn(&Value) -> Result<ToolEffect, ToolExecutionErr
 const ASYNC_TOOLS: &[&str] = &[
     "navigate",
     "click",
+    "click_at",
     "fill_form",
     "page_map",
     "read_content",
@@ -107,6 +108,7 @@ impl ToolRegistry {
         match name {
             "navigate" => crate::tools::navigate::execute(input, browser).await,
             "click" => crate::tools::click::execute(input, browser).await,
+            "click_at" => crate::tools::click_at::execute(input, browser).await,
             "fill_form" => crate::tools::fill_form::execute(input, browser).await,
             "page_map" => crate::tools::page_map::execute(input, browser).await,
             "read_content" => crate::tools::read_content::execute(input, browser).await,
@@ -137,7 +139,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn new_with_core_tools_registers_all_twenty() {
+    fn new_with_core_tools_registers_all_twenty_one() {
         let registry = ToolRegistry::new_with_core_tools();
         let effect_tools = [
             "fork",
@@ -145,7 +147,7 @@ mod tests {
             "cancel_subagent",
             "subagent_status",
         ];
-        assert_eq!(registry.len(), 20);
+        assert_eq!(registry.len(), 21);
         for &name in ASYNC_TOOLS.iter().chain(effect_tools.iter()) {
             assert!(registry.contains(name), "missing core tool: {name}");
         }
@@ -154,7 +156,7 @@ mod tests {
     #[test]
     fn new_for_child_same_as_parent() {
         let registry = ToolRegistry::new_for_child();
-        assert_eq!(registry.len(), 20);
+        assert_eq!(registry.len(), 21);
         assert!(registry.contains("fork"));
         assert!(registry.contains("navigate"));
     }

--- a/crates/agent/src/tools/click_at.rs
+++ b/crates/agent/src/tools/click_at.rs
@@ -1,0 +1,105 @@
+use serde_json::Value;
+
+use crate::BrowserContext;
+use crate::{CrawlError, ToolEffect, ToolExecutionError};
+
+#[derive(Debug)]
+struct ClickAtInput {
+    x: f64,
+    y: f64,
+}
+
+fn parse_input(input: &Value) -> Result<ClickAtInput, CrawlError> {
+    let x = input
+        .get("x")
+        .and_then(Value::as_f64)
+        .ok_or_else(|| CrawlError::new("missing required field: x"))?;
+
+    let y = input
+        .get("y")
+        .and_then(Value::as_f64)
+        .ok_or_else(|| CrawlError::new("missing required field: y"))?;
+
+    Ok(ClickAtInput { x, y })
+}
+
+pub async fn execute(
+    input: &Value,
+    browser: &mut BrowserContext,
+) -> Result<ToolEffect, ToolExecutionError> {
+    let params = parse_input(input)?;
+    browser
+        .acquire_bridge()
+        .await
+        .map_err(|e| ToolExecutionError::new(e.to_string()))?
+        .click_at(params.x, params.y)
+        .await
+        .map_err(|e| ToolExecutionError::new(e.to_string()))?;
+
+    let page_state = super::feedback::post_action_page_state(browser).await;
+
+    Ok(ToolEffect::reply_json(&serde_json::json!({
+        "success": true,
+        "message": format!("Clicked at coordinates ({}, {})", params.x, params.y),
+        "page_state": page_state
+    })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_valid_coordinates() {
+        let input = json!({"x": 100.0, "y": 200.0});
+        let result = parse_input(&input).unwrap();
+        assert!((result.x - 100.0).abs() < f64::EPSILON);
+        assert!((result.y - 200.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parse_integer_coordinates() {
+        let input = json!({"x": 150, "y": 300});
+        let result = parse_input(&input).unwrap();
+        assert!((result.x - 150.0).abs() < f64::EPSILON);
+        assert!((result.y - 300.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parse_missing_x_returns_error() {
+        let input = json!({"y": 200});
+        let err = parse_input(&input).unwrap_err();
+        assert!(err.to_string().contains('x'));
+    }
+
+    #[test]
+    fn parse_missing_y_returns_error() {
+        let input = json!({"x": 100});
+        let err = parse_input(&input).unwrap_err();
+        assert!(err.to_string().contains('y'));
+    }
+
+    #[test]
+    fn parse_non_numeric_returns_error() {
+        let input = json!({"x": "abc", "y": 200});
+        assert!(parse_input(&input).is_err());
+    }
+
+    #[test]
+    fn click_at_response_includes_page_state() {
+        let mock_pm = json!({
+            "headings": [], "landmarks": [], "forms": [], "links": [],
+            "interactive": {}, "meta": {"title": "Test", "url": "https://test.com", "description": ""}
+        });
+        let page_state = crate::tools::feedback::build_page_state_from_map(mock_pm);
+        let response = json!({
+            "success": true,
+            "message": "Clicked at coordinates (100, 200)",
+            "page_state": page_state
+        });
+        assert!(response["page_state"]["url"].is_string());
+        assert!(response["page_state"]["title"].is_string());
+        assert!(!response["page_state"]["page_map"].is_null());
+    }
+}

--- a/crates/agent/src/tools/mod.rs
+++ b/crates/agent/src/tools/mod.rs
@@ -1,5 +1,6 @@
 pub mod cancel_subagent;
 pub mod click;
+pub mod click_at;
 pub mod feedback;
 pub mod fill_form;
 pub mod fork;

--- a/crates/agent/src/tools/screenshot.rs
+++ b/crates/agent/src/tools/screenshot.rs
@@ -215,6 +215,9 @@ mod tests {
         async fn click(&mut self, _: &str) -> Result<(), BridgeError> {
             Ok(())
         }
+        async fn click_at(&mut self, _: f64, _: f64) -> Result<(), BridgeError> {
+            Ok(())
+        }
         async fn fill(&mut self, _: &str, _: &str) -> Result<(), BridgeError> {
             Ok(())
         }

--- a/crates/browser/src/browser_backend.rs
+++ b/crates/browser/src/browser_backend.rs
@@ -35,6 +35,7 @@ pub trait BrowserBackend: Debug {
     async fn list_resources(&mut self) -> Result<serde_json::Value, BridgeError>;
     async fn save_file(&mut self, url: &str, path: &str) -> Result<String, BridgeError>;
     async fn click(&mut self, selector: &str) -> Result<(), BridgeError>;
+    async fn click_at(&mut self, x: f64, y: f64) -> Result<(), BridgeError>;
     async fn fill(&mut self, selector: &str, value: &str) -> Result<(), BridgeError>;
     async fn screenshot(&mut self) -> Result<(String, usize), BridgeError>;
     async fn go_back(&mut self) -> Result<String, BridgeError>;

--- a/crates/browser/src/extension.rs
+++ b/crates/browser/src/extension.rs
@@ -304,6 +304,11 @@ impl BrowserBackend for ExtensionBridge {
             .await
     }
 
+    async fn click_at(&mut self, x: f64, y: f64) -> Result<(), BridgeError> {
+        self.expect_unit("click_at", json!({ "x": x, "y": y }))
+            .await
+    }
+
     async fn fill(&mut self, selector: &str, value: &str) -> Result<(), BridgeError> {
         self.expect_unit(
             "fill",

--- a/crates/browser/src/playwright/backend_impl.rs
+++ b/crates/browser/src/playwright/backend_impl.rs
@@ -91,6 +91,10 @@ impl BrowserBackend for PlaywrightBridge {
         PlaywrightBridge::click(self, selector).await
     }
 
+    async fn click_at(&mut self, x: f64, y: f64) -> Result<(), BridgeError> {
+        PlaywrightBridge::click_at(self, x, y).await
+    }
+
     async fn fill(&mut self, selector: &str, value: &str) -> Result<(), BridgeError> {
         PlaywrightBridge::fill(self, selector, value).await
     }

--- a/crates/browser/src/playwright/bridge.rs
+++ b/crates/browser/src/playwright/bridge.rs
@@ -369,6 +369,16 @@ impl PlaywrightBridge {
         Ok(())
     }
 
+    pub async fn click_at(&mut self, x: f64, y: f64) -> Result<(), BridgeError> {
+        let cmd = serde_json::json!({
+            "action": "click_at",
+            "x": x,
+            "y": y,
+        });
+        self.send_raw_command(&cmd).await?;
+        Ok(())
+    }
+
     pub async fn fill(&mut self, selector: &str, value: &str) -> Result<(), BridgeError> {
         let cmd = serde_json::json!({
             "action": "fill",

--- a/crates/browser/src/playwright/bridge_script.rs
+++ b/crates/browser/src/playwright/bridge_script.rs
@@ -277,6 +277,16 @@ async function bootstrap() {
       continue;
     }
 
+    if (command.action === 'click_at') {
+      try {
+        await page.mouse.click(command.x, command.y);
+        process.stdout.write(JSON.stringify({ event: 'bridge_response', ok: true, result: { clicked: true, x: command.x, y: command.y } }) + '\n');
+      } catch (error) {
+        process.stdout.write(JSON.stringify({ event: 'bridge_response', ok: false, error: { kind: 'click_at_failed', message: String(error) } }) + '\n');
+      }
+      continue;
+    }
+
     if (command.action === 'fill') {
       try {
         const sel = await resolveFillSelector(page, command.selector);

--- a/crates/browser/tests/public_api.rs
+++ b/crates/browser/tests/public_api.rs
@@ -121,6 +121,10 @@ impl BrowserBackend for MockBrowserBackend {
         Ok(())
     }
 
+    async fn click_at(&mut self, _x: f64, _y: f64) -> Result<(), BridgeError> {
+        Ok(())
+    }
+
     async fn fill(&mut self, _selector: &str, _value: &str) -> Result<(), BridgeError> {
         Ok(())
     }

--- a/crates/cli/tests/mcp_stdio.rs
+++ b/crates/cli/tests/mcp_stdio.rs
@@ -160,7 +160,7 @@ fn stdio_server_handles_initialize_list_and_tool_call() {
     assert!(names.contains(&"run_goal"));
     assert!(!names.contains(&"fork"));
     assert!(!names.contains(&"list_builtin_tools"));
-    assert_eq!(names.len(), 17);
+    assert_eq!(names.len(), 18);
 
     server.send(&json!({
         "jsonrpc": "2.0",
@@ -259,7 +259,7 @@ fn stdio_server_supports_line_delimited_jsonrpc() {
     assert_eq!(response["id"], 21);
     assert!(names.contains(&"navigate"));
     assert!(names.contains(&"run_goal"));
-    assert_eq!(names.len(), 17);
+    assert_eq!(names.len(), 18);
 
     server.shutdown();
 }

--- a/crates/mcp-server/src/server.rs
+++ b/crates/mcp-server/src/server.rs
@@ -989,12 +989,12 @@ mod tests {
     }
 
     #[test]
-    fn tools_list_has_16_browser_tools_plus_run_goal() {
+    fn tools_list_has_17_browser_tools_plus_run_goal() {
         let browser_specs: Vec<_> = mvp_tool_specs()
             .into_iter()
             .filter(|spec| !EXCLUDED_TOOLS.contains(&spec.name))
             .collect();
-        assert_eq!(browser_specs.len(), 16);
+        assert_eq!(browser_specs.len(), 17);
         let names: BTreeSet<&str> = browser_specs.iter().map(|s| s.name).collect();
         assert!(names.contains("navigate"));
         assert!(names.contains("click"));

--- a/extension/README.md
+++ b/extension/README.md
@@ -64,7 +64,7 @@ The extension communicates with acrawl over a local WebSocket connection:
 3. acrawl sends `{id, action, payload}` commands (navigate, click, screenshot, etc.)
 4. The extension executes them via Chrome DevTools Protocol (CDP) and returns `{id, ok, result}`
 
-All 16 browser tools work through this bridge — the same tool surface as CloakBrowser.
+All 17 browser tools work through this bridge — the same tool surface as CloakBrowser.
 
 ## Troubleshooting
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -17,6 +17,7 @@ try {
     'commands/wait.js',
     'commands/select_option.js',
     'commands/save_file.js',
+    'commands/click_at.js',
     'commands/cookies.js'
   );
 } catch (e) {
@@ -267,6 +268,9 @@ async function handleCommand(cmd) {
             break;
           case 'click':
             result = await handleClick(tabId, cmd.payload || {});
+            break;
+          case 'click_at':
+            result = await handleClickAt(tabId, cmd.payload || {});
             break;
           case 'fill':
             result = await handleFill(tabId, cmd.payload || {});

--- a/extension/commands/click_at.js
+++ b/extension/commands/click_at.js
@@ -1,0 +1,37 @@
+'use strict';
+
+async function handleClickAt(tabId, payload) {
+  const x = payload?.x;
+  const y = payload?.y;
+  if (typeof x !== 'number' || typeof y !== 'number') {
+    throw new Error('click_at requires numeric payload.x and payload.y');
+  }
+
+  await ensureAttached(tabId);
+
+  await cdp(tabId, 'Input.dispatchMouseEvent', {
+    type: 'mouseMoved',
+    x,
+    y,
+    button: 'none',
+    buttons: 0,
+  });
+  await cdp(tabId, 'Input.dispatchMouseEvent', {
+    type: 'mousePressed',
+    x,
+    y,
+    button: 'left',
+    buttons: 1,
+    clickCount: 1,
+  });
+  await cdp(tabId, 'Input.dispatchMouseEvent', {
+    type: 'mouseReleased',
+    x,
+    y,
+    button: 'left',
+    buttons: 0,
+    clickCount: 1,
+  });
+
+  return { clicked: true, x, y };
+}


### PR DESCRIPTION
## Summary

Adds a new `click_at` tool (#21) that dispatches real mouse clicks at specific viewport coordinates via Playwright's `page.mouse.click(x, y)`. This enables interaction with canvas elements, maps, SVGs, and other UI components that lack stable CSS selectors.

## Motivation

The existing `click` tool only accepts CSS selectors. For canvas/drawing/annotation testing, users need to click at (x, y) on the viewport. Previously, this required falling back to `execute_js` with synthetic MouseEvent dispatches - which don't replicate real browser pointer behavior (capture, bubbling, pointer capture). `click_at` uses Playwright's native `page.mouse.click()` which fires real input events through the browser's event pipeline.

## Schema (OpenAI strict-mode compatible)

All properties are required with no nullable optionals - fully compatible with OpenAI's `strict: true` function calling mode.

`json
{
  "type": "object",
  "properties": {
    "x": { "type": "number", "description": "X coordinate in viewport pixels" },
    "y": { "type": "number", "description": "Y coordinate in viewport pixels" }
  },
  "required": ["x", "y"],
  "additionalProperties": false
}
`

## Design Decision: Separate Tool vs. Extending click

We chose a separate `click_at` tool instead of adding optional x/y parameters to the existing `click` tool because:

1. **OpenAI strict mode** requires all properties in `required` - adding optional coordinates to `click` would force the LLM to emit `"x": null, "y": null` on every normal click
2. **No LLM confusion** - each tool has a single clear purpose with no mutually-exclusive parameter modes
3. **Clean JSON schemas** - no nullable gymnastics needed for MCP clients

## Changes

**Browser crate (3 files):**
- `BrowserBackend` trait: +1 method `click_at(x, y)`
- `PlaywrightBridge`: bridge command + Node.js handler using `page.mouse.click()`
- `ExtensionBridge`: sends `click_at` action to Chrome extension

**Agent crate (5 files):**
- New handler: `tools/click_at.rs` with input parsing + 7 unit tests
- Registry: added to `ASYNC_TOOLS` + `execute_async` dispatch
- Tool spec: added to `mvp_tool_specs()` (tool count 20 -> 21)

**Docs (3 files):**
- README.md, AGENTS.md, extension/README.md: updated all tool counts and tables

**Tests:**
- All mock `BrowserBackend` impls updated
- 315+ tests pass across `agent` and `browser` crates
- Clippy clean with `-D warnings`
