### PR TITLE
feat: differential page_map feedback for interaction tools

### DIFF
--- a/crates/agent/src/tools/feedback.rs
+++ b/crates/agent/src/tools/feedback.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::time::Duration;
 
 use serde_json::{json, Value};
@@ -51,7 +51,11 @@ fn extract_url(pm: &Value) -> &str {
 }
 
 fn url_without_hash(url: &str) -> &str {
-    url.split_once('#').map_or(url, |(base, _)| base)
+    match url.split_once('#') {
+        Some((_, frag)) if frag.starts_with('/') || frag.starts_with("!/") => url,
+        Some((base, _)) => base,
+        None => url,
+    }
 }
 
 fn extract_title(pm: &Value) -> &str {
@@ -80,24 +84,53 @@ fn landmark_key(lm: &Value) -> Option<String> {
     Some(format!("{tag}\x00{role}\x00{id}"))
 }
 
-fn collect_keys(items: &[Value], key_fn: fn(&Value) -> Option<String>) -> HashSet<String> {
-    items.iter().filter_map(key_fn).collect()
-}
-
 fn diff_array(
     prev_items: &[Value],
     curr_items: &[Value],
     key_fn: fn(&Value) -> Option<String>,
 ) -> (Vec<Value>, Vec<Value>) {
-    let prev_keys = collect_keys(prev_items, key_fn);
-    let curr_keys = collect_keys(curr_items, key_fn);
+    let mut prev_counts: HashMap<String, usize> = HashMap::new();
+    for item in prev_items {
+        if let Some(k) = key_fn(item) {
+            *prev_counts.entry(k).or_default() += 1;
+        }
+    }
+
+    let mut curr_counts: HashMap<String, usize> = HashMap::new();
+    for item in curr_items {
+        if let Some(k) = key_fn(item) {
+            *curr_counts.entry(k).or_default() += 1;
+        }
+    }
+
+    let mut added_budget: HashMap<&str, usize> = HashMap::new();
+    for (k, &curr_n) in &curr_counts {
+        let prev_n = prev_counts.get(k.as_str()).copied().unwrap_or(0);
+        if curr_n > prev_n {
+            added_budget.insert(k.as_str(), curr_n - prev_n);
+        }
+    }
+
+    let mut removed_budget: HashMap<&str, usize> = HashMap::new();
+    for (k, &prev_n) in &prev_counts {
+        let curr_n = curr_counts.get(k.as_str()).copied().unwrap_or(0);
+        if prev_n > curr_n {
+            removed_budget.insert(k.as_str(), prev_n - curr_n);
+        }
+    }
 
     let added: Vec<Value> = curr_items
         .iter()
         .filter(|item| {
-            key_fn(item)
-                .as_ref()
-                .is_some_and(|k| !prev_keys.contains(k))
+            if let Some(k) = key_fn(item) {
+                if let Some(budget) = added_budget.get_mut(k.as_str()) {
+                    if *budget > 0 {
+                        *budget -= 1;
+                        return true;
+                    }
+                }
+            }
+            false
         })
         .cloned()
         .collect();
@@ -105,9 +138,15 @@ fn diff_array(
     let removed: Vec<Value> = prev_items
         .iter()
         .filter(|item| {
-            key_fn(item)
-                .as_ref()
-                .is_some_and(|k| !curr_keys.contains(k))
+            if let Some(k) = key_fn(item) {
+                if let Some(budget) = removed_budget.get_mut(k.as_str()) {
+                    if *budget > 0 {
+                        *budget -= 1;
+                        return true;
+                    }
+                }
+            }
+            false
         })
         .cloned()
         .collect();
@@ -119,6 +158,66 @@ fn get_array<'a>(pm: &'a Value, key: &str) -> &'a [Value] {
     pm.get(key)
         .and_then(Value::as_array)
         .map_or(&[], Vec::as_slice)
+}
+
+fn get_interactive_elements(pm: &Value) -> &[Value] {
+    pm.get("interactive")
+        .and_then(|i| i.get("elements"))
+        .and_then(Value::as_array)
+        .map_or(&[], Vec::as_slice)
+}
+
+const STATE_FIELDS: &[&str] = &[
+    "disabled",
+    "checked",
+    "aria_pressed",
+    "aria_expanded",
+    "aria_selected",
+];
+
+fn diff_interactive(prev_elements: &[Value], curr_elements: &[Value]) -> Vec<Value> {
+    let prev_by_selector: HashMap<&str, &Value> = prev_elements
+        .iter()
+        .filter_map(|el| el.get("selector").and_then(Value::as_str).map(|s| (s, el)))
+        .collect();
+
+    let mut modified = Vec::new();
+
+    for el in curr_elements {
+        let Some(selector) = el.get("selector").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some(prev_el) = prev_by_selector.get(selector) else {
+            continue;
+        };
+
+        let mut changed_fields = serde_json::Map::new();
+        for &field in STATE_FIELDS {
+            let prev_val = prev_el.get(field);
+            let curr_val = el.get(field);
+            if prev_val != curr_val {
+                changed_fields.insert(
+                    field.to_string(),
+                    curr_val.cloned().unwrap_or(Value::Null),
+                );
+            }
+        }
+
+        if !changed_fields.is_empty() {
+            let mut entry = serde_json::Map::new();
+            entry.insert("selector".into(), json!(selector));
+            if let Some(tag) = el.get("tag") {
+                entry.insert("tag".into(), tag.clone());
+            }
+            if let Some(text) = el.get("text") {
+                entry.insert("text".into(), text.clone());
+            }
+            entry.insert("state_changes".into(), Value::Object(changed_fields));
+            modified.push(Value::Object(entry));
+        }
+    }
+
+    modified
 }
 
 pub fn build_diff_page_state(prev: &Value, current: &mut Value) -> Value {
@@ -133,13 +232,16 @@ pub fn build_diff_page_state(prev: &Value, current: &mut Value) -> Value {
         diff_array(get_array(prev, "links"), get_array(current, "links"), link_key);
     let (added_landmarks, removed_landmarks) =
         diff_array(get_array(prev, "landmarks"), get_array(current, "landmarks"), landmark_key);
+    let modified_interactive =
+        diff_interactive(get_interactive_elements(prev), get_interactive_elements(current));
 
     let has_changes = !added_headings.is_empty()
         || !removed_headings.is_empty()
         || !added_links.is_empty()
         || !removed_links.is_empty()
         || !added_landmarks.is_empty()
-        || !removed_landmarks.is_empty();
+        || !removed_landmarks.is_empty()
+        || !modified_interactive.is_empty();
 
     if !has_changes {
         return json!({
@@ -181,6 +283,9 @@ pub fn build_diff_page_state(prev: &Value, current: &mut Value) -> Value {
     }
     if !removed_landmarks.is_empty() {
         changes.insert("removed_landmarks".into(), Value::Array(removed_landmarks));
+    }
+    if !modified_interactive.is_empty() {
+        changes.insert("modified_interactive".into(), Value::Array(modified_interactive));
     }
 
     json!({
@@ -530,7 +635,88 @@ mod tests {
 
         assert_eq!(url_without_hash("https://example.com/page#section"), "https://example.com/page");
         assert_eq!(url_without_hash("https://example.com/page"), "https://example.com/page");
-        assert_eq!(url_without_hash("https://app.com/#/dashboard"), "https://app.com/");
+        assert_eq!(url_without_hash("https://app.com/#/dashboard"), "https://app.com/#/dashboard");
+        assert_eq!(url_without_hash("https://app.com/#!/billing"), "https://app.com/#!/billing");
         assert_eq!(url_without_hash("unknown"), "unknown");
+    }
+
+    #[test]
+    fn diff_interactive_state_changes_detected() {
+        let prev = json!({
+            "headings": [],
+            "landmarks": [],
+            "links": [],
+            "forms": [],
+            "interactive": {
+                "counts": {"buttons": 2, "inputs": 0, "selects": 0, "textareas": 0, "total": 2},
+                "elements": [
+                    {"tag": "button", "text": "Menu", "selector": "#menu-btn", "aria_expanded": "false"},
+                    {"tag": "button", "text": "Submit", "selector": "#submit-btn", "disabled": true}
+                ]
+            },
+            "meta": {"title": "Page", "url": "https://example.com/", "description": ""}
+        });
+
+        let mut current = json!({
+            "headings": [],
+            "landmarks": [],
+            "links": [],
+            "forms": [],
+            "interactive": {
+                "counts": {"buttons": 2, "inputs": 0, "selects": 0, "textareas": 0, "total": 2},
+                "elements": [
+                    {"tag": "button", "text": "Menu", "selector": "#menu-btn", "aria_expanded": "true"},
+                    {"tag": "button", "text": "Submit", "selector": "#submit-btn"}
+                ]
+            },
+            "meta": {"title": "Page", "url": "https://example.com/", "description": ""}
+        });
+
+        let result = build_diff_page_state(&prev, &mut current);
+
+        assert_eq!(result["changed"], true);
+        let changes = &result["changes"];
+        let modified = changes["modified_interactive"].as_array().unwrap();
+        assert_eq!(modified.len(), 2);
+
+        let menu = modified.iter().find(|e| e["selector"] == "#menu-btn").unwrap();
+        assert_eq!(menu["state_changes"]["aria_expanded"], "true");
+
+        let submit = modified.iter().find(|e| e["selector"] == "#submit-btn").unwrap();
+        assert!(submit["state_changes"]["disabled"].is_null());
+    }
+
+    #[test]
+    fn diff_duplicate_links_counted_correctly() {
+        let prev = json!({
+            "headings": [],
+            "landmarks": [],
+            "links": [
+                {"text": "Read more", "href": "https://example.com/post/1", "selector": "a:nth-of-type(1)"},
+                {"text": "Read more", "href": "https://example.com/post/1", "selector": "a:nth-of-type(2)"}
+            ],
+            "forms": [],
+            "interactive": {},
+            "meta": {"title": "Page", "url": "https://example.com/", "description": ""}
+        });
+
+        let mut current = json!({
+            "headings": [],
+            "landmarks": [],
+            "links": [
+                {"text": "Read more", "href": "https://example.com/post/1", "selector": "a:nth-of-type(1)"}
+            ],
+            "forms": [],
+            "interactive": {},
+            "meta": {"title": "Page", "url": "https://example.com/", "description": ""}
+        });
+
+        let result = build_diff_page_state(&prev, &mut current);
+
+        assert_eq!(result["changed"], true);
+        let changes = &result["changes"];
+        let removed = changes["removed_links"].as_array().unwrap();
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0]["text"], "Read more");
     }
 }

--- a/crates/agent/src/tools/feedback.rs
+++ b/crates/agent/src/tools/feedback.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::time::Duration;
 
 use serde_json::{json, Value};
@@ -9,7 +10,7 @@ use super::page_map::apply_page_map_caps;
 
 const FEEDBACK_TIMEOUT: Duration = Duration::from_secs(3);
 
-/// Build structured page state from a raw `page_map` value.
+/// Build structured page state from a raw `page_map` value (full, no diff).
 ///
 /// Applies caps, extracts url/title from meta, and strips `forms` and
 /// `interactive` fields to keep interaction responses concise.
@@ -42,6 +43,154 @@ pub fn build_page_state_from_map(mut pm: Value) -> Value {
     })
 }
 
+fn extract_url(pm: &Value) -> &str {
+    pm.get("meta")
+        .and_then(|m| m.get("url"))
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+}
+
+fn url_without_hash(url: &str) -> &str {
+    url.split_once('#').map_or(url, |(base, _)| base)
+}
+
+fn extract_title(pm: &Value) -> &str {
+    pm.get("meta")
+        .and_then(|m| m.get("title"))
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+}
+
+fn heading_key(h: &Value) -> Option<String> {
+    let text = h.get("text")?.as_str()?;
+    let level = h.get("level")?.as_u64()?;
+    Some(format!("{level}:{text}"))
+}
+
+fn link_key(l: &Value) -> Option<String> {
+    let href = l.get("href")?.as_str()?;
+    let text = l.get("text").and_then(Value::as_str).unwrap_or("");
+    Some(format!("{text}\x00{href}"))
+}
+
+fn landmark_key(lm: &Value) -> Option<String> {
+    let tag = lm.get("tag").and_then(Value::as_str).unwrap_or("");
+    let role = lm.get("role").and_then(Value::as_str).unwrap_or("");
+    let id = lm.get("id").and_then(Value::as_str).unwrap_or("");
+    Some(format!("{tag}\x00{role}\x00{id}"))
+}
+
+fn collect_keys(items: &[Value], key_fn: fn(&Value) -> Option<String>) -> HashSet<String> {
+    items.iter().filter_map(key_fn).collect()
+}
+
+fn diff_array(
+    prev_items: &[Value],
+    curr_items: &[Value],
+    key_fn: fn(&Value) -> Option<String>,
+) -> (Vec<Value>, Vec<Value>) {
+    let prev_keys = collect_keys(prev_items, key_fn);
+    let curr_keys = collect_keys(curr_items, key_fn);
+
+    let added: Vec<Value> = curr_items
+        .iter()
+        .filter(|item| {
+            key_fn(item)
+                .as_ref()
+                .is_some_and(|k| !prev_keys.contains(k))
+        })
+        .cloned()
+        .collect();
+
+    let removed: Vec<Value> = prev_items
+        .iter()
+        .filter(|item| {
+            key_fn(item)
+                .as_ref()
+                .is_some_and(|k| !curr_keys.contains(k))
+        })
+        .cloned()
+        .collect();
+
+    (added, removed)
+}
+
+fn get_array<'a>(pm: &'a Value, key: &str) -> &'a [Value] {
+    pm.get(key)
+        .and_then(Value::as_array)
+        .map_or(&[], Vec::as_slice)
+}
+
+pub fn build_diff_page_state(prev: &Value, current: &mut Value) -> Value {
+    apply_page_map_caps(current);
+
+    let url = extract_url(current).to_string();
+    let title = extract_title(current).to_string();
+
+    let (added_headings, removed_headings) =
+        diff_array(get_array(prev, "headings"), get_array(current, "headings"), heading_key);
+    let (added_links, removed_links) =
+        diff_array(get_array(prev, "links"), get_array(current, "links"), link_key);
+    let (added_landmarks, removed_landmarks) =
+        diff_array(get_array(prev, "landmarks"), get_array(current, "landmarks"), landmark_key);
+
+    let has_changes = !added_headings.is_empty()
+        || !removed_headings.is_empty()
+        || !added_links.is_empty()
+        || !removed_links.is_empty()
+        || !added_landmarks.is_empty()
+        || !removed_landmarks.is_empty();
+
+    if !has_changes {
+        return json!({
+            "url": url,
+            "title": title,
+            "changed": false
+        });
+    }
+
+    let total_prev = get_array(prev, "headings").len()
+        + get_array(prev, "links").len()
+        + get_array(prev, "landmarks").len();
+    let total_changed = added_headings.len()
+        + removed_headings.len()
+        + added_links.len()
+        + removed_links.len()
+        + added_landmarks.len()
+        + removed_landmarks.len();
+
+    if total_prev > 0 && total_changed > total_prev {
+        return build_page_state_from_map(current.clone());
+    }
+
+    let mut changes = serde_json::Map::new();
+    if !added_headings.is_empty() {
+        changes.insert("added_headings".into(), Value::Array(added_headings));
+    }
+    if !removed_headings.is_empty() {
+        changes.insert("removed_headings".into(), Value::Array(removed_headings));
+    }
+    if !added_links.is_empty() {
+        changes.insert("added_links".into(), Value::Array(added_links));
+    }
+    if !removed_links.is_empty() {
+        changes.insert("removed_links".into(), Value::Array(removed_links));
+    }
+    if !added_landmarks.is_empty() {
+        changes.insert("added_landmarks".into(), Value::Array(added_landmarks));
+    }
+    if !removed_landmarks.is_empty() {
+        changes.insert("removed_landmarks".into(), Value::Array(removed_landmarks));
+    }
+
+    json!({
+        "url": url,
+        "title": title,
+        "changed": true,
+        "changes": changes
+    })
+}
+
 fn fallback_value() -> Value {
     json!({
         "url": "unknown",
@@ -52,9 +201,9 @@ fn fallback_value() -> Value {
 
 /// Best-effort post-action page state for interaction tool responses.
 ///
-/// Calls the bridge `page_map` with a 3-second timeout. On success, returns
-/// structured url + title + trimmed `page_map`. On any failure, returns a
-/// fallback with null `page_map` — never propagates errors.
+/// If a previous page_map snapshot exists for the same URL, returns a
+/// differential response (only added/removed elements). Otherwise returns
+/// the full page_map. Always updates the snapshot cache for next comparison.
 pub async fn post_action_page_state(browser: &mut BrowserContext) -> Value {
     let result = timeout(FEEDBACK_TIMEOUT, async {
         let mut bridge = browser.acquire_bridge().await?;
@@ -63,7 +212,18 @@ pub async fn post_action_page_state(browser: &mut BrowserContext) -> Value {
     .await;
 
     match result {
-        Ok(Ok(pm)) => build_page_state_from_map(pm),
+        Ok(Ok(mut pm)) => {
+            let full_url = extract_url(&pm).to_string();
+            let cache_key = url_without_hash(&full_url).to_string();
+
+            let response = match browser.page_snapshot_for_url(&cache_key) {
+                Some(prev) => build_diff_page_state(prev, &mut pm),
+                None => build_page_state_from_map(pm.clone()),
+            };
+
+            browser.set_page_snapshot(cache_key, pm);
+            response
+        }
         _ => fallback_value(),
     }
 }
@@ -72,7 +232,7 @@ pub async fn post_action_page_state(browser: &mut BrowserContext) -> Value {
 mod tests {
     use serde_json::json;
 
-    use super::{build_page_state_from_map, fallback_value};
+    use super::{build_diff_page_state, build_page_state_from_map, fallback_value};
 
     #[test]
     fn feedback_fallback_value_has_correct_shape() {
@@ -164,5 +324,207 @@ mod tests {
         assert!(pm.get("truncated_links").is_some());
         assert!(pm.get("truncated_forms").is_some());
         assert!(pm.get("truncated_landmarks").is_some());
+    }
+
+    fn base_page_map() -> serde_json::Value {
+        json!({
+            "headings": [
+                {"level": 1, "text": "Welcome", "selector": "#welcome", "char_count": 100, "preview": "Hello"}
+            ],
+            "landmarks": [
+                {"tag": "nav", "role": "navigation", "id": "main-nav", "selector": "nav", "text_preview": "Nav"}
+            ],
+            "links": [
+                {"text": "Home", "href": "https://example.com/", "selector": "a.home"},
+                {"text": "About", "href": "https://example.com/about", "selector": "a.about"}
+            ],
+            "forms": [],
+            "interactive": {},
+            "meta": {"title": "Test Page", "url": "https://example.com/page", "description": ""}
+        })
+    }
+
+    #[test]
+    fn diff_no_changes_returns_changed_false() {
+        let prev = base_page_map();
+        let mut current = base_page_map();
+
+        let result = build_diff_page_state(&prev, &mut current);
+
+        assert_eq!(result["changed"], false);
+        assert_eq!(result["url"], "https://example.com/page");
+        assert_eq!(result["title"], "Test Page");
+        assert!(result.get("changes").is_none());
+    }
+
+    #[test]
+    fn diff_modal_added_shows_only_new_elements() {
+        let prev = base_page_map();
+        let mut current = json!({
+            "headings": [
+                {"level": 1, "text": "Welcome", "selector": "#welcome", "char_count": 100, "preview": "Hello"},
+                {"level": 2, "text": "Sign Up", "selector": "div.modal > h2", "char_count": 50, "preview": "Create account"}
+            ],
+            "landmarks": [
+                {"tag": "nav", "role": "navigation", "id": "main-nav", "selector": "nav", "text_preview": "Nav"},
+                {"tag": "dialog", "role": "dialog", "id": "signup", "selector": "#signup", "text_preview": "Sign up form"}
+            ],
+            "links": [
+                {"text": "Home", "href": "https://example.com/", "selector": "a.home"},
+                {"text": "About", "href": "https://example.com/about", "selector": "a.about"},
+                {"text": "Login instead", "href": "https://example.com/login", "selector": "div.modal a"}
+            ],
+            "forms": [],
+            "interactive": {},
+            "meta": {"title": "Test Page", "url": "https://example.com/page", "description": ""}
+        });
+
+        let result = build_diff_page_state(&prev, &mut current);
+
+        assert_eq!(result["changed"], true);
+        let changes = &result["changes"];
+        assert_eq!(changes["added_headings"].as_array().unwrap().len(), 1);
+        assert_eq!(changes["added_headings"][0]["text"], "Sign Up");
+        assert_eq!(changes["added_links"].as_array().unwrap().len(), 1);
+        assert_eq!(changes["added_links"][0]["text"], "Login instead");
+        assert_eq!(changes["added_landmarks"].as_array().unwrap().len(), 1);
+        assert_eq!(changes["added_landmarks"][0]["tag"], "dialog");
+        assert!(changes.get("removed_headings").is_none());
+        assert!(changes.get("removed_links").is_none());
+        assert!(changes.get("removed_landmarks").is_none());
+    }
+
+    #[test]
+    fn diff_modal_closed_shows_removed_elements() {
+        let prev = json!({
+            "headings": [
+                {"level": 1, "text": "Welcome", "selector": "#welcome", "char_count": 100, "preview": "Hello"},
+                {"level": 2, "text": "Sign Up", "selector": "div.modal > h2", "char_count": 50, "preview": "Create"}
+            ],
+            "landmarks": [
+                {"tag": "nav", "role": "navigation", "id": "main-nav", "selector": "nav", "text_preview": "Nav"}
+            ],
+            "links": [
+                {"text": "Home", "href": "https://example.com/", "selector": "a.home"},
+                {"text": "Login instead", "href": "https://example.com/login", "selector": "div.modal a"}
+            ],
+            "forms": [],
+            "interactive": {},
+            "meta": {"title": "Test Page", "url": "https://example.com/page", "description": ""}
+        });
+
+        let mut current = json!({
+            "headings": [
+                {"level": 1, "text": "Welcome", "selector": "#welcome", "char_count": 100, "preview": "Hello"}
+            ],
+            "landmarks": [
+                {"tag": "nav", "role": "navigation", "id": "main-nav", "selector": "nav", "text_preview": "Nav"}
+            ],
+            "links": [
+                {"text": "Home", "href": "https://example.com/", "selector": "a.home"}
+            ],
+            "forms": [],
+            "interactive": {},
+            "meta": {"title": "Test Page", "url": "https://example.com/page", "description": ""}
+        });
+
+        let result = build_diff_page_state(&prev, &mut current);
+
+        assert_eq!(result["changed"], true);
+        let changes = &result["changes"];
+        assert_eq!(changes["removed_headings"].as_array().unwrap().len(), 1);
+        assert_eq!(changes["removed_headings"][0]["text"], "Sign Up");
+        assert_eq!(changes["removed_links"].as_array().unwrap().len(), 1);
+        assert_eq!(changes["removed_links"][0]["href"], "https://example.com/login");
+        assert!(changes.get("added_headings").is_none());
+    }
+
+    #[test]
+    fn diff_ignores_selector_changes_for_same_content() {
+        let prev = json!({
+            "headings": [
+                {"level": 1, "text": "Title", "selector": "div:nth-of-type(1) > h1", "char_count": 10, "preview": "T"}
+            ],
+            "landmarks": [],
+            "links": [
+                {"text": "Link", "href": "https://example.com/page", "selector": "div:nth-of-type(1) > a"}
+            ],
+            "forms": [],
+            "interactive": {},
+            "meta": {"title": "Page", "url": "https://example.com/page", "description": ""}
+        });
+
+        let mut current = json!({
+            "headings": [
+                {"level": 1, "text": "Title", "selector": "div:nth-of-type(2) > h1", "char_count": 10, "preview": "T"}
+            ],
+            "landmarks": [],
+            "links": [
+                {"text": "Link", "href": "https://example.com/page", "selector": "div:nth-of-type(2) > a"}
+            ],
+            "forms": [],
+            "interactive": {},
+            "meta": {"title": "Page", "url": "https://example.com/page", "description": ""}
+        });
+
+        let result = build_diff_page_state(&prev, &mut current);
+
+        assert_eq!(result["changed"], false);
+    }
+
+    #[test]
+    fn diff_too_large_falls_back_to_full_page_map() {
+        let prev = json!({
+            "headings": [
+                {"level": 1, "text": "Home", "selector": "h1", "char_count": 10, "preview": "Home"},
+                {"level": 2, "text": "Features", "selector": "h2", "char_count": 10, "preview": "Feat"}
+            ],
+            "landmarks": [
+                {"tag": "main", "role": "main", "id": "content", "selector": "#content", "text_preview": "Main"}
+            ],
+            "links": [
+                {"text": "Link A", "href": "https://example.com/a", "selector": "a"},
+                {"text": "Link B", "href": "https://example.com/b", "selector": "a"}
+            ],
+            "forms": [],
+            "interactive": {},
+            "meta": {"title": "Home", "url": "https://example.com/", "description": ""}
+        });
+
+        let mut current = json!({
+            "headings": [
+                {"level": 1, "text": "About Us", "selector": "h1", "char_count": 20, "preview": "About"},
+                {"level": 2, "text": "Team", "selector": "h2.team", "char_count": 15, "preview": "Team"},
+                {"level": 2, "text": "Mission", "selector": "h2.mission", "char_count": 15, "preview": "Mission"}
+            ],
+            "landmarks": [
+                {"tag": "main", "role": "main", "id": "about", "selector": "#about", "text_preview": "About"}
+            ],
+            "links": [
+                {"text": "Contact", "href": "https://example.com/contact", "selector": "a"},
+                {"text": "Join Us", "href": "https://example.com/careers", "selector": "a"}
+            ],
+            "forms": [],
+            "interactive": {},
+            "meta": {"title": "About", "url": "https://example.com/", "description": ""}
+        });
+
+        let result = build_diff_page_state(&prev, &mut current);
+
+        assert!(
+            result.get("page_map").is_some(),
+            "should fall back to full page_map when diff is too large"
+        );
+        assert_eq!(result["url"], "https://example.com/");
+    }
+
+    #[test]
+    fn url_without_hash_strips_fragment() {
+        use super::url_without_hash;
+
+        assert_eq!(url_without_hash("https://example.com/page#section"), "https://example.com/page");
+        assert_eq!(url_without_hash("https://example.com/page"), "https://example.com/page");
+        assert_eq!(url_without_hash("https://app.com/#/dashboard"), "https://app.com/");
+        assert_eq!(url_without_hash("unknown"), "unknown");
     }
 }

--- a/crates/agent/src/tools/feedback.rs
+++ b/crates/agent/src/tools/feedback.rs
@@ -74,7 +74,7 @@ fn link_key(l: &Value) -> Option<String> {
 }
 
 fn landmark_key(lm: &Value) -> Option<String> {
-    let tag = lm.get("tag").and_then(Value::as_str).unwrap_or("");
+    let tag = lm.get("tag")?.as_str()?;
     let role = lm.get("role").and_then(Value::as_str).unwrap_or("");
     let id = lm.get("id").and_then(Value::as_str).unwrap_or("");
     Some(format!("{tag}\x00{role}\x00{id}"))
@@ -201,18 +201,24 @@ fn fallback_value() -> Value {
 
 /// Best-effort post-action page state for interaction tool responses.
 ///
-/// If a previous page_map snapshot exists for the same URL, returns a
-/// differential response (only added/removed elements). Otherwise returns
-/// the full page_map. Always updates the snapshot cache for next comparison.
+/// Calls `page_map_feedback` on the bridge (which may return a pre-computed
+/// diff from the extension, or a full `page_map` from Playwright). If the
+/// response is already a diff, passes it through. Otherwise applies
+/// Rust-side differential comparison against the cached snapshot.
 pub async fn post_action_page_state(browser: &mut BrowserContext) -> Value {
     let result = timeout(FEEDBACK_TIMEOUT, async {
         let mut bridge = browser.acquire_bridge().await?;
-        bridge.page_map(None).await
+        bridge.page_map_feedback().await
     })
     .await;
 
     match result {
-        Ok(Ok(mut pm)) => {
+        Ok(Ok(pm)) => {
+            if pm.get("changed").is_some() {
+                return pm;
+            }
+
+            let mut pm = pm;
             let full_url = extract_url(&pm).to_string();
             let cache_key = url_without_hash(&full_url).to_string();
 

--- a/crates/agent/src/tools/feedback.rs
+++ b/crates/agent/src/tools/feedback.rs
@@ -249,10 +249,7 @@ fn diff_interactive(prev_elements: &[Value], curr_elements: &[Value]) -> Interac
             let prev_val = prev_el.get(field);
             let curr_val = el.get(field);
             if prev_val != curr_val {
-                changed_fields.insert(
-                    field.to_string(),
-                    curr_val.cloned().unwrap_or(Value::Null),
-                );
+                changed_fields.insert(field.to_string(), curr_val.cloned().unwrap_or(Value::Null));
             }
         }
 
@@ -270,7 +267,11 @@ fn diff_interactive(prev_elements: &[Value], curr_elements: &[Value]) -> Interac
         }
     }
 
-    InteractiveDiff { added, removed, modified }
+    InteractiveDiff {
+        added,
+        removed,
+        modified,
+    }
 }
 
 pub fn build_diff_page_state(prev: &Value, current: &mut Value) -> Value {
@@ -279,14 +280,25 @@ pub fn build_diff_page_state(prev: &Value, current: &mut Value) -> Value {
     let url = extract_url(current).to_string();
     let title = extract_title(current).to_string();
 
-    let (added_headings, removed_headings) =
-        diff_array(get_array(prev, "headings"), get_array(current, "headings"), heading_key);
-    let (added_links, removed_links) =
-        diff_array(get_array(prev, "links"), get_array(current, "links"), link_key);
-    let (added_landmarks, removed_landmarks) =
-        diff_array(get_array(prev, "landmarks"), get_array(current, "landmarks"), landmark_key);
-    let interactive_diff =
-        diff_interactive(get_interactive_elements(prev), get_interactive_elements(current));
+    let (added_headings, removed_headings) = diff_array(
+        get_array(prev, "headings"),
+        get_array(current, "headings"),
+        heading_key,
+    );
+    let (added_links, removed_links) = diff_array(
+        get_array(prev, "links"),
+        get_array(current, "links"),
+        link_key,
+    );
+    let (added_landmarks, removed_landmarks) = diff_array(
+        get_array(prev, "landmarks"),
+        get_array(current, "landmarks"),
+        landmark_key,
+    );
+    let interactive_diff = diff_interactive(
+        get_interactive_elements(prev),
+        get_interactive_elements(current),
+    );
 
     let has_changes = !added_headings.is_empty()
         || !removed_headings.is_empty()
@@ -340,13 +352,22 @@ pub fn build_diff_page_state(prev: &Value, current: &mut Value) -> Value {
         changes.insert("removed_landmarks".into(), Value::Array(removed_landmarks));
     }
     if !interactive_diff.added.is_empty() {
-        changes.insert("added_interactive".into(), Value::Array(interactive_diff.added));
+        changes.insert(
+            "added_interactive".into(),
+            Value::Array(interactive_diff.added),
+        );
     }
     if !interactive_diff.removed.is_empty() {
-        changes.insert("removed_interactive".into(), Value::Array(interactive_diff.removed));
+        changes.insert(
+            "removed_interactive".into(),
+            Value::Array(interactive_diff.removed),
+        );
     }
     if !interactive_diff.modified.is_empty() {
-        changes.insert("modified_interactive".into(), Value::Array(interactive_diff.modified));
+        changes.insert(
+            "modified_interactive".into(),
+            Value::Array(interactive_diff.modified),
+        );
     }
 
     json!({
@@ -607,7 +628,10 @@ mod tests {
         assert_eq!(changes["removed_headings"].as_array().unwrap().len(), 1);
         assert_eq!(changes["removed_headings"][0]["text"], "Sign Up");
         assert_eq!(changes["removed_links"].as_array().unwrap().len(), 1);
-        assert_eq!(changes["removed_links"][0]["href"], "https://example.com/login");
+        assert_eq!(
+            changes["removed_links"][0]["href"],
+            "https://example.com/login"
+        );
         assert!(changes.get("added_headings").is_none());
     }
 
@@ -694,10 +718,22 @@ mod tests {
     fn url_without_hash_strips_fragment() {
         use super::url_without_hash;
 
-        assert_eq!(url_without_hash("https://example.com/page#section"), "https://example.com/page");
-        assert_eq!(url_without_hash("https://example.com/page"), "https://example.com/page");
-        assert_eq!(url_without_hash("https://app.com/#/dashboard"), "https://app.com/#/dashboard");
-        assert_eq!(url_without_hash("https://app.com/#!/billing"), "https://app.com/#!/billing");
+        assert_eq!(
+            url_without_hash("https://example.com/page#section"),
+            "https://example.com/page"
+        );
+        assert_eq!(
+            url_without_hash("https://example.com/page"),
+            "https://example.com/page"
+        );
+        assert_eq!(
+            url_without_hash("https://app.com/#/dashboard"),
+            "https://app.com/#/dashboard"
+        );
+        assert_eq!(
+            url_without_hash("https://app.com/#!/billing"),
+            "https://app.com/#!/billing"
+        );
         assert_eq!(url_without_hash("unknown"), "unknown");
     }
 
@@ -740,10 +776,16 @@ mod tests {
         let modified = changes["modified_interactive"].as_array().unwrap();
         assert_eq!(modified.len(), 2);
 
-        let menu = modified.iter().find(|e| e["selector"] == "#menu-btn").unwrap();
+        let menu = modified
+            .iter()
+            .find(|e| e["selector"] == "#menu-btn")
+            .unwrap();
         assert_eq!(menu["state_changes"]["aria_expanded"], "true");
 
-        let submit = modified.iter().find(|e| e["selector"] == "#submit-btn").unwrap();
+        let submit = modified
+            .iter()
+            .find(|e| e["selector"] == "#submit-btn")
+            .unwrap();
         assert!(submit["state_changes"]["disabled"].is_null());
     }
 

--- a/crates/agent/src/tools/feedback.rs
+++ b/crates/agent/src/tools/feedback.rs
@@ -170,15 +170,68 @@ fn get_interactive_elements(pm: &Value) -> &[Value] {
 const STATE_FIELDS: &[&str] = &[
     "disabled",
     "checked",
+    "value",
     "aria_pressed",
     "aria_expanded",
     "aria_selected",
 ];
 
-fn diff_interactive(prev_elements: &[Value], curr_elements: &[Value]) -> Vec<Value> {
+const MAX_INTERACTIVE_DIFF: usize = 5;
+
+struct InteractiveDiff {
+    added: Vec<Value>,
+    removed: Vec<Value>,
+    modified: Vec<Value>,
+}
+
+fn interactive_entry_brief(el: &Value) -> Value {
+    let mut entry = serde_json::Map::new();
+    if let Some(selector) = el.get("selector") {
+        entry.insert("selector".into(), selector.clone());
+    }
+    if let Some(tag) = el.get("tag") {
+        entry.insert("tag".into(), tag.clone());
+    }
+    if let Some(text) = el.get("text") {
+        entry.insert("text".into(), text.clone());
+    }
+    if let Some(role) = el.get("role") {
+        entry.insert("role".into(), role.clone());
+    }
+    Value::Object(entry)
+}
+
+fn diff_interactive(prev_elements: &[Value], curr_elements: &[Value]) -> InteractiveDiff {
     let prev_by_selector: HashMap<&str, &Value> = prev_elements
         .iter()
         .filter_map(|el| el.get("selector").and_then(Value::as_str).map(|s| (s, el)))
+        .collect();
+
+    let curr_by_selector: HashMap<&str, &Value> = curr_elements
+        .iter()
+        .filter_map(|el| el.get("selector").and_then(Value::as_str).map(|s| (s, el)))
+        .collect();
+
+    let added: Vec<Value> = curr_elements
+        .iter()
+        .filter(|el| {
+            el.get("selector")
+                .and_then(Value::as_str)
+                .is_some_and(|s| !prev_by_selector.contains_key(s))
+        })
+        .take(MAX_INTERACTIVE_DIFF)
+        .map(interactive_entry_brief)
+        .collect();
+
+    let removed: Vec<Value> = prev_elements
+        .iter()
+        .filter(|el| {
+            el.get("selector")
+                .and_then(Value::as_str)
+                .is_some_and(|s| !curr_by_selector.contains_key(s))
+        })
+        .take(MAX_INTERACTIVE_DIFF)
+        .map(interactive_entry_brief)
         .collect();
 
     let mut modified = Vec::new();
@@ -217,7 +270,7 @@ fn diff_interactive(prev_elements: &[Value], curr_elements: &[Value]) -> Vec<Val
         }
     }
 
-    modified
+    InteractiveDiff { added, removed, modified }
 }
 
 pub fn build_diff_page_state(prev: &Value, current: &mut Value) -> Value {
@@ -232,7 +285,7 @@ pub fn build_diff_page_state(prev: &Value, current: &mut Value) -> Value {
         diff_array(get_array(prev, "links"), get_array(current, "links"), link_key);
     let (added_landmarks, removed_landmarks) =
         diff_array(get_array(prev, "landmarks"), get_array(current, "landmarks"), landmark_key);
-    let modified_interactive =
+    let interactive_diff =
         diff_interactive(get_interactive_elements(prev), get_interactive_elements(current));
 
     let has_changes = !added_headings.is_empty()
@@ -241,7 +294,9 @@ pub fn build_diff_page_state(prev: &Value, current: &mut Value) -> Value {
         || !removed_links.is_empty()
         || !added_landmarks.is_empty()
         || !removed_landmarks.is_empty()
-        || !modified_interactive.is_empty();
+        || !interactive_diff.added.is_empty()
+        || !interactive_diff.removed.is_empty()
+        || !interactive_diff.modified.is_empty();
 
     if !has_changes {
         return json!({
@@ -284,8 +339,14 @@ pub fn build_diff_page_state(prev: &Value, current: &mut Value) -> Value {
     if !removed_landmarks.is_empty() {
         changes.insert("removed_landmarks".into(), Value::Array(removed_landmarks));
     }
-    if !modified_interactive.is_empty() {
-        changes.insert("modified_interactive".into(), Value::Array(modified_interactive));
+    if !interactive_diff.added.is_empty() {
+        changes.insert("added_interactive".into(), Value::Array(interactive_diff.added));
+    }
+    if !interactive_diff.removed.is_empty() {
+        changes.insert("removed_interactive".into(), Value::Array(interactive_diff.removed));
+    }
+    if !interactive_diff.modified.is_empty() {
+        changes.insert("modified_interactive".into(), Value::Array(interactive_diff.modified));
     }
 
     json!({
@@ -718,5 +779,126 @@ mod tests {
         let removed = changes["removed_links"].as_array().unwrap();
         assert_eq!(removed.len(), 1);
         assert_eq!(removed[0]["text"], "Read more");
+    }
+
+    #[test]
+    fn diff_added_interactive_elements_detected() {
+        let prev = json!({
+            "headings": [],
+            "landmarks": [],
+            "links": [],
+            "forms": [],
+            "interactive": {
+                "counts": {"buttons": 1, "inputs": 0, "selects": 0, "textareas": 0, "total": 1},
+                "elements": [
+                    {"tag": "button", "text": "Add Element", "selector": "#add-btn", "type": "submit"}
+                ]
+            },
+            "meta": {"title": "Page", "url": "https://example.com/", "description": ""}
+        });
+
+        let mut current = json!({
+            "headings": [],
+            "landmarks": [],
+            "links": [],
+            "forms": [],
+            "interactive": {
+                "counts": {"buttons": 2, "inputs": 0, "selects": 0, "textareas": 0, "total": 2},
+                "elements": [
+                    {"tag": "button", "text": "Add Element", "selector": "#add-btn", "type": "submit"},
+                    {"tag": "button", "text": "Delete", "selector": "#del-btn", "type": "submit"}
+                ]
+            },
+            "meta": {"title": "Page", "url": "https://example.com/", "description": ""}
+        });
+
+        let result = build_diff_page_state(&prev, &mut current);
+
+        assert_eq!(result["changed"], true);
+        let changes = &result["changes"];
+        let added = changes["added_interactive"].as_array().unwrap();
+        assert_eq!(added.len(), 1);
+        assert_eq!(added[0]["text"], "Delete");
+        assert_eq!(added[0]["selector"], "#del-btn");
+    }
+
+    #[test]
+    fn diff_removed_interactive_elements_detected() {
+        let prev = json!({
+            "headings": [],
+            "landmarks": [],
+            "links": [],
+            "forms": [],
+            "interactive": {
+                "counts": {"buttons": 2, "inputs": 0, "selects": 0, "textareas": 0, "total": 2},
+                "elements": [
+                    {"tag": "button", "text": "Add Element", "selector": "#add-btn", "type": "submit"},
+                    {"tag": "button", "text": "Delete", "selector": "#del-btn", "type": "submit"}
+                ]
+            },
+            "meta": {"title": "Page", "url": "https://example.com/", "description": ""}
+        });
+
+        let mut current = json!({
+            "headings": [],
+            "landmarks": [],
+            "links": [],
+            "forms": [],
+            "interactive": {
+                "counts": {"buttons": 1, "inputs": 0, "selects": 0, "textareas": 0, "total": 1},
+                "elements": [
+                    {"tag": "button", "text": "Add Element", "selector": "#add-btn", "type": "submit"}
+                ]
+            },
+            "meta": {"title": "Page", "url": "https://example.com/", "description": ""}
+        });
+
+        let result = build_diff_page_state(&prev, &mut current);
+
+        assert_eq!(result["changed"], true);
+        let changes = &result["changes"];
+        let removed = changes["removed_interactive"].as_array().unwrap();
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0]["text"], "Delete");
+    }
+
+    #[test]
+    fn diff_select_value_change_detected() {
+        let prev = json!({
+            "headings": [],
+            "landmarks": [],
+            "links": [],
+            "forms": [],
+            "interactive": {
+                "counts": {"buttons": 0, "inputs": 0, "selects": 1, "textareas": 0, "total": 1},
+                "elements": [
+                    {"tag": "select", "text": "Option 1\nOption 2", "selector": "#dropdown", "type": "select-one", "value": "Please select"}
+                ]
+            },
+            "meta": {"title": "Page", "url": "https://example.com/", "description": ""}
+        });
+
+        let mut current = json!({
+            "headings": [],
+            "landmarks": [],
+            "links": [],
+            "forms": [],
+            "interactive": {
+                "counts": {"buttons": 0, "inputs": 0, "selects": 1, "textareas": 0, "total": 1},
+                "elements": [
+                    {"tag": "select", "text": "Option 1\nOption 2", "selector": "#dropdown", "type": "select-one", "value": "Option 1"}
+                ]
+            },
+            "meta": {"title": "Page", "url": "https://example.com/", "description": ""}
+        });
+
+        let result = build_diff_page_state(&prev, &mut current);
+
+        assert_eq!(result["changed"], true);
+        let changes = &result["changes"];
+        let modified = changes["modified_interactive"].as_array().unwrap();
+        assert_eq!(modified.len(), 1);
+        assert_eq!(modified[0]["selector"], "#dropdown");
+        assert_eq!(modified[0]["state_changes"]["value"], "Option 1");
     }
 }

--- a/crates/agent/src/tools/navigate.rs
+++ b/crates/agent/src/tools/navigate.rs
@@ -300,10 +300,11 @@ pub async fn execute(
         .and_then(|m| m.get("url"))
         .and_then(Value::as_str)
         .unwrap_or("unknown");
-    let cache_key = pm_url
-        .split_once('#')
-        .map_or(pm_url, |(base, _)| base)
-        .to_string();
+    let cache_key = match pm_url.split_once('#') {
+        Some((_, frag)) if frag.starts_with('/') || frag.starts_with("!/") => pm_url.to_string(),
+        Some((base, _)) => base.to_string(),
+        None => pm_url.to_string(),
+    };
     browser.set_page_snapshot(cache_key, page_map.clone());
 
     let content_length = content.chars().count();

--- a/crates/agent/src/tools/navigate.rs
+++ b/crates/agent/src/tools/navigate.rs
@@ -295,6 +295,17 @@ pub async fn execute(
         value
     };
 
+    let pm_url = page_map
+        .get("meta")
+        .and_then(|m| m.get("url"))
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let cache_key = pm_url
+        .split_once('#')
+        .map_or(pm_url, |(base, _)| base)
+        .to_string();
+    browser.set_page_snapshot(cache_key, page_map.clone());
+
     let content_length = content.chars().count();
 
     Ok(ToolEffect::reply_json(&json!({

--- a/crates/agent/src/tools/page_map.rs
+++ b/crates/agent/src/tools/page_map.rs
@@ -51,6 +51,16 @@ pub async fn execute(
 
     apply_page_map_caps(&mut result);
 
+    if scope.is_none() {
+        let url = result
+            .get("meta")
+            .and_then(|m| m.get("url"))
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let cache_key = url.split_once('#').map_or(url, |(base, _)| base).to_string();
+        browser.set_page_snapshot(cache_key, result.clone());
+    }
+
     Ok(ToolEffect::reply_json(&result))
 }
 

--- a/crates/agent/src/tools/page_map.rs
+++ b/crates/agent/src/tools/page_map.rs
@@ -57,7 +57,11 @@ pub async fn execute(
             .and_then(|m| m.get("url"))
             .and_then(Value::as_str)
             .unwrap_or("unknown");
-        let cache_key = url.split_once('#').map_or(url, |(base, _)| base).to_string();
+        let cache_key = match url.split_once('#') {
+            Some((_, frag)) if frag.starts_with('/') || frag.starts_with("!/") => url.to_string(),
+            Some((base, _)) => base.to_string(),
+            None => url.to_string(),
+        };
         browser.set_page_snapshot(cache_key, result.clone());
     }
 

--- a/crates/browser/src/browser_backend.rs
+++ b/crates/browser/src/browser_backend.rs
@@ -56,4 +56,8 @@ pub trait BrowserBackend: Debug {
         options: &ScreenshotOptions<'_>,
     ) -> Result<(String, usize), BridgeError>;
     async fn go_back(&mut self) -> Result<String, BridgeError>;
+
+    async fn page_map_feedback(&mut self) -> Result<serde_json::Value, BridgeError> {
+        self.page_map(None).await
+    }
 }

--- a/crates/browser/src/context.rs
+++ b/crates/browser/src/context.rs
@@ -9,7 +9,7 @@ pub struct BrowserContext {
     page_index: usize,
     current_url: Option<String>,
     browser_has_url: Option<String>,
-    /// Cached page_map from the last post-action feedback, keyed by URL.
+    /// Cached `page_map` from the last post-action feedback, keyed by URL.
     /// Used for differential comparison on subsequent same-page interactions.
     last_page_snapshot: Option<(String, Value)>,
 }

--- a/crates/browser/src/context.rs
+++ b/crates/browser/src/context.rs
@@ -1,3 +1,4 @@
+use serde_json::Value;
 use tokio::sync::MutexGuard;
 
 use crate::{BridgeError, BrowserBackend, SharedBridge};
@@ -8,6 +9,9 @@ pub struct BrowserContext {
     page_index: usize,
     current_url: Option<String>,
     browser_has_url: Option<String>,
+    /// Cached page_map from the last post-action feedback, keyed by URL.
+    /// Used for differential comparison on subsequent same-page interactions.
+    last_page_snapshot: Option<(String, Value)>,
 }
 
 impl BrowserContext {
@@ -23,6 +27,7 @@ impl BrowserContext {
             page_index,
             current_url: None,
             browser_has_url: None,
+            last_page_snapshot: None,
         }
     }
 
@@ -78,5 +83,21 @@ impl BrowserContext {
 
     pub fn set_page_index(&mut self, page_index: usize) {
         self.page_index = page_index;
+    }
+
+    pub fn set_page_snapshot(&mut self, url: String, page_map: Value) {
+        self.last_page_snapshot = Some((url, page_map));
+    }
+
+    #[must_use]
+    pub fn page_snapshot_for_url(&self, url: &str) -> Option<&Value> {
+        self.last_page_snapshot
+            .as_ref()
+            .filter(|(cached_url, _)| cached_url == url)
+            .map(|(_, map)| map)
+    }
+
+    pub fn clear_page_snapshot(&mut self) {
+        self.last_page_snapshot = None;
     }
 }

--- a/crates/browser/src/extension.rs
+++ b/crates/browser/src/extension.rs
@@ -154,6 +154,12 @@ impl BrowserBackend for ExtensionBridge {
         Self::require_result(response, "page_map")
     }
 
+    async fn page_map_feedback(&mut self) -> Result<Value, BridgeError> {
+        let payload = json!({"diff": true});
+        let response = self.send_command("page_map", payload).await?;
+        Self::require_result(response, "page_map")
+    }
+
     async fn read_content(
         &mut self,
         heading: Option<&str>,

--- a/crates/browser/src/playwright/bridge_script.rs
+++ b/crates/browser/src/playwright/bridge_script.rs
@@ -485,6 +485,13 @@ async function bootstrap() {
                 };
                 if (el.disabled) entry.disabled = true;
                 if (el.type) entry.type = el.type;
+                if ((el.tagName === 'SELECT' || el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') && el.value) {
+                  let val = el.value;
+                  if (el.tagName === 'SELECT' && el.selectedOptions && el.selectedOptions.length) {
+                    val = el.selectedOptions[0].text || val;
+                  }
+                  entry.value = val.slice(0, 60);
+                }
                 const ariaPressed = el.getAttribute('aria-pressed');
                 if (ariaPressed) entry.aria_pressed = ariaPressed;
                 const ariaExpanded = el.getAttribute('aria-expanded');

--- a/extension/commands/page_map.js
+++ b/extension/commands/page_map.js
@@ -61,13 +61,37 @@ function computePageMapDiff(prev, current) {
   const { added: addedLandmarks, removed: removedLandmarks } =
     diffArrays(prev.landmarks || [], current.landmarks || [], landmarkKey);
 
-  const STATE_FIELDS = ['disabled', 'checked', 'aria_pressed', 'aria_expanded', 'aria_selected'];
+  const STATE_FIELDS = ['disabled', 'checked', 'value', 'aria_pressed', 'aria_expanded', 'aria_selected'];
+  const MAX_INTERACTIVE_DIFF = 5;
   const prevElements = prev.interactive?.elements || [];
   const currElements = current.interactive?.elements || [];
   const prevBySelector = Object.create(null);
   for (const el of prevElements) {
     if (el.selector) prevBySelector[el.selector] = el;
   }
+  const currBySelector = Object.create(null);
+  for (const el of currElements) {
+    if (el.selector) currBySelector[el.selector] = el;
+  }
+
+  const briefEntry = (el) => {
+    const e = { selector: el.selector };
+    if (el.tag) e.tag = el.tag;
+    if (el.text) e.text = el.text;
+    if (el.role) e.role = el.role;
+    return e;
+  };
+
+  const addedInteractive = currElements
+    .filter(el => el.selector && !prevBySelector[el.selector])
+    .slice(0, MAX_INTERACTIVE_DIFF)
+    .map(briefEntry);
+
+  const removedInteractive = prevElements
+    .filter(el => el.selector && !currBySelector[el.selector])
+    .slice(0, MAX_INTERACTIVE_DIFF)
+    .map(briefEntry);
+
   const modifiedInteractive = [];
   for (const el of currElements) {
     if (!el.selector) continue;
@@ -91,6 +115,7 @@ function computePageMapDiff(prev, current) {
   const hasChanges = addedHeadings.length + removedHeadings.length +
     addedLinks.length + removedLinks.length +
     addedLandmarks.length + removedLandmarks.length +
+    addedInteractive.length + removedInteractive.length +
     modifiedInteractive.length > 0;
 
   if (!hasChanges) {
@@ -114,6 +139,8 @@ function computePageMapDiff(prev, current) {
   if (removedLinks.length) changes.removed_links = removedLinks;
   if (addedLandmarks.length) changes.added_landmarks = addedLandmarks;
   if (removedLandmarks.length) changes.removed_landmarks = removedLandmarks;
+  if (addedInteractive.length) changes.added_interactive = addedInteractive;
+  if (removedInteractive.length) changes.removed_interactive = removedInteractive;
   if (modifiedInteractive.length) changes.modified_interactive = modifiedInteractive;
 
   return { url, title, changed: true, changes };
@@ -248,6 +275,13 @@ function pageMapScript(scope) {
         };
         if (el.disabled) entry.disabled = true;
         if (el.type) entry.type = el.type;
+        if ((el.tagName === 'SELECT' || el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') && el.value) {
+          let val = el.value;
+          if (el.tagName === 'SELECT' && el.selectedOptions && el.selectedOptions.length) {
+            val = el.selectedOptions[0].text || val;
+          }
+          entry.value = val.slice(0, 60);
+        }
         const ariaPressed = el.getAttribute('aria-pressed');
         if (ariaPressed) entry.aria_pressed = ariaPressed;
         const ariaExpanded = el.getAttribute('aria-expanded');

--- a/extension/commands/page_map.js
+++ b/extension/commands/page_map.js
@@ -1,5 +1,64 @@
 'use strict';
 
+const pageMapCache = new Map();
+
+function urlWithoutHash(url) {
+  const idx = url.indexOf('#');
+  return idx === -1 ? url : url.slice(0, idx);
+}
+
+function headingKey(h) { return `${h.level}:${h.text}`; }
+function linkKey(l) { return `${l.text}\x00${l.href}`; }
+function landmarkKey(lm) { return `${lm.tag || ''}\x00${lm.role || ''}\x00${lm.id || ''}`; }
+
+function diffArrays(prev, curr, keyFn) {
+  const prevKeys = new Set(prev.map(keyFn));
+  const currKeys = new Set(curr.map(keyFn));
+  const added = curr.filter(item => !prevKeys.has(keyFn(item)));
+  const removed = prev.filter(item => !currKeys.has(keyFn(item)));
+  return { added, removed };
+}
+
+function computePageMapDiff(prev, current) {
+  const url = current.meta?.url || 'unknown';
+  const title = current.meta?.title || 'unknown';
+
+  const { added: addedHeadings, removed: removedHeadings } =
+    diffArrays(prev.headings || [], current.headings || [], headingKey);
+  const { added: addedLinks, removed: removedLinks } =
+    diffArrays(prev.links || [], current.links || [], linkKey);
+  const { added: addedLandmarks, removed: removedLandmarks } =
+    diffArrays(prev.landmarks || [], current.landmarks || [], landmarkKey);
+
+  const hasChanges = addedHeadings.length + removedHeadings.length +
+    addedLinks.length + removedLinks.length +
+    addedLandmarks.length + removedLandmarks.length > 0;
+
+  if (!hasChanges) {
+    return { url, title, changed: false };
+  }
+
+  const totalPrev = (prev.headings || []).length +
+    (prev.links || []).length + (prev.landmarks || []).length;
+  const totalChanged = addedHeadings.length + removedHeadings.length +
+    addedLinks.length + removedLinks.length +
+    addedLandmarks.length + removedLandmarks.length;
+
+  if (totalPrev > 0 && totalChanged > totalPrev) {
+    return null; // diff too large, caller should return full
+  }
+
+  const changes = {};
+  if (addedHeadings.length) changes.added_headings = addedHeadings;
+  if (removedHeadings.length) changes.removed_headings = removedHeadings;
+  if (addedLinks.length) changes.added_links = addedLinks;
+  if (removedLinks.length) changes.removed_links = removedLinks;
+  if (addedLandmarks.length) changes.added_landmarks = addedLandmarks;
+  if (removedLandmarks.length) changes.removed_landmarks = removedLandmarks;
+
+  return { url, title, changed: true, changes };
+}
+
 function pageMapScript(scope) {
   let root = document;
   if (scope) {
@@ -157,6 +216,7 @@ async function handlePageMap(tabId, payload) {
   await ensureAttached(tabId);
 
   const scope = (payload && payload.scope) || null;
+  const diffMode = Boolean(payload && payload.diff);
   const expression = scope
     ? `(${pageMapScript.toString()})(${JSON.stringify(scope)})`
     : `(${pageMapScript.toString()})(null)`;
@@ -170,5 +230,25 @@ async function handlePageMap(tabId, payload) {
     throw new Error(res.exceptionDetails.text || 'page_map script threw exception');
   }
 
-  return res.result?.value || {};
+  const current = res.result?.value || {};
+
+  if (diffMode && !scope) {
+    const currentUrl = urlWithoutHash(current.meta?.url || '');
+    const cached = pageMapCache.get(tabId);
+
+    if (cached && cached.url === currentUrl) {
+      const diff = computePageMapDiff(cached.data, current);
+      pageMapCache.set(tabId, { url: currentUrl, data: current });
+      if (diff !== null) {
+        return diff;
+      }
+    } else {
+      pageMapCache.set(tabId, { url: currentUrl, data: current });
+    }
+  } else if (!scope) {
+    const currentUrl = urlWithoutHash(current.meta?.url || '');
+    pageMapCache.set(tabId, { url: currentUrl, data: current });
+  }
+
+  return current;
 }

--- a/extension/commands/page_map.js
+++ b/extension/commands/page_map.js
@@ -4,7 +4,10 @@ const pageMapCache = new Map();
 
 function urlWithoutHash(url) {
   const idx = url.indexOf('#');
-  return idx === -1 ? url : url.slice(0, idx);
+  if (idx === -1) return url;
+  const frag = url.slice(idx + 1);
+  if (frag.startsWith('/') || frag.startsWith('!/')) return url;
+  return url.slice(0, idx);
 }
 
 function headingKey(h) { return `${h.level}:${h.text}`; }
@@ -12,10 +15,38 @@ function linkKey(l) { return `${l.text}\x00${l.href}`; }
 function landmarkKey(lm) { return `${lm.tag || ''}\x00${lm.role || ''}\x00${lm.id || ''}`; }
 
 function diffArrays(prev, curr, keyFn) {
-  const prevKeys = new Set(prev.map(keyFn));
-  const currKeys = new Set(curr.map(keyFn));
-  const added = curr.filter(item => !prevKeys.has(keyFn(item)));
-  const removed = prev.filter(item => !currKeys.has(keyFn(item)));
+  const prevCounts = Object.create(null);
+  for (const item of prev) {
+    const k = keyFn(item);
+    prevCounts[k] = (prevCounts[k] || 0) + 1;
+  }
+  const currCounts = Object.create(null);
+  for (const item of curr) {
+    const k = keyFn(item);
+    currCounts[k] = (currCounts[k] || 0) + 1;
+  }
+
+  const addedBudget = Object.create(null);
+  for (const k of Object.keys(currCounts)) {
+    const diff = currCounts[k] - (prevCounts[k] || 0);
+    if (diff > 0) addedBudget[k] = diff;
+  }
+  const removedBudget = Object.create(null);
+  for (const k of Object.keys(prevCounts)) {
+    const diff = prevCounts[k] - (currCounts[k] || 0);
+    if (diff > 0) removedBudget[k] = diff;
+  }
+
+  const added = curr.filter(item => {
+    const k = keyFn(item);
+    if (addedBudget[k] > 0) { addedBudget[k]--; return true; }
+    return false;
+  });
+  const removed = prev.filter(item => {
+    const k = keyFn(item);
+    if (removedBudget[k] > 0) { removedBudget[k]--; return true; }
+    return false;
+  });
   return { added, removed };
 }
 
@@ -30,9 +61,37 @@ function computePageMapDiff(prev, current) {
   const { added: addedLandmarks, removed: removedLandmarks } =
     diffArrays(prev.landmarks || [], current.landmarks || [], landmarkKey);
 
+  const STATE_FIELDS = ['disabled', 'checked', 'aria_pressed', 'aria_expanded', 'aria_selected'];
+  const prevElements = prev.interactive?.elements || [];
+  const currElements = current.interactive?.elements || [];
+  const prevBySelector = Object.create(null);
+  for (const el of prevElements) {
+    if (el.selector) prevBySelector[el.selector] = el;
+  }
+  const modifiedInteractive = [];
+  for (const el of currElements) {
+    if (!el.selector) continue;
+    const prevEl = prevBySelector[el.selector];
+    if (!prevEl) continue;
+    const stateChanges = {};
+    for (const field of STATE_FIELDS) {
+      const pv = prevEl[field] ?? null;
+      const cv = el[field] ?? null;
+      if (pv !== cv) stateChanges[field] = cv;
+    }
+    if (Object.keys(stateChanges).length > 0) {
+      const entry = { selector: el.selector };
+      if (el.tag) entry.tag = el.tag;
+      if (el.text) entry.text = el.text;
+      entry.state_changes = stateChanges;
+      modifiedInteractive.push(entry);
+    }
+  }
+
   const hasChanges = addedHeadings.length + removedHeadings.length +
     addedLinks.length + removedLinks.length +
-    addedLandmarks.length + removedLandmarks.length > 0;
+    addedLandmarks.length + removedLandmarks.length +
+    modifiedInteractive.length > 0;
 
   if (!hasChanges) {
     return { url, title, changed: false };
@@ -55,6 +114,7 @@ function computePageMapDiff(prev, current) {
   if (removedLinks.length) changes.removed_links = removedLinks;
   if (addedLandmarks.length) changes.added_landmarks = addedLandmarks;
   if (removedLandmarks.length) changes.removed_landmarks = removedLandmarks;
+  if (modifiedInteractive.length) changes.modified_interactive = modifiedInteractive;
 
   return { url, title, changed: true, changes };
 }


### PR DESCRIPTION
## Summary

After an interaction tool executes (click, fill, select, hover, etc.), the agent now receives a **differential page_map** showing exactly what changed — instead of a full page dump or nothing at all.

## Changes

### Core differential engine (Rust + extension JS)
- Capture page_map before/after interaction, compute structural diff
- **Structural diff**: added/removed headings, links, landmarks (multiset-aware for duplicates)
- **Interactive state diff**: detect changes to `disabled`, `checked`, `value`, `aria-expanded`, `aria-pressed`, `aria-selected`
- **Interactive element diff**: report newly appeared or disappeared interactive elements (capped at 5)
- **Form control value tracking**: capture select/input/textarea `value` in page_map, enabling select option change detection
- **Hash-route preservation**: `#/path` and `#!/path` fragments preserved in cache keys (only simple anchors stripped)
- **Fallback**: when diff is too large (changes > previous element count), falls back to full page_map

### Cache seeding
- `navigate` seeds the page snapshot cache so the first interaction after navigation produces a diff
- `page_map` (explicit tool) always updates the cache
- `post_action_page_state` updates cache after computing diff

### Response format
```json
{
  "changed": true,
  "url": "...",
  "title": "...",
  "changes": {
    "added_headings": [...],
    "removed_links": [...],
    "added_interactive": [{"tag": "button", "text": "Delete", "selector": "..."}],
    "modified_interactive": [{"selector": "#dropdown", "state_changes": {"value": "Option 1"}}]
  }
}
```

When nothing changed: `{"changed": false, "url": "...", "title": "..."}`

### Files changed
- `crates/agent/src/tools/feedback.rs` — diff engine, interactive state tracking, multiset comparison
- `crates/agent/src/tools/page_map.rs` — cache seeding on explicit page_map calls
- `crates/agent/src/tools/navigate.rs` — cache seeding after navigation
- `crates/browser/src/browser_backend.rs` — `page_map_feedback()` trait method
- `crates/browser/src/extension.rs` — extension bridge `page_map_feedback` sends `{diff: true}`
- `crates/browser/src/context.rs` — snapshot cache storage on BrowserContext
- `crates/browser/src/playwright/bridge_script.rs` — value capture for select/input/textarea
- `extension/commands/page_map.js` — extension-side diff computation with all the same logic

## Testing
- 10 unit tests covering: no-change, modal add/remove, selector stability, large-diff fallback, interactive state changes, added/removed interactive, select value changes, duplicate element handling, hash-route preservation
- E2E verified on: books.toscrape.com, the-internet.herokuapp.com (checkboxes, dropdowns, add/remove elements), github.com (accordion, nav menu), wikipedia.org (search autocomplete)
