### PR TITLE
feat: enrich page_map and wait tools with better observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ The agent spawns up to 5 concurrent sub-agents, each on its own browser tab, to 
 | `go_back` | Browser back button. Returns `page_state` with the resulting page structure. |
 | `scroll` | Scroll up or down by pixel amount (`pixels`, default: 500). Returns `page_state` after scrolling. |
 | `switch_tab` | Switch to a different browser tab by index. Returns `page_state` of the new tab. |
-| `wait` | Wait for a CSS selector to appear or a timeout (up to 300s). |
+| `wait` | Wait for a CSS selector to reach a given state (`visible`, `hidden`, `attached`, `detached`) or a fixed timeout (up to 300s). |
 
 #### Interaction
 
@@ -195,7 +195,7 @@ The agent spawns up to 5 concurrent sub-agents, each on its own browser tab, to 
 
 | Tool | Description |
 |------|-------------|
-| `page_map` | Get the page's structural map: headings, landmarks, forms, links, and interactive element counts. |
+| `page_map` | Get the page's structural map: headings, landmarks, forms, links, and interactive elements (with selectors and state). Supports `scope` to query within a specific element (e.g. a modal). |
 | `read_content` | Extract text by heading name or CSS selector, with offset/limit pagination for large pages. |
 | `list_resources` | List all links, images, and forms on the current page. |
 | `screenshot` | Capture a full-page screenshot (base64 PNG). |

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -180,11 +180,16 @@ pub fn mvp_tool_specs() -> Vec<acrawl_core::ToolSpec> {
                 "type": "object",
                 "properties": {
                     "selector": { "type": "string" },
-                    "seconds": { "type": "number" }
+                    "seconds": { "type": "number" },
+                    "state": {
+                        "type": "string",
+                        "enum": ["visible", "hidden", "attached", "detached"],
+                        "description": "Wait for element to reach this state. Default: attached (exists in DOM)."
+                    }
                 },
                 "additionalProperties": false
             }),
-            instructions: Some("Use after actions that trigger page changes (form submits, AJAX requests). Pass `selector` to wait for an element, or `seconds` for a fixed delay."),
+            instructions: Some("Use after actions that trigger page changes (form submits, AJAX requests). Pass `selector` to wait for an element, or `seconds` for a fixed delay. Use `state: \"visible\"` to wait until the element is actually visible (not just in the DOM). Use `state: \"hidden\"` to wait for an element to disappear (e.g. a loading spinner)."),
         },
         ToolSpec {
             name: "select_option",
@@ -288,11 +293,15 @@ pub fn mvp_tool_specs() -> Vec<acrawl_core::ToolSpec> {
             description: "Get comprehensive page structure: headings, landmarks, forms, interactive elements, and links",
             input_schema: json!({
                 "type": "object",
-                "properties": {},
-                "required": [],
+                "properties": {
+                    "scope": {
+                        "type": "string",
+                        "description": "CSS selector to scope all queries within (e.g. \"[role='dialog']\" for modal content only). If omitted, queries the full page."
+                    }
+                },
                 "additionalProperties": false
             }),
-            instructions: Some("Returns the full page anatomy: heading hierarchy (h1-h6 with section sizes), landmark regions (nav/main/aside/article/footer), forms (with field details), links (text + href, capped at 50), interactive element counts, and page metadata. Use links[].href with navigate instead of clicking when the URL is visible. If headings is empty, the page has no semantic headings \u{2014} check landmarks instead."),
+            instructions: Some("Returns the full page anatomy: heading hierarchy (h1-h6 with section sizes), landmark regions, forms (with field details), links (text + href, capped at 50), interactive elements (buttons/inputs/selects with their text, selector, and state like disabled/aria-pressed/aria-expanded), and page metadata. Use scope to inspect only a modal/dialog/overlay without noise from the background page. Use links[].href with navigate instead of clicking when the URL is visible."),
         },
         ToolSpec {
             name: "read_content",

--- a/crates/agent/src/tools/feedback.rs
+++ b/crates/agent/src/tools/feedback.rs
@@ -58,7 +58,7 @@ fn fallback_value() -> Value {
 pub async fn post_action_page_state(browser: &mut BrowserContext) -> Value {
     let result = timeout(FEEDBACK_TIMEOUT, async {
         let mut bridge = browser.acquire_bridge().await?;
-        bridge.page_map().await
+        bridge.page_map(None).await
     })
     .await;
 

--- a/crates/agent/src/tools/navigate.rs
+++ b/crates/agent/src/tools/navigate.rs
@@ -265,7 +265,7 @@ pub async fn execute(
 
     let page_map = if page.fetched_via_browser {
         match browser.acquire_bridge().await {
-            Ok(mut bridge) => match bridge.page_map().await {
+            Ok(mut bridge) => match bridge.page_map(None).await {
                 Ok(mut value) => {
                     apply_page_map_caps(&mut value);
                     value

--- a/crates/agent/src/tools/page_map.rs
+++ b/crates/agent/src/tools/page_map.rs
@@ -109,7 +109,9 @@ mod tests {
                 "buttons": 1,
                 "inputs": 2,
                 "selects": 3,
-                "textareas": 4
+                "textareas": 4,
+                "total": 10,
+                "elements": []
             },
             "meta": {
                 "title": "Example",
@@ -263,5 +265,59 @@ mod tests {
 
         assert_eq!(value["links"].as_array().map(Vec::len), Some(5));
         assert_eq!(value["truncated_links"], json!(false));
+    }
+
+    #[test]
+    fn page_map_interactive_backward_compat_shape() {
+        let value = json!({
+            "interactive": {
+                "buttons": 3,
+                "inputs": 2,
+                "selects": 1,
+                "textareas": 0,
+                "total": 6,
+                "elements": [
+                    {"tag": "button", "text": "Submit", "selector": "#submit"}
+                ]
+            }
+        });
+
+        let interactive = &value["interactive"];
+
+        assert_eq!(interactive["buttons"], json!(3));
+        assert_eq!(interactive["inputs"], json!(2));
+        assert_eq!(interactive["selects"], json!(1));
+        assert_eq!(interactive["textareas"], json!(0));
+        assert_eq!(interactive["total"], json!(6));
+        assert!(interactive["elements"].is_array());
+        assert_eq!(interactive["elements"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn page_map_scope_not_found_response() {
+        let value = json!({
+            "scope_not_found": true,
+            "scope": "[role='dialog']",
+            "headings": [],
+            "landmarks": [],
+            "forms": [],
+            "links": [],
+            "interactive": {
+                "buttons": 0,
+                "inputs": 0,
+                "selects": 0,
+                "textareas": 0,
+                "total": 0,
+                "elements": []
+            },
+            "meta": { "title": "Test", "description": "", "url": "https://example.com" },
+            "total_landmarks": 0,
+            "total_forms": 0,
+            "total_links": 0
+        });
+
+        assert_eq!(value["scope_not_found"], json!(true));
+        assert_eq!(value["scope"], json!("[role='dialog']"));
+        assert!(value["headings"].as_array().unwrap().is_empty());
     }
 }

--- a/crates/agent/src/tools/page_map.rs
+++ b/crates/agent/src/tools/page_map.rs
@@ -39,13 +39,13 @@ pub async fn execute(
     input: &Value,
     browser: &mut BrowserContext,
 ) -> Result<ToolEffect, ToolExecutionError> {
-    let _ = input;
+    let scope = input.get("scope").and_then(Value::as_str);
 
     let mut result = browser
         .acquire_bridge()
         .await
         .map_err(|e| ToolExecutionError::new(e.to_string()))?
-        .page_map()
+        .page_map(scope)
         .await
         .map_err(|e| ToolExecutionError::new(e.to_string()))?;
 

--- a/crates/agent/src/tools/page_map.rs
+++ b/crates/agent/src/tools/page_map.rs
@@ -106,11 +106,7 @@ mod tests {
                 }
             ],
             "interactive": {
-                "buttons": 1,
-                "inputs": 2,
-                "selects": 3,
-                "textareas": 4,
-                "total": 10,
+                "counts": { "buttons": 1, "inputs": 2, "selects": 3, "textareas": 4, "total": 10 },
                 "elements": []
             },
             "meta": {
@@ -271,11 +267,7 @@ mod tests {
     fn page_map_interactive_backward_compat_shape() {
         let value = json!({
             "interactive": {
-                "buttons": 3,
-                "inputs": 2,
-                "selects": 1,
-                "textareas": 0,
-                "total": 6,
+                "counts": { "buttons": 3, "inputs": 2, "selects": 1, "textareas": 0, "total": 6 },
                 "elements": [
                     {"tag": "button", "text": "Submit", "selector": "#submit"}
                 ]
@@ -284,11 +276,11 @@ mod tests {
 
         let interactive = &value["interactive"];
 
-        assert_eq!(interactive["buttons"], json!(3));
-        assert_eq!(interactive["inputs"], json!(2));
-        assert_eq!(interactive["selects"], json!(1));
-        assert_eq!(interactive["textareas"], json!(0));
-        assert_eq!(interactive["total"], json!(6));
+        assert_eq!(interactive["counts"]["buttons"], json!(3));
+        assert_eq!(interactive["counts"]["inputs"], json!(2));
+        assert_eq!(interactive["counts"]["selects"], json!(1));
+        assert_eq!(interactive["counts"]["textareas"], json!(0));
+        assert_eq!(interactive["counts"]["total"], json!(6));
         assert!(interactive["elements"].is_array());
         assert_eq!(interactive["elements"].as_array().unwrap().len(), 1);
     }
@@ -303,11 +295,7 @@ mod tests {
             "forms": [],
             "links": [],
             "interactive": {
-                "buttons": 0,
-                "inputs": 0,
-                "selects": 0,
-                "textareas": 0,
-                "total": 0,
+                "counts": { "buttons": 0, "inputs": 0, "selects": 0, "textareas": 0, "total": 0 },
                 "elements": []
             },
             "meta": { "title": "Test", "description": "", "url": "https://example.com" },

--- a/crates/agent/src/tools/screenshot.rs
+++ b/crates/agent/src/tools/screenshot.rs
@@ -192,7 +192,7 @@ mod tests {
         async fn scroll(&mut self, _: &str, _: i64) -> Result<(), BridgeError> {
             Ok(())
         }
-        async fn page_map(&mut self) -> Result<serde_json::Value, BridgeError> {
+        async fn page_map(&mut self, _scope: Option<&str>) -> Result<serde_json::Value, BridgeError> {
             Ok(serde_json::json!({}))
         }
         async fn read_content(
@@ -204,7 +204,7 @@ mod tests {
         ) -> Result<serde_json::Value, BridgeError> {
             Ok(serde_json::json!({}))
         }
-        async fn wait_for_selector(&mut self, _: &str, _: u64) -> Result<bool, BridgeError> {
+        async fn wait_for_selector(&mut self, _: &str, _: u64, _: Option<&str>) -> Result<bool, BridgeError> {
             Ok(true)
         }
         async fn select_option(&mut self, _: &str, _: &str) -> Result<(), BridgeError> {

--- a/crates/agent/src/tools/screenshot.rs
+++ b/crates/agent/src/tools/screenshot.rs
@@ -192,7 +192,10 @@ mod tests {
         async fn scroll(&mut self, _: &str, _: i64) -> Result<(), BridgeError> {
             Ok(())
         }
-        async fn page_map(&mut self, _scope: Option<&str>) -> Result<serde_json::Value, BridgeError> {
+        async fn page_map(
+            &mut self,
+            _scope: Option<&str>,
+        ) -> Result<serde_json::Value, BridgeError> {
             Ok(serde_json::json!({}))
         }
         async fn read_content(
@@ -204,7 +207,12 @@ mod tests {
         ) -> Result<serde_json::Value, BridgeError> {
             Ok(serde_json::json!({}))
         }
-        async fn wait_for_selector(&mut self, _: &str, _: u64, _: Option<&str>) -> Result<bool, BridgeError> {
+        async fn wait_for_selector(
+            &mut self,
+            _: &str,
+            _: u64,
+            _: Option<&str>,
+        ) -> Result<bool, BridgeError> {
             Ok(true)
         }
         async fn select_option(&mut self, _: &str, _: &str) -> Result<(), BridgeError> {

--- a/crates/agent/src/tools/wait.rs
+++ b/crates/agent/src/tools/wait.rs
@@ -12,6 +12,7 @@ const MAX_TIMEOUT_SECONDS: f64 = 300.0;
 pub struct WaitInput {
     pub selector: Option<String>,
     pub timeout_ms: u64,
+    pub state: Option<String>,
 }
 
 pub fn parse_input(input: &Value) -> Result<WaitInput, CrawlError> {
@@ -22,6 +23,20 @@ pub fn parse_input(input: &Value) -> Result<WaitInput, CrawlError> {
 
     let timeout_ms = parse_timeout_ms(input)?;
 
+    let state = input
+        .get("state")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    if let Some(ref s) = state {
+        let valid = ["visible", "hidden", "attached", "detached"];
+        if !valid.contains(&s.as_str()) {
+            return Err(CrawlError::new(format!(
+                "wait state must be one of: visible, hidden, attached, detached (got: {s})"
+            )));
+        }
+    }
+
     if selector.is_none() && timeout_ms == 0 {
         return Err(CrawlError::new(
             "wait requires either a selector or a positive timeout",
@@ -31,6 +46,7 @@ pub fn parse_input(input: &Value) -> Result<WaitInput, CrawlError> {
     Ok(WaitInput {
         selector,
         timeout_ms,
+        state,
     })
 }
 
@@ -79,7 +95,7 @@ pub async fn execute(
             .acquire_bridge()
             .await
             .map_err(|e| ToolExecutionError::new(e.to_string()))?
-            .wait_for_selector(selector, parsed.timeout_ms)
+            .wait_for_selector(selector, parsed.timeout_ms, parsed.state.as_deref())
             .await
             .map_err(|e| ToolExecutionError::new(e.to_string()))?;
 

--- a/crates/agent/src/tools/wait.rs
+++ b/crates/agent/src/tools/wait.rs
@@ -9,6 +9,7 @@ const DEFAULT_TIMEOUT_MS: u64 = 5_000;
 const MAX_TIMEOUT_MS: u64 = 300_000;
 const MAX_TIMEOUT_SECONDS: f64 = 300.0;
 
+#[derive(Debug)]
 pub struct WaitInput {
     pub selector: Option<String>,
     pub timeout_ms: u64,
@@ -35,6 +36,12 @@ pub fn parse_input(input: &Value) -> Result<WaitInput, CrawlError> {
                 "wait state must be one of: visible, hidden, attached, detached (got: {s})"
             )));
         }
+    }
+
+    if state.is_some() && selector.is_none() {
+        return Err(CrawlError::new(
+            "wait state requires a selector (state has no effect with a time-only wait)",
+        ));
     }
 
     if selector.is_none() && timeout_ms == 0 {
@@ -158,5 +165,37 @@ mod tests {
 
         let input = json!({"seconds": 301.0});
         assert!(parse_input(&input).is_err());
+    }
+
+    #[test]
+    fn parses_valid_state() {
+        for state in &["visible", "hidden", "attached", "detached"] {
+            let input = json!({"selector": "div", "state": state});
+            let parsed = parse_input(&input).unwrap();
+            assert_eq!(parsed.state.as_deref(), Some(*state));
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_state() {
+        let input = json!({"selector": "div", "state": "bogus"});
+        let err = parse_input(&input).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("visible, hidden, attached, detached"));
+    }
+
+    #[test]
+    fn rejects_state_without_selector() {
+        let input = json!({"seconds": 5, "state": "visible"});
+        let err = parse_input(&input).unwrap_err();
+        assert!(err.to_string().contains("state requires a selector"));
+    }
+
+    #[test]
+    fn state_none_when_omitted() {
+        let input = json!({"selector": "#btn"});
+        let parsed = parse_input(&input).unwrap();
+        assert!(parsed.state.is_none());
     }
 }

--- a/crates/browser/src/browser_backend.rs
+++ b/crates/browser/src/browser_backend.rs
@@ -23,7 +23,7 @@ pub trait BrowserBackend: Debug {
     async fn new_page(&mut self, url: Option<&str>) -> Result<usize, BridgeError>;
     async fn close_page(&mut self, page_index: usize) -> Result<(), BridgeError>;
     async fn scroll(&mut self, direction: &str, pixels: i64) -> Result<(), BridgeError>;
-    async fn page_map(&mut self) -> Result<serde_json::Value, BridgeError>;
+    async fn page_map(&mut self, scope: Option<&str>) -> Result<serde_json::Value, BridgeError>;
     async fn read_content(
         &mut self,
         heading: Option<&str>,
@@ -35,6 +35,7 @@ pub trait BrowserBackend: Debug {
         &mut self,
         selector: &str,
         timeout_ms: u64,
+        state: Option<&str>,
     ) -> Result<bool, BridgeError>;
     async fn select_option(&mut self, selector: &str, value: &str) -> Result<(), BridgeError>;
     async fn evaluate(&mut self, script: &str) -> Result<serde_json::Value, BridgeError>;

--- a/crates/browser/src/extension.rs
+++ b/crates/browser/src/extension.rs
@@ -145,8 +145,12 @@ impl BrowserBackend for ExtensionBridge {
         .await
     }
 
-    async fn page_map(&mut self) -> Result<Value, BridgeError> {
-        let response = self.send_command("page_map", json!({})).await?;
+    async fn page_map(&mut self, scope: Option<&str>) -> Result<Value, BridgeError> {
+        let mut payload = json!({});
+        if let Some(s) = scope {
+            payload["scope"] = json!(s);
+        }
+        let response = self.send_command("page_map", payload).await?;
         Self::require_result(response, "page_map")
     }
 
@@ -175,15 +179,17 @@ impl BrowserBackend for ExtensionBridge {
         &mut self,
         selector: &str,
         timeout_ms: u64,
+        state: Option<&str>,
     ) -> Result<bool, BridgeError> {
+        let mut payload = json!({
+            "selector": selector,
+            "timeout_ms": timeout_ms,
+        });
+        if let Some(s) = state {
+            payload["state"] = json!(s);
+        }
         let response = self
-            .send_command(
-                "wait_for_selector",
-                json!({
-                    "selector": selector,
-                    "timeout_ms": timeout_ms,
-                }),
-            )
+            .send_command("wait_for_selector", payload)
             .await?;
         let result = Self::require_result(response, "wait_for_selector")?;
         Ok(result

--- a/crates/browser/src/extension.rs
+++ b/crates/browser/src/extension.rs
@@ -188,9 +188,7 @@ impl BrowserBackend for ExtensionBridge {
         if let Some(s) = state {
             payload["state"] = json!(s);
         }
-        let response = self
-            .send_command("wait_for_selector", payload)
-            .await?;
+        let response = self.send_command("wait_for_selector", payload).await?;
         let result = Self::require_result(response, "wait_for_selector")?;
         Ok(result
             .get("found")

--- a/crates/browser/src/playwright/backend_impl.rs
+++ b/crates/browser/src/playwright/backend_impl.rs
@@ -21,8 +21,8 @@ impl BrowserBackend for PlaywrightBridge {
         PlaywrightBridge::scroll(self, direction, pixels).await
     }
 
-    async fn page_map(&mut self) -> Result<serde_json::Value, BridgeError> {
-        PlaywrightBridge::page_map(self).await
+    async fn page_map(&mut self, scope: Option<&str>) -> Result<serde_json::Value, BridgeError> {
+        PlaywrightBridge::page_map(self, scope).await
     }
 
     async fn read_content(
@@ -39,8 +39,9 @@ impl BrowserBackend for PlaywrightBridge {
         &mut self,
         selector: &str,
         timeout_ms: u64,
+        state: Option<&str>,
     ) -> Result<bool, BridgeError> {
-        PlaywrightBridge::wait_for_selector(self, selector, timeout_ms).await
+        PlaywrightBridge::wait_for_selector(self, selector, timeout_ms, state).await
     }
 
     async fn select_option(&mut self, selector: &str, value: &str) -> Result<(), BridgeError> {

--- a/crates/browser/src/playwright/bridge.rs
+++ b/crates/browser/src/playwright/bridge.rs
@@ -215,8 +215,14 @@ impl PlaywrightBridge {
         Ok(())
     }
 
-    pub async fn page_map(&mut self) -> Result<serde_json::Value, BridgeError> {
-        let cmd = serde_json::json!({ "action": "page_map" });
+    pub async fn page_map(
+        &mut self,
+        scope: Option<&str>,
+    ) -> Result<serde_json::Value, BridgeError> {
+        let mut cmd = serde_json::json!({ "action": "page_map" });
+        if let Some(s) = scope {
+            cmd["scope"] = serde_json::Value::String(s.to_string());
+        }
         self.send_raw_command(&cmd).await
     }
 
@@ -241,12 +247,16 @@ impl PlaywrightBridge {
         &mut self,
         selector: &str,
         timeout_ms: u64,
+        state: Option<&str>,
     ) -> Result<bool, BridgeError> {
-        let cmd = serde_json::json!({
+        let mut cmd = serde_json::json!({
             "action": "wait_for_selector",
             "selector": selector,
             "timeout_ms": timeout_ms,
         });
+        if let Some(s) = state {
+            cmd["state"] = serde_json::Value::String(s.to_string());
+        }
         let result = self.send_raw_command(&cmd).await?;
         Ok(result
             .get("found")

--- a/crates/browser/src/playwright/bridge_script.rs
+++ b/crates/browser/src/playwright/bridge_script.rs
@@ -357,7 +357,14 @@ async function bootstrap() {
       try {
         const scope = command.scope || null;
         const result = await page.evaluate((scope) => {
-          const root = scope ? (document.querySelector(scope) || document) : document;
+          let root = document;
+          if (scope) {
+            const scoped = document.querySelector(scope);
+            if (!scoped) {
+              return { scope_not_found: true, scope, headings: [], landmarks: [], forms: [], links: [], interactive: { buttons: 0, inputs: 0, selects: 0, textareas: 0, total: 0, elements: [] }, meta: { title: document.title, description: '', url: window.location.href }, total_landmarks: 0, total_forms: 0, total_links: 0 };
+            }
+            root = scoped;
+          }
 
           function cssPath(el) {
             if (el.id) return '#' + CSS.escape(el.id);
@@ -491,7 +498,7 @@ async function bootstrap() {
               }
             }
           }
-          const interactive = { counts, elements: interactiveEls };
+          const interactive = { buttons: counts.buttons, inputs: counts.inputs, selects: counts.selects, textareas: counts.textareas, total: counts.total, elements: interactiveEls };
 
           const meta = {
             title: document.title,

--- a/crates/browser/src/playwright/bridge_script.rs
+++ b/crates/browser/src/playwright/bridge_script.rs
@@ -355,7 +355,10 @@ async function bootstrap() {
 
     if (command.action === 'page_map') {
       try {
-        const result = await page.evaluate(() => {
+        const scope = command.scope || null;
+        const result = await page.evaluate((scope) => {
+          const root = scope ? (document.querySelector(scope) || document) : document;
+
           function cssPath(el) {
             if (el.id) return '#' + CSS.escape(el.id);
             const parts = [];
@@ -373,7 +376,7 @@ async function bootstrap() {
             return parts.join(' > ');
           }
 
-          const headings = Array.from(document.querySelectorAll('h1, h2, h3, h4, h5, h6')).map((el) => {
+          const headings = Array.from(root.querySelectorAll('h1, h2, h3, h4, h5, h6')).map((el) => {
             const level = parseInt(el.tagName[1]);
             const text = el.innerText.trim();
             const id = el.id || null;
@@ -391,7 +394,7 @@ async function bootstrap() {
             return { level, text, id, selector, char_count, preview };
           });
 
-          const landmarks = Array.from(document.querySelectorAll('nav, main, aside, article, footer, header, section[aria-label], [role="navigation"], [role="main"], [role="complementary"]')).map((el) => ({
+          const landmarks = Array.from(root.querySelectorAll('nav, main, aside, article, footer, header, section[aria-label], [role="navigation"], [role="main"], [role="complementary"]')).map((el) => ({
             tag: el.tagName.toLowerCase(),
             role: el.getAttribute('role'),
             id: el.id || null,
@@ -403,7 +406,7 @@ async function bootstrap() {
 
           const MAX_FORMS = 10;
           const MAX_FIELDS_PER_FORM = 30;
-          const allForms = Array.from(document.querySelectorAll('form'));
+          const allForms = Array.from(root.querySelectorAll('form'));
           const total_forms = allForms.length;
           const forms = allForms.slice(0, MAX_FORMS).map((f) => {
             const allFields = Array.from(f.querySelectorAll('input, select, textarea'));
@@ -433,7 +436,7 @@ async function bootstrap() {
           const MAX_LINKS = 50;
           let total_links = 0;
           const links = [];
-          for (const a of document.querySelectorAll('a[href]')) {
+          for (const a of root.querySelectorAll('a[href]')) {
             const text = (a.textContent || '').trim();
             const rawHref = a.getAttribute('href') || '';
             const href = a.href || rawHref;
@@ -445,12 +448,50 @@ async function bootstrap() {
             }
           }
 
-          const interactive = {
-            buttons: document.querySelectorAll('button').length,
-            inputs: document.querySelectorAll('input').length,
-            selects: document.querySelectorAll('select').length,
-            textareas: document.querySelectorAll('textarea').length,
-          };
+          const MAX_INTERACTIVE = 30;
+          const interactiveEls = [];
+          const selectors = [
+            ['button', 'button'],
+            ['input', 'input:not([type="hidden"])'],
+            ['select', 'select'],
+            ['textarea', 'textarea'],
+            ['a[role="button"]', 'a[role="button"]'],
+            ['[role="tab"]', '[role="tab"]'],
+            ['[role="menuitem"]', '[role="menuitem"]'],
+            ['[role="option"]', '[role="option"]'],
+            ['[role="switch"]', '[role="switch"]'],
+            ['[role="checkbox"]', '[role="checkbox"]'],
+          ];
+          const counts = { buttons: 0, inputs: 0, selects: 0, textareas: 0, total: 0 };
+          for (const [label, sel] of selectors) {
+            for (const el of root.querySelectorAll(sel)) {
+              counts.total++;
+              if (el.tagName === 'BUTTON' || el.getAttribute('role') === 'button') counts.buttons++;
+              else if (el.tagName === 'INPUT') counts.inputs++;
+              else if (el.tagName === 'SELECT') counts.selects++;
+              else if (el.tagName === 'TEXTAREA') counts.textareas++;
+              if (interactiveEls.length < MAX_INTERACTIVE) {
+                const entry = {
+                  tag: el.tagName.toLowerCase(),
+                  text: (el.textContent || el.value || '').trim().slice(0, 60),
+                  selector: cssPath(el),
+                };
+                if (el.disabled) entry.disabled = true;
+                if (el.type) entry.type = el.type;
+                const ariaPressed = el.getAttribute('aria-pressed');
+                if (ariaPressed) entry.aria_pressed = ariaPressed;
+                const ariaExpanded = el.getAttribute('aria-expanded');
+                if (ariaExpanded) entry.aria_expanded = ariaExpanded;
+                const ariaSelected = el.getAttribute('aria-selected');
+                if (ariaSelected) entry.aria_selected = ariaSelected;
+                const role = el.getAttribute('role');
+                if (role) entry.role = role;
+                if (el.checked) entry.checked = true;
+                interactiveEls.push(entry);
+              }
+            }
+          }
+          const interactive = { counts, elements: interactiveEls };
 
           const meta = {
             title: document.title,
@@ -459,7 +500,7 @@ async function bootstrap() {
           };
 
           return { headings, landmarks: cappedLandmarks, forms, links, interactive, meta, total_landmarks, total_forms, total_links };
-        });
+        }, scope);
         process.stdout.write(JSON.stringify({ event: 'bridge_response', ok: true, result }) + '\n');
       } catch (error) {
         process.stdout.write(JSON.stringify({ event: 'bridge_response', ok: false, error: { kind: 'page_map_error', message: String(error) } }) + '\n');
@@ -518,7 +559,9 @@ async function bootstrap() {
     if (command.action === 'wait_for_selector') {
       try {
         const timeout = command.timeout_ms || 5000;
-        await page.waitForSelector(command.selector, { timeout });
+        const opts = { timeout };
+        if (command.state) opts.state = command.state;
+        await page.waitForSelector(command.selector, opts);
         process.stdout.write(JSON.stringify({ event: 'bridge_response', ok: true, result: { found: true } }) + '\n');
       } catch (error) {
         process.stdout.write(JSON.stringify({ event: 'bridge_response', ok: true, result: { found: false } }) + '\n');

--- a/crates/browser/src/playwright/bridge_script.rs
+++ b/crates/browser/src/playwright/bridge_script.rs
@@ -361,7 +361,7 @@ async function bootstrap() {
           if (scope) {
             const scoped = document.querySelector(scope);
             if (!scoped) {
-              return { scope_not_found: true, scope, headings: [], landmarks: [], forms: [], links: [], interactive: { buttons: 0, inputs: 0, selects: 0, textareas: 0, total: 0, elements: [] }, meta: { title: document.title, description: '', url: window.location.href }, total_landmarks: 0, total_forms: 0, total_links: 0 };
+              return { scope_not_found: true, scope, headings: [], landmarks: [], forms: [], links: [], interactive: { counts: { buttons: 0, inputs: 0, selects: 0, textareas: 0, total: 0 }, elements: [] }, meta: { title: document.title, description: '', url: window.location.href }, total_landmarks: 0, total_forms: 0, total_links: 0 };
             }
             root = scoped;
           }
@@ -498,7 +498,7 @@ async function bootstrap() {
               }
             }
           }
-          const interactive = { buttons: counts.buttons, inputs: counts.inputs, selects: counts.selects, textareas: counts.textareas, total: counts.total, elements: interactiveEls };
+          const interactive = { counts, elements: interactiveEls };
 
           const meta = {
             title: document.title,

--- a/crates/browser/tests/public_api.rs
+++ b/crates/browser/tests/public_api.rs
@@ -46,7 +46,7 @@ impl BrowserBackend for MockBrowserBackend {
         Ok(())
     }
 
-    async fn page_map(&mut self) -> Result<serde_json::Value, BridgeError> {
+    async fn page_map(&mut self, _scope: Option<&str>) -> Result<serde_json::Value, BridgeError> {
         Ok(serde_json::json!({"headings": []}))
     }
 
@@ -64,6 +64,7 @@ impl BrowserBackend for MockBrowserBackend {
         &mut self,
         _selector: &str,
         _timeout_ms: u64,
+        _state: Option<&str>,
     ) -> Result<bool, BridgeError> {
         Ok(true)
     }

--- a/extension/background.js
+++ b/extension/background.js
@@ -282,7 +282,7 @@ async function handleCommand(cmd) {
             result = await handleExecuteJs(tabId, cmd.payload || {});
             break;
           case 'page_map':
-            result = await handlePageMap(tabId);
+            result = await handlePageMap(tabId, cmd.payload || {});
             break;
           case 'read_content':
             result = await handleReadContent(tabId, cmd.payload || {});

--- a/extension/commands/page_map.js
+++ b/extension/commands/page_map.js
@@ -1,7 +1,14 @@
 'use strict';
 
 function pageMapScript(scope) {
-  const root = scope ? (document.querySelector(scope) || document) : document;
+  let root = document;
+  if (scope) {
+    const scoped = document.querySelector(scope);
+    if (!scoped) {
+      return { scope_not_found: true, scope, headings: [], landmarks: [], forms: [], links: [], interactive: { buttons: 0, inputs: 0, selects: 0, textareas: 0, total: 0, elements: [] }, meta: { title: document.title, description: '', url: window.location.href }, total_landmarks: 0, total_forms: 0, total_links: 0 };
+    }
+    root = scoped;
+  }
 
   function cssPath(el) {
     if (el.id) return '#' + CSS.escape(el.id);
@@ -135,7 +142,7 @@ function pageMapScript(scope) {
       }
     }
   }
-  const interactive = { counts, elements: interactiveEls };
+  const interactive = { buttons: counts.buttons, inputs: counts.inputs, selects: counts.selects, textareas: counts.textareas, total: counts.total, elements: interactiveEls };
 
   const meta = {
     title: document.title,

--- a/extension/commands/page_map.js
+++ b/extension/commands/page_map.js
@@ -1,6 +1,8 @@
 'use strict';
 
-function pageMapScript() {
+function pageMapScript(scope) {
+  const root = scope ? (document.querySelector(scope) || document) : document;
+
   function cssPath(el) {
     if (el.id) return '#' + CSS.escape(el.id);
     const parts = [];
@@ -18,7 +20,7 @@ function pageMapScript() {
     return parts.join(' > ');
   }
 
-  const headings = Array.from(document.querySelectorAll('h1, h2, h3, h4, h5, h6')).map((el) => {
+  const headings = Array.from(root.querySelectorAll('h1, h2, h3, h4, h5, h6')).map((el) => {
     const level = parseInt(el.tagName[1]);
     const text = el.innerText.trim();
     const id = el.id || null;
@@ -36,7 +38,7 @@ function pageMapScript() {
     return { level, text, id, selector, char_count, preview };
   });
 
-  const landmarks = Array.from(document.querySelectorAll('nav, main, aside, article, footer, header, section[aria-label], [role="navigation"], [role="main"], [role="complementary"]')).map((el) => ({
+  const landmarks = Array.from(root.querySelectorAll('nav, main, aside, article, footer, header, section[aria-label], [role="navigation"], [role="main"], [role="complementary"]')).map((el) => ({
     tag: el.tagName.toLowerCase(),
     role: el.getAttribute('role'),
     id: el.id || null,
@@ -48,7 +50,7 @@ function pageMapScript() {
 
   const MAX_FORMS = 10;
   const MAX_FIELDS_PER_FORM = 30;
-  const allForms = Array.from(document.querySelectorAll('form'));
+  const allForms = Array.from(root.querySelectorAll('form'));
   const total_forms = allForms.length;
   const forms = allForms.slice(0, MAX_FORMS).map((f) => {
     const allFields = Array.from(f.querySelectorAll('input, select, textarea'));
@@ -78,7 +80,7 @@ function pageMapScript() {
   const MAX_LINKS = 50;
   let total_links = 0;
   const links = [];
-  for (const a of document.querySelectorAll('a[href]')) {
+  for (const a of root.querySelectorAll('a[href]')) {
     const text = (a.textContent || '').trim();
     const rawHref = a.getAttribute('href') || '';
     const href = a.href || rawHref;
@@ -90,12 +92,50 @@ function pageMapScript() {
     }
   }
 
-  const interactive = {
-    buttons: document.querySelectorAll('button').length,
-    inputs: document.querySelectorAll('input').length,
-    selects: document.querySelectorAll('select').length,
-    textareas: document.querySelectorAll('textarea').length,
-  };
+  const MAX_INTERACTIVE = 30;
+  const interactiveEls = [];
+  const selectors = [
+    ['button', 'button'],
+    ['input', 'input:not([type="hidden"])'],
+    ['select', 'select'],
+    ['textarea', 'textarea'],
+    ['a[role="button"]', 'a[role="button"]'],
+    ['[role="tab"]', '[role="tab"]'],
+    ['[role="menuitem"]', '[role="menuitem"]'],
+    ['[role="option"]', '[role="option"]'],
+    ['[role="switch"]', '[role="switch"]'],
+    ['[role="checkbox"]', '[role="checkbox"]'],
+  ];
+  const counts = { buttons: 0, inputs: 0, selects: 0, textareas: 0, total: 0 };
+  for (const [label, sel] of selectors) {
+    for (const el of root.querySelectorAll(sel)) {
+      counts.total++;
+      if (el.tagName === 'BUTTON' || el.getAttribute('role') === 'button') counts.buttons++;
+      else if (el.tagName === 'INPUT') counts.inputs++;
+      else if (el.tagName === 'SELECT') counts.selects++;
+      else if (el.tagName === 'TEXTAREA') counts.textareas++;
+      if (interactiveEls.length < MAX_INTERACTIVE) {
+        const entry = {
+          tag: el.tagName.toLowerCase(),
+          text: (el.textContent || el.value || '').trim().slice(0, 60),
+          selector: cssPath(el),
+        };
+        if (el.disabled) entry.disabled = true;
+        if (el.type) entry.type = el.type;
+        const ariaPressed = el.getAttribute('aria-pressed');
+        if (ariaPressed) entry.aria_pressed = ariaPressed;
+        const ariaExpanded = el.getAttribute('aria-expanded');
+        if (ariaExpanded) entry.aria_expanded = ariaExpanded;
+        const ariaSelected = el.getAttribute('aria-selected');
+        if (ariaSelected) entry.aria_selected = ariaSelected;
+        const role = el.getAttribute('role');
+        if (role) entry.role = role;
+        if (el.checked) entry.checked = true;
+        interactiveEls.push(entry);
+      }
+    }
+  }
+  const interactive = { counts, elements: interactiveEls };
 
   const meta = {
     title: document.title,
@@ -106,13 +146,16 @@ function pageMapScript() {
   return { headings, landmarks: cappedLandmarks, forms, links, interactive, meta, total_landmarks, total_forms, total_links };
 }
 
-const PAGE_MAP_SCRIPT = '(' + pageMapScript.toString() + ')()';
-
-async function handlePageMap(tabId) {
+async function handlePageMap(tabId, payload) {
   await ensureAttached(tabId);
 
+  const scope = (payload && payload.scope) || null;
+  const expression = scope
+    ? `(${pageMapScript.toString()})(${JSON.stringify(scope)})`
+    : `(${pageMapScript.toString()})(null)`;
+
   const res = await cdp(tabId, 'Runtime.evaluate', {
-    expression: PAGE_MAP_SCRIPT,
+    expression,
     returnByValue: true,
   });
 

--- a/extension/commands/page_map.js
+++ b/extension/commands/page_map.js
@@ -5,7 +5,7 @@ function pageMapScript(scope) {
   if (scope) {
     const scoped = document.querySelector(scope);
     if (!scoped) {
-      return { scope_not_found: true, scope, headings: [], landmarks: [], forms: [], links: [], interactive: { buttons: 0, inputs: 0, selects: 0, textareas: 0, total: 0, elements: [] }, meta: { title: document.title, description: '', url: window.location.href }, total_landmarks: 0, total_forms: 0, total_links: 0 };
+      return { scope_not_found: true, scope, headings: [], landmarks: [], forms: [], links: [], interactive: { counts: { buttons: 0, inputs: 0, selects: 0, textareas: 0, total: 0 }, elements: [] }, meta: { title: document.title, description: '', url: window.location.href }, total_landmarks: 0, total_forms: 0, total_links: 0 };
     }
     root = scoped;
   }
@@ -142,7 +142,7 @@ function pageMapScript(scope) {
       }
     }
   }
-  const interactive = { buttons: counts.buttons, inputs: counts.inputs, selects: counts.selects, textareas: counts.textareas, total: counts.total, elements: interactiveEls };
+  const interactive = { counts, elements: interactiveEls };
 
   const meta = {
     title: document.title,

--- a/extension/commands/wait.js
+++ b/extension/commands/wait.js
@@ -12,9 +12,9 @@ async function handleWait(tabId, payload) {
     while (Date.now() - start < timeoutMs) {
       let checkExpr;
       if (state === 'visible') {
-        checkExpr = `(() => { const el = document.querySelector(${JSON.stringify(selector)}); return el && el.offsetWidth > 0 && el.offsetHeight > 0; })()`;
+        checkExpr = `(() => { const el = document.querySelector(${JSON.stringify(selector)}); if (!el) return false; const s = getComputedStyle(el); if (s.display === 'none' || s.visibility === 'hidden') return false; const r = el.getBoundingClientRect(); return r.width > 0 && r.height > 0; })()`;
       } else if (state === 'hidden') {
-        checkExpr = `(() => { const el = document.querySelector(${JSON.stringify(selector)}); return !el || el.offsetWidth === 0 || el.offsetHeight === 0; })()`;
+        checkExpr = `(() => { const el = document.querySelector(${JSON.stringify(selector)}); if (!el) return true; const s = getComputedStyle(el); if (s.display === 'none' || s.visibility === 'hidden') return true; const r = el.getBoundingClientRect(); return r.width === 0 && r.height === 0; })()`;
       } else if (state === 'detached') {
         checkExpr = `!document.querySelector(${JSON.stringify(selector)})`;
       } else {

--- a/extension/commands/wait.js
+++ b/extension/commands/wait.js
@@ -3,26 +3,38 @@
 async function handleWait(tabId, payload) {
   await ensureAttached(tabId);
 
-  const { selector, seconds } = payload || {};
+  const { selector, seconds, state } = payload || {};
 
   if (selector) {
     const timeoutMs = payload.timeout_ms ?? 30000;
     const start = Date.now();
 
     while (Date.now() - start < timeoutMs) {
+      let checkExpr;
+      if (state === 'visible') {
+        checkExpr = `(() => { const el = document.querySelector(${JSON.stringify(selector)}); return el && el.offsetWidth > 0 && el.offsetHeight > 0; })()`;
+      } else if (state === 'hidden') {
+        checkExpr = `(() => { const el = document.querySelector(${JSON.stringify(selector)}); return !el || el.offsetWidth === 0 || el.offsetHeight === 0; })()`;
+      } else if (state === 'detached') {
+        checkExpr = `!document.querySelector(${JSON.stringify(selector)})`;
+      } else {
+        // 'attached' or default: element exists in DOM
+        checkExpr = `!!document.querySelector(${JSON.stringify(selector)})`;
+      }
+
       const found = await cdp(tabId, 'Runtime.evaluate', {
-        expression: `!!document.querySelector(${JSON.stringify(selector)})`,
+        expression: checkExpr,
         returnByValue: true,
       });
 
       if (found.result?.value === true) {
-        return { found: true, selector };
+        return { found: true, selector, state: state || 'attached' };
       }
 
       await new Promise(resolve => setTimeout(resolve, 200));
     }
 
-    return { found: false, selector, timed_out: true };
+    return { found: false, selector, state: state || 'attached', timed_out: true };
   }
 
   if (seconds) {


### PR DESCRIPTION
## Summary

Give the LLM agent better situational awareness when interacting with pages.

### page_map

- **scope parameter** — optional CSS selector to constrain all queries within a specific element (e.g. a modal/dialog), reducing noise from the background page.
- **interactive elements enrichment** — returns detailed element info (tag, text, selector, disabled, type, aria-pressed/expanded/selected, role, checked) for up to 30 interactive elements, alongside the existing flat count fields.
- **strict scope fallback** — returns \\scope_not_found: true\\ with empty sections when the scope selector doesn't match, instead of silently falling back to the full document.

### wait

- **state parameter** — new enum (\\isible\\, \\hidden\\, \\ttached\\, \\detached\\) to specify what condition to wait for, instead of just 'element exists in DOM'.
- **input validation** — rejects \\state\\ when no \\selector\\ is provided (state has no effect with time-only waits).
- **extension parity** — extension backend now uses \\getComputedStyle\\ + \\getBoundingClientRect\\ for visible/hidden checks, matching Playwright's stricter semantics.

### Backward Compatibility

- All new parameters are optional — existing callers are unaffected.
- The \\interactive\\ response preserves flat count fields (\\uttons\\, \\inputs\\, \\selects\\, \\	extareas\\) at root level. New \\	otal\\ and \\elements\\ fields are additive.
- Both CloakBrowser (Playwright) and Extension bridge are updated consistently.

### Testing

- Added tests for state parsing, state-without-selector rejection, interactive backward-compat shape, and scope_not_found response contract.
- All existing tests pass (357 tests across agent + browser crates).
- Clippy clean, cargo fmt applied.