### PR TITLE
feat(agent): stable @eN element references for interaction tools

### DIFF
--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -76,7 +76,7 @@ pub fn mvp_tool_specs() -> Vec<acrawl_core::ToolSpec> {
                 "required": ["selector"],
                 "additionalProperties": false
             }),
-            instructions: Some("May trigger navigation or page changes. The response includes post-action page state (URL, title, page structure) so you can see what changed. Use navigate with a direct URL from page_map.links instead of click when possible \u{2014} it's more reliable."),
+            instructions: Some("May trigger navigation or page changes. The response includes post-action page state (URL, title, page structure) so you can see what changed. Use navigate with a direct URL from page_map.links instead of click when possible \u{2014} it's more reliable. The selector field accepts CSS selectors or @eN element refs from page_map output (e.g., \"@e3\")."),
         },
         ToolSpec {
             name: "click_at",
@@ -108,7 +108,7 @@ pub fn mvp_tool_specs() -> Vec<acrawl_core::ToolSpec> {
                 "required": ["fields"],
                 "additionalProperties": false
             }),
-            instructions: Some("Keys in `fields` can be CSS selectors (`#email`, `input[name=\"q\"]`) or plain field names/IDs that are resolved automatically. Set `submit` to true to submit after filling. Use `form_selector` when the page has multiple forms. The response includes post-action page state showing the resulting URL and page structure."),
+            instructions: Some("Keys in `fields` accept CSS selectors, plain field names/IDs, or @eN element refs from page_map (e.g., {\"@e5\": \"value\"}). Set `submit` to true to submit after filling. Use `form_selector` when the page has multiple forms. The response includes post-action page state showing the resulting URL and page structure."),
         },
         ToolSpec {
             name: "screenshot",
@@ -205,7 +205,7 @@ pub fn mvp_tool_specs() -> Vec<acrawl_core::ToolSpec> {
                 "required": ["selector"],
                 "additionalProperties": false
             }),
-            instructions: Some("Provide `selector` for the <select> element, then one of `value`, `label`, or `index` to identify the option. Returns a `page_state` with the updated page structure after selection."),
+            instructions: Some("Provide `selector` for the <select> element, then one of `value`, `label`, or `index` to identify the option. Returns a `page_state` with the updated page structure after selection. The selector field accepts CSS selectors or @eN element refs from page_map output (e.g., \"@e4\")."),
         },
         ToolSpec {
             name: "execute_js",
@@ -231,7 +231,7 @@ pub fn mvp_tool_specs() -> Vec<acrawl_core::ToolSpec> {
                 "required": ["selector"],
                 "additionalProperties": false
             }),
-            instructions: Some("Use to reveal tooltips, dropdown menus, or hidden content. Returns a `page_state` with the updated page structure after hover."),
+            instructions: Some("Use to reveal tooltips, dropdown menus, or hidden content. Returns a `page_state` with the updated page structure after hover. The selector field accepts CSS selectors or @eN element refs from page_map output (e.g., \"@e2\")."),
         },
         ToolSpec {
             name: "press_key",
@@ -245,7 +245,7 @@ pub fn mvp_tool_specs() -> Vec<acrawl_core::ToolSpec> {
                 "required": ["key"],
                 "additionalProperties": false
             }),
-            instructions: Some("Press Enter to submit, Escape to close modals, Tab to move focus, or arrow keys to navigate. Optional `selector` targets a specific element. Returns a `page_state` with the updated page structure after the keypress."),
+            instructions: Some("Press Enter to submit, Escape to close modals, Tab to move focus, or arrow keys to navigate. Optional `selector` targets a specific element (accepts CSS selectors or @eN refs from page_map). Returns a `page_state` with the updated page structure after the keypress."),
         },
         ToolSpec {
             name: "switch_tab",
@@ -301,7 +301,7 @@ pub fn mvp_tool_specs() -> Vec<acrawl_core::ToolSpec> {
                 },
                 "additionalProperties": false
             }),
-            instructions: Some("Returns the full page anatomy: heading hierarchy (h1-h6 with section sizes), landmark regions, forms (with field details), links (text + href, capped at 50), interactive elements (buttons/inputs/selects with their text, selector, and state like disabled/aria-pressed/aria-expanded), and page metadata. Use scope to inspect only a modal/dialog/overlay without noise from the background page. Use links[].href with navigate instead of clicking when the URL is visible."),
+            instructions: Some("Returns the full page anatomy: heading hierarchy (h1-h6 with section sizes), landmark regions, forms (with field details), links (text + href, capped at 50), interactive elements (buttons/inputs/selects with their text, selector, and state like disabled/aria-pressed/aria-expanded), and page metadata. Use scope to inspect only a modal/dialog/overlay without noise from the background page. Use links[].href with navigate instead of clicking when the URL is visible. Each interactive element includes a `ref` field (@e1, @e2, ...) \u{2014} use these stable handles in click, fill_form, hover, press_key, and select_option instead of copying full CSS selectors."),
         },
         ToolSpec {
             name: "read_content",

--- a/crates/agent/src/tools/click.rs
+++ b/crates/agent/src/tools/click.rs
@@ -28,11 +28,14 @@ pub async fn execute(
     browser: &mut BrowserContext,
 ) -> Result<ToolEffect, ToolExecutionError> {
     let params = parse_input(input)?;
+    let selector = super::ref_resolve::resolve_selector(&params.selector, browser.ref_map())
+        .map_err(ToolExecutionError::new)?;
+
     browser
         .acquire_bridge()
         .await
         .map_err(|e| ToolExecutionError::new(e.to_string()))?
-        .click(&params.selector)
+        .click(&selector)
         .await
         .map_err(|e| ToolExecutionError::new(e.to_string()))?;
 

--- a/crates/agent/src/tools/feedback.rs
+++ b/crates/agent/src/tools/feedback.rs
@@ -198,6 +198,9 @@ fn interactive_entry_brief(el: &Value) -> Value {
     if let Some(role) = el.get("role") {
         entry.insert("role".into(), role.clone());
     }
+    if let Some(ref_val) = el.get("ref") {
+        entry.insert("ref".into(), ref_val.clone());
+    }
     Value::Object(entry)
 }
 

--- a/crates/agent/src/tools/feedback.rs
+++ b/crates/agent/src/tools/feedback.rs
@@ -6,7 +6,7 @@ use tokio::time::timeout;
 
 use crate::BrowserContext;
 
-use super::page_map::apply_page_map_caps;
+use super::page_map::{apply_page_map_caps, normalize_url};
 
 const FEEDBACK_TIMEOUT: Duration = Duration::from_secs(3);
 
@@ -48,14 +48,6 @@ fn extract_url(pm: &Value) -> &str {
         .and_then(|m| m.get("url"))
         .and_then(Value::as_str)
         .unwrap_or("unknown")
-}
-
-fn url_without_hash(url: &str) -> &str {
-    match url.split_once('#') {
-        Some((_, frag)) if frag.starts_with('/') || frag.starts_with("!/") => url,
-        Some((base, _)) => base,
-        None => url,
-    }
 }
 
 fn extract_title(pm: &Value) -> &str {
@@ -410,7 +402,7 @@ pub async fn post_action_page_state(browser: &mut BrowserContext) -> Value {
 
             let mut pm = pm;
             let full_url = extract_url(&pm).to_string();
-            let cache_key = url_without_hash(&full_url).to_string();
+            let cache_key = normalize_url(&full_url).to_string();
 
             let response = match browser.page_snapshot_for_url(&cache_key) {
                 Some(prev) => build_diff_page_state(prev, &mut pm),
@@ -719,25 +711,25 @@ mod tests {
 
     #[test]
     fn url_without_hash_strips_fragment() {
-        use super::url_without_hash;
+        use super::super::page_map::normalize_url;
 
         assert_eq!(
-            url_without_hash("https://example.com/page#section"),
+            normalize_url("https://example.com/page#section"),
             "https://example.com/page"
         );
         assert_eq!(
-            url_without_hash("https://example.com/page"),
+            normalize_url("https://example.com/page"),
             "https://example.com/page"
         );
         assert_eq!(
-            url_without_hash("https://app.com/#/dashboard"),
+            normalize_url("https://app.com/#/dashboard"),
             "https://app.com/#/dashboard"
         );
         assert_eq!(
-            url_without_hash("https://app.com/#!/billing"),
+            normalize_url("https://app.com/#!/billing"),
             "https://app.com/#!/billing"
         );
-        assert_eq!(url_without_hash("unknown"), "unknown");
+        assert_eq!(normalize_url("unknown"), "unknown");
     }
 
     #[test]

--- a/crates/agent/src/tools/fill_form.rs
+++ b/crates/agent/src/tools/fill_form.rs
@@ -58,7 +58,17 @@ pub async fn execute(
 ) -> Result<ToolEffect, ToolExecutionError> {
     let params = parse_input(input)?;
 
-    for (selector, value) in &params.fields {
+    let resolved_fields: Vec<(String, String)> = params
+        .fields
+        .iter()
+        .map(|(sel, val)| {
+            let resolved = super::ref_resolve::resolve_selector(sel, browser.ref_map())
+                .map_err(ToolExecutionError::new)?;
+            Ok::<_, ToolExecutionError>((resolved, val.clone()))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    for (selector, value) in &resolved_fields {
         browser
             .acquire_bridge()
             .await

--- a/crates/agent/src/tools/go_back.rs
+++ b/crates/agent/src/tools/go_back.rs
@@ -9,6 +9,8 @@ pub async fn execute(
 ) -> Result<ToolEffect, ToolExecutionError> {
     let _ = input;
 
+    browser.ref_map_mut().clear();
+
     let url = browser
         .acquire_bridge()
         .await

--- a/crates/agent/src/tools/hover.rs
+++ b/crates/agent/src/tools/hover.rs
@@ -16,12 +16,14 @@ pub async fn execute(
     browser: &mut BrowserContext,
 ) -> Result<ToolEffect, ToolExecutionError> {
     let selector = parse_input(input)?;
+    let resolved = super::ref_resolve::resolve_selector(&selector, browser.ref_map())
+        .map_err(ToolExecutionError::new)?;
 
     browser
         .acquire_bridge()
         .await
         .map_err(|e| ToolExecutionError::new(e.to_string()))?
-        .hover(&selector)
+        .hover(&resolved)
         .await
         .map_err(|e| ToolExecutionError::new(e.to_string()))?;
 

--- a/crates/agent/src/tools/mod.rs
+++ b/crates/agent/src/tools/mod.rs
@@ -8,6 +8,7 @@ pub mod go_back;
 pub mod navigate;
 pub mod page_map;
 pub mod read_content;
+pub mod ref_resolve;
 pub mod screenshot;
 
 pub mod execute_js;

--- a/crates/agent/src/tools/navigate.rs
+++ b/crates/agent/src/tools/navigate.rs
@@ -1,7 +1,7 @@
 use serde_json::{json, Value};
 
 use crate::markdown::{extract_main_html, html_to_markdown, DEFAULT_MAX_MARKDOWN_CHARS};
-use crate::tools::page_map::apply_page_map_caps;
+use crate::tools::page_map::{annotate_refs, apply_page_map_caps, normalize_url};
 use crate::BrowserContext;
 use crate::FetchRouter;
 use crate::{CrawlError, ToolEffect, ToolExecutionError};
@@ -262,8 +262,9 @@ pub async fn execute(
     };
 
     browser.set_navigated_url(&page.url, page.fetched_via_browser);
+    browser.ref_map_mut().clear();
 
-    let page_map = if page.fetched_via_browser {
+    let mut page_map = if page.fetched_via_browser {
         match browser.acquire_bridge().await {
             Ok(mut bridge) => match bridge.page_map(None).await {
                 Ok(mut value) => {
@@ -295,16 +296,14 @@ pub async fn execute(
         value
     };
 
+    annotate_refs(&mut page_map, browser);
+
     let pm_url = page_map
         .get("meta")
         .and_then(|m| m.get("url"))
         .and_then(Value::as_str)
         .unwrap_or("unknown");
-    let cache_key = match pm_url.split_once('#') {
-        Some((_, frag)) if frag.starts_with('/') || frag.starts_with("!/") => pm_url.to_string(),
-        Some((base, _)) => base.to_string(),
-        None => pm_url.to_string(),
-    };
+    let cache_key = normalize_url(pm_url).to_string();
     browser.set_page_snapshot(cache_key, page_map.clone());
 
     let content_length = content.chars().count();

--- a/crates/agent/src/tools/page_map.rs
+++ b/crates/agent/src/tools/page_map.rs
@@ -7,11 +7,46 @@ const MAX_PAGE_MAP_LINKS: usize = 50;
 const MAX_PAGE_MAP_FORMS: usize = 10;
 const MAX_PAGE_MAP_LANDMARKS: usize = 20;
 
-fn normalized_page_map_url(url: &str) -> String {
+/// Normalize a URL for page-map caching and ref lifecycle comparison.
+/// Strips fragment unless it looks like a hash-based route (`#/…` or `#!/…`).
+#[must_use]
+pub fn normalize_url(url: &str) -> &str {
     match url.split_once('#') {
-        Some((_, frag)) if frag.starts_with('/') || frag.starts_with("!/") => url.to_string(),
-        Some((base, _)) => base.to_string(),
-        None => url.to_string(),
+        Some((_, frag)) if frag.starts_with('/') || frag.starts_with("!/") => url,
+        Some((base, _)) => base,
+        None => url,
+    }
+}
+
+/// Annotate interactive elements in a `page_map` value with `@eN` refs.
+/// Assigns or reuses stable refs via the browser context's `RefMap`.
+pub fn annotate_refs(result: &mut Value, browser: &mut BrowserContext) {
+    if let Some(elements) = result
+        .get_mut("interactive")
+        .and_then(|interactive| interactive.get_mut("elements"))
+        .and_then(Value::as_array_mut)
+    {
+        for el in elements.iter_mut() {
+            let selector = el.get("selector").and_then(Value::as_str).map(String::from);
+            if let Some(selector) = selector {
+                let role = el
+                    .get("role")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                let name = el
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                let ref_id = browser
+                    .ref_map_mut()
+                    .assign_or_reuse(&selector, &role, &name);
+                if let Some(obj) = el.as_object_mut() {
+                    obj.insert("ref".to_string(), Value::String(format!("@{ref_id}")));
+                }
+            }
+        }
     }
 }
 
@@ -66,7 +101,7 @@ pub async fn execute(
             .and_then(Value::as_str)
             .unwrap_or("unknown");
 
-        let cache_key = normalized_page_map_url(url);
+        let cache_key = normalize_url(url).to_string();
 
         if let Some(prev_url) = browser.snapshot_url() {
             if prev_url != cache_key.as_str() {
@@ -74,35 +109,10 @@ pub async fn execute(
             }
         }
 
-        if let Some(elements) = result
-            .get_mut("interactive")
-            .and_then(|interactive| interactive.get_mut("elements"))
-            .and_then(Value::as_array_mut)
-        {
-            for el in elements.iter_mut() {
-                let selector = el.get("selector").and_then(Value::as_str).map(String::from);
-                if let Some(selector) = selector {
-                    let role = el
-                        .get("role")
-                        .and_then(Value::as_str)
-                        .unwrap_or("")
-                        .to_string();
-                    let name = el
-                        .get("name")
-                        .and_then(Value::as_str)
-                        .unwrap_or("")
-                        .to_string();
-                    let ref_id = browser
-                        .ref_map_mut()
-                        .assign_or_reuse(&selector, &role, &name);
-                    if let Some(obj) = el.as_object_mut() {
-                        obj.insert("ref".to_string(), Value::String(format!("@{ref_id}")));
-                    }
-                }
-            }
-        }
-
+        annotate_refs(&mut result, browser);
         browser.set_page_snapshot(cache_key, result.clone());
+    } else {
+        annotate_refs(&mut result, browser);
     }
 
     Ok(ToolEffect::reply_json(&result))
@@ -524,5 +534,138 @@ mod tests {
         map_a.clear();
         assert!(map_a.get("e1").is_none());
         assert!(map_b.get("e1").is_some());
+    }
+
+    // ─── Lifecycle integration tests: annotate_refs + invalidation ──────────
+
+    #[test]
+    fn annotate_refs_injects_ref_fields_into_elements() {
+        use std::sync::Arc;
+        use tokio::sync::Mutex;
+
+        use browser::BrowserContext;
+
+        use super::annotate_refs;
+
+        let bridge: Arc<Mutex<Box<dyn browser::BrowserBackend + Send>>> =
+            Arc::new(Mutex::new(Box::new(browser::NopBridge)));
+        let mut ctx = BrowserContext::new(bridge);
+
+        let mut value = json!({
+            "interactive": {
+                "elements": [
+                    {"tag": "button", "text": "Submit", "selector": "#submit", "role": "button", "name": "Submit"},
+                    {"tag": "input", "text": "", "selector": "#email", "role": "textbox", "name": "Email"}
+                ]
+            }
+        });
+
+        annotate_refs(&mut value, &mut ctx);
+
+        let elements = value["interactive"]["elements"].as_array().unwrap();
+        assert_eq!(elements[0]["ref"], json!("@e1"));
+        assert_eq!(elements[1]["ref"], json!("@e2"));
+
+        assert_eq!(ctx.ref_map().get("e1").unwrap().selector, "#submit");
+        assert_eq!(ctx.ref_map().get("e2").unwrap().selector, "#email");
+    }
+
+    #[test]
+    fn annotate_refs_reuses_existing_refs_for_same_selector() {
+        use std::sync::Arc;
+        use tokio::sync::Mutex;
+
+        use browser::BrowserContext;
+
+        use super::annotate_refs;
+
+        let bridge: Arc<Mutex<Box<dyn browser::BrowserBackend + Send>>> =
+            Arc::new(Mutex::new(Box::new(browser::NopBridge)));
+        let mut ctx = BrowserContext::new(bridge);
+
+        let mut value1 = json!({
+            "interactive": {
+                "elements": [
+                    {"selector": "#submit", "role": "button", "name": "Submit"}
+                ]
+            }
+        });
+        annotate_refs(&mut value1, &mut ctx);
+
+        let mut value2 = json!({
+            "interactive": {
+                "elements": [
+                    {"selector": "#submit", "role": "button", "name": "Submit"},
+                    {"selector": "#cancel", "role": "button", "name": "Cancel"}
+                ]
+            }
+        });
+        annotate_refs(&mut value2, &mut ctx);
+
+        let elements = value2["interactive"]["elements"].as_array().unwrap();
+        assert_eq!(elements[0]["ref"], json!("@e1"));
+        assert_eq!(elements[1]["ref"], json!("@e2"));
+    }
+
+    #[test]
+    fn ref_clear_invalidates_stale_refs() {
+        use std::sync::Arc;
+        use tokio::sync::Mutex;
+
+        use browser::BrowserContext;
+
+        use super::annotate_refs;
+        use crate::tools::ref_resolve::resolve_selector;
+
+        let bridge: Arc<Mutex<Box<dyn browser::BrowserBackend + Send>>> =
+            Arc::new(Mutex::new(Box::new(browser::NopBridge)));
+        let mut ctx = BrowserContext::new(bridge);
+
+        let mut value = json!({
+            "interactive": {
+                "elements": [
+                    {"selector": "#old-btn", "role": "button", "name": "Old"}
+                ]
+            }
+        });
+        annotate_refs(&mut value, &mut ctx);
+        assert_eq!(resolve_selector("@e1", ctx.ref_map()).unwrap(), "#old-btn");
+
+        ctx.ref_map_mut().clear();
+
+        let err = resolve_selector("@e1", ctx.ref_map()).unwrap_err();
+        assert!(err.contains("Unknown element ref"));
+
+        let mut value2 = json!({
+            "interactive": {
+                "elements": [
+                    {"selector": "#new-btn", "role": "button", "name": "New"}
+                ]
+            }
+        });
+        annotate_refs(&mut value2, &mut ctx);
+        assert_eq!(resolve_selector("@e1", ctx.ref_map()).unwrap(), "#new-btn");
+    }
+
+    #[test]
+    fn normalize_url_strips_hash_preserves_routes() {
+        use super::normalize_url;
+
+        assert_eq!(
+            normalize_url("https://example.com/page#section"),
+            "https://example.com/page"
+        );
+        assert_eq!(
+            normalize_url("https://app.com/#/dashboard"),
+            "https://app.com/#/dashboard"
+        );
+        assert_eq!(
+            normalize_url("https://app.com/#!/billing"),
+            "https://app.com/#!/billing"
+        );
+        assert_eq!(
+            normalize_url("https://example.com/page"),
+            "https://example.com/page"
+        );
     }
 }

--- a/crates/agent/src/tools/page_map.rs
+++ b/crates/agent/src/tools/page_map.rs
@@ -378,4 +378,151 @@ mod tests {
         assert_eq!(value["scope"], json!("[role='dialog']"));
         assert!(value["headings"].as_array().unwrap().is_empty());
     }
+
+    // ─── Integration tests: @eN ref lifecycle ───────────────────────────────
+
+    #[test]
+    fn page_map_injects_ref_into_interactive_elements() {
+        let mut value = json!({
+            "interactive": {
+                "counts": {"buttons": 1, "inputs": 0, "selects": 0, "textareas": 0, "total": 1},
+                "elements": [
+                    {"tag": "button", "text": "Submit", "selector": "#submit", "role": "button"}
+                ]
+            },
+            "headings": [], "landmarks": [], "forms": [], "links": [],
+            "meta": {"title": "Test", "description": "", "url": "https://example.com"}
+        });
+
+        apply_page_map_caps(&mut value);
+
+        // Verify element structure is intact (ref would be injected by execute() with browser)
+        let elements = value["interactive"]["elements"].as_array().unwrap();
+        assert_eq!(elements.len(), 1);
+        assert_eq!(elements[0]["selector"], json!("#submit"));
+        assert_eq!(elements[0]["role"], json!("button"));
+    }
+
+    #[test]
+    fn page_map_ref_assignment_stability() {
+        use browser::RefMap;
+
+        let mut ref_map = RefMap::new();
+        // Assign twice for same selector → same ref
+        let r1 = ref_map.assign_or_reuse("#submit", "button", "Submit");
+        let r2 = ref_map.assign_or_reuse("#submit", "button", "Submit");
+        assert_eq!(r1, r2);
+        assert_eq!(r1, "e1");
+
+        // Different selector → new ref
+        let r3 = ref_map.assign_or_reuse("#email", "textbox", "Email");
+        assert_ne!(r1, r3);
+        assert_eq!(r3, "e2");
+    }
+
+    #[test]
+    fn page_map_ref_reset_on_clear() {
+        use browser::RefMap;
+
+        let mut ref_map = RefMap::new();
+        let r1 = ref_map.assign_or_reuse("#btn", "button", "Click me");
+        assert_eq!(r1, "e1");
+
+        ref_map.clear();
+
+        // After clear, counter resets
+        let r2 = ref_map.assign_or_reuse("#other-btn", "button", "Other");
+        assert_eq!(r2, "e1");
+        // Original ref no longer exists — e1 now points to #other-btn
+        assert_eq!(
+            ref_map.get("e1").map(|e| e.selector.as_str()),
+            Some("#other-btn")
+        );
+    }
+
+    #[test]
+    fn fill_form_fields_css_selectors_pass_through_resolve() {
+        use browser::RefMap;
+
+        use crate::tools::ref_resolve::resolve_selector;
+
+        let map = RefMap::new();
+        // Pure CSS selectors pass through unchanged
+        assert_eq!(resolve_selector("#email", &map).unwrap(), "#email");
+        assert_eq!(
+            resolve_selector("input[name='q']", &map).unwrap(),
+            "input[name='q']"
+        );
+    }
+
+    #[test]
+    fn fill_form_ref_key_resolves_to_selector() {
+        use browser::RefMap;
+
+        use crate::tools::ref_resolve::resolve_selector;
+
+        let mut map = RefMap::new();
+        map.assign_or_reuse("#email-input", "textbox", "Email");
+        // @e1 should resolve to "#email-input"
+        let resolved = resolve_selector("@e1", &map).unwrap();
+        assert_eq!(resolved, "#email-input");
+    }
+
+    #[test]
+    fn invalid_ref_produces_clear_error_message() {
+        use browser::RefMap;
+
+        use crate::tools::ref_resolve::resolve_selector;
+
+        let map = RefMap::new(); // empty map
+        let err = resolve_selector("@e999", &map).unwrap_err();
+        assert!(err.contains("Unknown element ref"));
+        assert!(err.contains("page_map"));
+    }
+
+    #[test]
+    fn backward_compat_css_selectors_work_alongside_refs() {
+        use browser::RefMap;
+
+        use crate::tools::ref_resolve::resolve_selector;
+
+        let mut map = RefMap::new();
+        map.assign_or_reuse("button.submit", "button", "Submit");
+
+        // @e1 resolves to CSS selector
+        assert_eq!(resolve_selector("@e1", &map).unwrap(), "button.submit");
+        // Unrelated CSS selectors pass through unchanged
+        assert_eq!(resolve_selector("#other", &map).unwrap(), "#other");
+        assert_eq!(
+            resolve_selector(".class-selector", &map).unwrap(),
+            ".class-selector"
+        );
+    }
+
+    #[test]
+    fn sub_agent_isolation_separate_ref_maps() {
+        use browser::RefMap;
+
+        // Two independent RefMaps (simulating two BrowserContexts)
+        let mut map_a = RefMap::new();
+        let mut map_b = RefMap::new();
+
+        // Assign to map_a
+        let ref_a = map_a.assign_or_reuse("#btn-a", "button", "A");
+        // Assign different selector to map_b
+        let ref_b = map_b.assign_or_reuse("#btn-b", "button", "B");
+
+        // Both start at e1 (independent counters)
+        assert_eq!(ref_a, "e1");
+        assert_eq!(ref_b, "e1");
+
+        // map_a's e1 points to #btn-a, not #btn-b
+        assert_eq!(map_a.get("e1").unwrap().selector, "#btn-a");
+        assert_eq!(map_b.get("e1").unwrap().selector, "#btn-b");
+
+        // Clearing map_a doesn't affect map_b
+        map_a.clear();
+        assert!(map_a.get("e1").is_none());
+        assert!(map_b.get("e1").is_some());
+    }
 }

--- a/crates/agent/src/tools/page_map.rs
+++ b/crates/agent/src/tools/page_map.rs
@@ -7,6 +7,14 @@ const MAX_PAGE_MAP_LINKS: usize = 50;
 const MAX_PAGE_MAP_FORMS: usize = 10;
 const MAX_PAGE_MAP_LANDMARKS: usize = 20;
 
+fn normalized_page_map_url(url: &str) -> String {
+    match url.split_once('#') {
+        Some((_, frag)) if frag.starts_with('/') || frag.starts_with("!/") => url.to_string(),
+        Some((base, _)) => base.to_string(),
+        None => url.to_string(),
+    }
+}
+
 pub fn apply_page_map_caps(value: &mut Value) {
     let truncated_links = truncate_array_field(value, "links", MAX_PAGE_MAP_LINKS);
     let truncated_forms = truncate_array_field(value, "forms", MAX_PAGE_MAP_FORMS);
@@ -57,11 +65,43 @@ pub async fn execute(
             .and_then(|m| m.get("url"))
             .and_then(Value::as_str)
             .unwrap_or("unknown");
-        let cache_key = match url.split_once('#') {
-            Some((_, frag)) if frag.starts_with('/') || frag.starts_with("!/") => url.to_string(),
-            Some((base, _)) => base.to_string(),
-            None => url.to_string(),
-        };
+
+        let cache_key = normalized_page_map_url(url);
+
+        if let Some(prev_url) = browser.snapshot_url() {
+            if prev_url != cache_key.as_str() {
+                browser.ref_map_mut().clear();
+            }
+        }
+
+        if let Some(elements) = result
+            .get_mut("interactive")
+            .and_then(|interactive| interactive.get_mut("elements"))
+            .and_then(Value::as_array_mut)
+        {
+            for el in elements.iter_mut() {
+                let selector = el.get("selector").and_then(Value::as_str).map(String::from);
+                if let Some(selector) = selector {
+                    let role = el
+                        .get("role")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string();
+                    let name = el
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string();
+                    let ref_id = browser
+                        .ref_map_mut()
+                        .assign_or_reuse(&selector, &role, &name);
+                    if let Some(obj) = el.as_object_mut() {
+                        obj.insert("ref".to_string(), Value::String(format!("@{ref_id}")));
+                    }
+                }
+            }
+        }
+
         browser.set_page_snapshot(cache_key, result.clone());
     }
 
@@ -297,6 +337,22 @@ mod tests {
         assert_eq!(interactive["counts"]["total"], json!(6));
         assert!(interactive["elements"].is_array());
         assert_eq!(interactive["elements"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn page_map_interactive_elements_get_ref_field() {
+        let value = json!({
+            "interactive": {
+                "counts": {"buttons": 1, "inputs": 0, "selects": 0, "textareas": 0, "total": 1},
+                "elements": [
+                    {"tag": "button", "text": "Submit", "selector": "#submit", "role": "button"}
+                ]
+            },
+            "headings": [], "landmarks": [], "forms": [], "links": [],
+            "meta": {"title": "T", "description": "", "url": "https://example.com"}
+        });
+
+        assert!(value["interactive"]["elements"][0].get("ref").is_none());
     }
 
     #[test]

--- a/crates/agent/src/tools/press_key.rs
+++ b/crates/agent/src/tools/press_key.rs
@@ -29,11 +29,19 @@ pub async fn execute(
 ) -> Result<ToolEffect, ToolExecutionError> {
     let parsed = parse_input(input)?;
 
+    let resolved_selector: Option<String> = if let Some(sel) = &parsed.selector {
+        let r = super::ref_resolve::resolve_selector(sel, browser.ref_map())
+            .map_err(ToolExecutionError::new)?;
+        Some(r)
+    } else {
+        None
+    };
+
     browser
         .acquire_bridge()
         .await
         .map_err(|e| ToolExecutionError::new(e.to_string()))?
-        .press_key(&parsed.key, parsed.selector.as_deref())
+        .press_key(&parsed.key, resolved_selector.as_deref())
         .await
         .map_err(|e| ToolExecutionError::new(e.to_string()))?;
 

--- a/crates/agent/src/tools/ref_resolve.rs
+++ b/crates/agent/src/tools/ref_resolve.rs
@@ -1,0 +1,69 @@
+use browser::{parse_ref, RefMap};
+
+/// Resolve an @eN ref or bare eN ref to its CSS selector.
+/// If input is a CSS selector (not a ref), returns it unchanged.
+/// Returns Err if input looks like a ref but is not found in the map.
+pub fn resolve_selector(input: &str, ref_map: &RefMap) -> Result<String, String> {
+    if let Some(ref_id) = parse_ref(input) {
+        match ref_map.get(&ref_id) {
+            Some(entry) => Ok(entry.selector.clone()),
+            None => Err(format!(
+                "Unknown element ref @{ref_id}. Call page_map to refresh."
+            )),
+        }
+    } else {
+        Ok(input.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use browser::RefMap;
+
+    use super::*;
+
+    #[test]
+    fn css_selector_passes_through() {
+        let map = RefMap::new();
+        let result = resolve_selector("#my-button", &map).unwrap();
+        assert_eq!(result, "#my-button");
+    }
+
+    #[test]
+    fn valid_ref_resolves_to_selector() {
+        let mut map = RefMap::new();
+        map.assign_or_reuse("button.submit", "button", "Submit");
+        let result = resolve_selector("@e1", &map).unwrap();
+        assert_eq!(result, "button.submit");
+    }
+
+    #[test]
+    fn bare_ref_resolves() {
+        let mut map = RefMap::new();
+        map.assign_or_reuse("input#email", "textbox", "Email");
+        let result = resolve_selector("e1", &map).unwrap();
+        assert_eq!(result, "input#email");
+    }
+
+    #[test]
+    fn unknown_ref_returns_error() {
+        let map = RefMap::new();
+        let err = resolve_selector("@e999", &map).unwrap_err();
+        assert!(err.contains("Unknown element ref"));
+        assert!(err.contains("@e999"));
+    }
+
+    #[test]
+    fn dot_selector_passes_through() {
+        let map = RefMap::new();
+        let result = resolve_selector(".btn-primary", &map).unwrap();
+        assert_eq!(result, ".btn-primary");
+    }
+
+    #[test]
+    fn empty_string_passes_through() {
+        let map = RefMap::new();
+        let result = resolve_selector("", &map).unwrap();
+        assert_eq!(result, "");
+    }
+}

--- a/crates/agent/src/tools/select_option.rs
+++ b/crates/agent/src/tools/select_option.rs
@@ -30,12 +30,14 @@ pub async fn execute(
     browser: &mut BrowserContext,
 ) -> Result<ToolEffect, ToolExecutionError> {
     let parsed = parse_input(input)?;
+    let resolved = super::ref_resolve::resolve_selector(&parsed.selector, browser.ref_map())
+        .map_err(ToolExecutionError::new)?;
 
     browser
         .acquire_bridge()
         .await
         .map_err(|e| ToolExecutionError::new(e.to_string()))?
-        .select_option(&parsed.selector, &parsed.value)
+        .select_option(&resolved, &parsed.value)
         .await
         .map_err(|e| ToolExecutionError::new(e.to_string()))?;
 

--- a/crates/agent/src/tools/switch_tab.rs
+++ b/crates/agent/src/tools/switch_tab.rs
@@ -17,6 +17,8 @@ pub async fn execute(
 ) -> Result<ToolEffect, ToolExecutionError> {
     let index = parse_input(input);
 
+    browser.ref_map_mut().clear();
+
     let result = browser
         .bridge()
         .lock()

--- a/crates/browser/src/context.rs
+++ b/crates/browser/src/context.rs
@@ -104,6 +104,14 @@ impl BrowserContext {
         self.last_page_snapshot = None;
     }
 
+    /// Returns the URL of the currently cached page snapshot, if any.
+    #[must_use]
+    pub fn snapshot_url(&self) -> Option<&str> {
+        self.last_page_snapshot
+            .as_ref()
+            .map(|(url, _)| url.as_str())
+    }
+
     pub fn ref_map_mut(&mut self) -> &mut RefMap {
         &mut self.ref_map
     }

--- a/crates/browser/src/context.rs
+++ b/crates/browser/src/context.rs
@@ -1,6 +1,7 @@
 use serde_json::Value;
 use tokio::sync::MutexGuard;
 
+use crate::ref_map::RefMap;
 use crate::{BridgeError, BrowserBackend, SharedBridge};
 
 #[derive(Debug, Clone)]
@@ -12,6 +13,7 @@ pub struct BrowserContext {
     /// Cached `page_map` from the last post-action feedback, keyed by URL.
     /// Used for differential comparison on subsequent same-page interactions.
     last_page_snapshot: Option<(String, Value)>,
+    ref_map: RefMap,
 }
 
 impl BrowserContext {
@@ -28,6 +30,7 @@ impl BrowserContext {
             current_url: None,
             browser_has_url: None,
             last_page_snapshot: None,
+            ref_map: RefMap::new(),
         }
     }
 
@@ -99,5 +102,13 @@ impl BrowserContext {
 
     pub fn clear_page_snapshot(&mut self) {
         self.last_page_snapshot = None;
+    }
+
+    pub fn ref_map_mut(&mut self) -> &mut RefMap {
+        &mut self.ref_map
+    }
+
+    pub fn ref_map(&self) -> &RefMap {
+        &self.ref_map
     }
 }

--- a/crates/browser/src/context.rs
+++ b/crates/browser/src/context.rs
@@ -116,6 +116,7 @@ impl BrowserContext {
         &mut self.ref_map
     }
 
+    #[must_use]
     pub fn ref_map(&self) -> &RefMap {
         &self.ref_map
     }

--- a/crates/browser/src/lib.rs
+++ b/crates/browser/src/lib.rs
@@ -5,6 +5,7 @@ pub mod fetch;
 pub mod markdown;
 pub mod playwright;
 pub mod ref_map;
+pub mod testing;
 pub mod ws_server;
 
 pub use browser_backend::{BrowserBackend, ScreenshotOptions};
@@ -13,6 +14,7 @@ pub use extension::ExtensionBridge;
 pub use fetch::{FetchError, FetchRouter, FetchedPage};
 pub use playwright::{BridgeError, BrowserState, PageInfo, PlaywrightBridge, SharedBridge};
 pub use ref_map::{parse_ref, RefEntry, RefMap};
+pub use testing::NopBridge;
 pub use ws_server::{
     generate_bridge_token, BridgeCommand, BridgeResponse, WsBridgeError, WsBridgeServer,
 };

--- a/crates/browser/src/lib.rs
+++ b/crates/browser/src/lib.rs
@@ -4,6 +4,7 @@ pub mod extension;
 pub mod fetch;
 pub mod markdown;
 pub mod playwright;
+pub mod ref_map;
 pub mod ws_server;
 
 pub use browser_backend::{BrowserBackend, ScreenshotOptions};
@@ -11,6 +12,7 @@ pub use context::BrowserContext;
 pub use extension::ExtensionBridge;
 pub use fetch::{FetchError, FetchRouter, FetchedPage};
 pub use playwright::{BridgeError, BrowserState, PageInfo, PlaywrightBridge, SharedBridge};
+pub use ref_map::{parse_ref, RefEntry, RefMap};
 pub use ws_server::{
     generate_bridge_token, BridgeCommand, BridgeResponse, WsBridgeError, WsBridgeServer,
 };

--- a/crates/browser/src/playwright/bridge.rs
+++ b/crates/browser/src/playwright/bridge.rs
@@ -30,9 +30,13 @@ pub type SharedBridge = Arc<Mutex<Box<dyn BrowserBackend + Send>>>;
 
 impl PlaywrightBridge {
     pub async fn new() -> Result<Self, BridgeError> {
+        let script_path = config_home_dir().join("bridge.cjs");
+        std::fs::write(&script_path, PLAYWRIGHT_BRIDGE_NODE_SCRIPT)
+            .map_err(|e| BridgeError::Protocol(format!("failed to write bridge script: {e}")))?;
+
         Self::new_with_invocation(
             "node",
-            vec!["-e".to_string(), PLAYWRIGHT_BRIDGE_NODE_SCRIPT.to_string()],
+            vec![script_path.to_string_lossy().into_owned()],
             DEFAULT_LAUNCH_TIMEOUT,
         )
         .await

--- a/crates/browser/src/playwright/bridge_script.rs
+++ b/crates/browser/src/playwright/bridge_script.rs
@@ -498,9 +498,52 @@ async function bootstrap() {
                 if (ariaExpanded) entry.aria_expanded = ariaExpanded;
                 const ariaSelected = el.getAttribute('aria-selected');
                 if (ariaSelected) entry.aria_selected = ariaSelected;
-                const role = el.getAttribute('role');
-                if (role) entry.role = role;
                 if (el.checked) entry.checked = true;
+                // Computed ARIA role (always set, based on element type)
+                const ariaRoleAttr = el.getAttribute('role');
+                if (ariaRoleAttr) {
+                  entry.role = ariaRoleAttr;
+                } else {
+                  const tag = el.tagName;
+                  const inputType = (el.type || '').toLowerCase();
+                  if (tag === 'BUTTON' || (tag === 'INPUT' && inputType === 'button') || (tag === 'INPUT' && inputType === 'submit') || (tag === 'INPUT' && inputType === 'reset') || (tag === 'INPUT' && inputType === 'image')) {
+                    entry.role = 'button';
+                  } else if (tag === 'A') {
+                    entry.role = 'link';
+                  } else if (tag === 'INPUT' && (inputType === 'checkbox')) {
+                    entry.role = 'checkbox';
+                  } else if (tag === 'INPUT' && (inputType === 'radio')) {
+                    entry.role = 'radio';
+                  } else if (tag === 'INPUT' && (inputType === 'range')) {
+                    entry.role = 'slider';
+                  } else if (tag === 'INPUT') {
+                    entry.role = 'textbox';
+                  } else if (tag === 'SELECT') {
+                    entry.role = 'combobox';
+                  } else if (tag === 'TEXTAREA') {
+                    entry.role = 'textbox';
+                  } else {
+                    entry.role = tag.toLowerCase();
+                  }
+                }
+                // Accessible name: prefer aria-label > aria-labelledby > innerText > placeholder > title > name attr
+                const ariaLabel = el.getAttribute('aria-label');
+                const ariaLabelledBy = el.getAttribute('aria-labelledby');
+                let elName = '';
+                if (ariaLabel) {
+                  elName = ariaLabel.trim().slice(0, 60);
+                } else if (ariaLabelledBy) {
+                  const labelEl = document.getElementById(ariaLabelledBy);
+                  if (labelEl) elName = (labelEl.innerText || '').trim().slice(0, 60);
+                }
+                if (!elName) {
+                  const innerTxt = (el.innerText || '').trim();
+                  if (innerTxt) elName = innerTxt.slice(0, 60);
+                }
+                if (!elName && el.placeholder) elName = el.placeholder.slice(0, 60);
+                if (!elName && el.title) elName = el.title.slice(0, 60);
+                if (!elName && el.name) elName = el.name.slice(0, 60);
+                if (elName) entry.name = elName;
                 interactiveEls.push(entry);
               }
             }

--- a/crates/browser/src/ref_map.rs
+++ b/crates/browser/src/ref_map.rs
@@ -1,0 +1,158 @@
+use std::collections::HashMap;
+
+/// Represents a single interactive element with its selector, role, and name.
+#[derive(Debug, Clone)]
+pub struct RefEntry {
+    pub selector: String,
+    pub role: String,
+    pub name: String,
+}
+
+/// Maps element references (e.g. "e1", "e5") to their entries.
+/// Provides stable ref assignment: same selector always gets the same ref number.
+#[derive(Debug, Clone)]
+pub struct RefMap {
+    /// Maps ref_id (e.g. "e1") to RefEntry
+    map: HashMap<String, RefEntry>,
+    /// Maps selector → ref_id (for stable lookup)
+    selector_to_ref: HashMap<String, String>,
+    next_ref: usize,
+}
+
+impl RefMap {
+    /// Create a new empty RefMap.
+    pub fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+            selector_to_ref: HashMap::new(),
+            next_ref: 1,
+        }
+    }
+
+    /// If element with same selector already has a ref, return that ref.
+    /// Otherwise assign next available ref number and return it.
+    /// Returns the ref_id string (e.g. "e1", "e5").
+    pub fn assign_or_reuse(&mut self, selector: &str, role: &str, name: &str) -> String {
+        if let Some(existing) = self.selector_to_ref.get(selector) {
+            return existing.clone();
+        }
+        let ref_id = format!("e{}", self.next_ref);
+        self.next_ref += 1;
+        self.map.insert(
+            ref_id.clone(),
+            RefEntry {
+                selector: selector.to_string(),
+                role: role.to_string(),
+                name: name.to_string(),
+            },
+        );
+        self.selector_to_ref
+            .insert(selector.to_string(), ref_id.clone());
+        ref_id
+    }
+
+    /// Look up a RefEntry by ref_id (e.g. "e1").
+    pub fn get(&self, ref_id: &str) -> Option<&RefEntry> {
+        self.map.get(ref_id)
+    }
+
+    /// Clear all refs and reset the counter to 1.
+    pub fn clear(&mut self) {
+        self.map.clear();
+        self.selector_to_ref.clear();
+        self.next_ref = 1;
+    }
+}
+
+impl Default for RefMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Parse @eN or bare eN → returns Some("eN") or None.
+/// Accepts: @e1, @e99, @e123, e1, e99, e123
+/// Rejects: @ex, @e, #foo, .bar, empty string
+pub fn parse_ref(input: &str) -> Option<String> {
+    let stripped = input.strip_prefix('@').unwrap_or(input);
+    if stripped.starts_with('e') && stripped.len() > 1 {
+        let digits = &stripped[1..];
+        if !digits.is_empty() && digits.chars().all(|c| c.is_ascii_digit()) {
+            return Some(stripped.to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_ref_with_at_prefix_e1() {
+        assert_eq!(parse_ref("@e1"), Some("e1".to_string()));
+    }
+
+    #[test]
+    fn parse_ref_with_at_prefix_e99() {
+        assert_eq!(parse_ref("@e99"), Some("e99".to_string()));
+    }
+
+    #[test]
+    fn parse_ref_bare_e5() {
+        assert_eq!(parse_ref("e5"), Some("e5".to_string()));
+    }
+
+    #[test]
+    fn parse_ref_rejects_at_ex() {
+        assert_eq!(parse_ref("@ex"), None);
+    }
+
+    #[test]
+    fn parse_ref_rejects_at_e() {
+        assert_eq!(parse_ref("@e"), None);
+    }
+
+    #[test]
+    fn parse_ref_rejects_hash_selector() {
+        assert_eq!(parse_ref("#my-button"), None);
+    }
+
+    #[test]
+    fn parse_ref_rejects_empty_string() {
+        assert_eq!(parse_ref(""), None);
+    }
+
+    #[test]
+    fn parse_ref_with_at_prefix_e123() {
+        assert_eq!(parse_ref("@e123"), Some("e123".to_string()));
+    }
+
+    #[test]
+    fn assign_or_reuse_same_selector_twice() {
+        let mut map = RefMap::new();
+        let ref1 = map.assign_or_reuse("button.submit", "button", "Submit");
+        let ref2 = map.assign_or_reuse("button.submit", "button", "Submit");
+        assert_eq!(ref1, ref2);
+        assert_eq!(ref1, "e1");
+    }
+
+    #[test]
+    fn assign_or_reuse_different_selectors_increments() {
+        let mut map = RefMap::new();
+        let ref1 = map.assign_or_reuse("button.submit", "button", "Submit");
+        let ref2 = map.assign_or_reuse("input.email", "textbox", "Email");
+        assert_eq!(ref1, "e1");
+        assert_eq!(ref2, "e2");
+    }
+
+    #[test]
+    fn clear_resets_counter() {
+        let mut map = RefMap::new();
+        let ref1 = map.assign_or_reuse("button.submit", "button", "Submit");
+        assert_eq!(ref1, "e1");
+        map.clear();
+        let ref2 = map.assign_or_reuse("button.submit", "button", "Submit");
+        assert_eq!(ref2, "e1");
+    }
+}

--- a/crates/browser/src/ref_map.rs
+++ b/crates/browser/src/ref_map.rs
@@ -12,15 +12,16 @@ pub struct RefEntry {
 /// Provides stable ref assignment: same selector always gets the same ref number.
 #[derive(Debug, Clone)]
 pub struct RefMap {
-    /// Maps ref_id (e.g. "e1") to RefEntry
+    /// Maps `ref_id` (e.g. "e1") to `RefEntry`
     map: HashMap<String, RefEntry>,
-    /// Maps selector → ref_id (for stable lookup)
+    /// Maps selector to `ref_id` (for stable lookup)
     selector_to_ref: HashMap<String, String>,
     next_ref: usize,
 }
 
 impl RefMap {
-    /// Create a new empty RefMap.
+    /// Create a new empty `RefMap`.
+    #[must_use]
     pub fn new() -> Self {
         Self {
             map: HashMap::new(),
@@ -31,7 +32,7 @@ impl RefMap {
 
     /// If element with same selector already has a ref, return that ref.
     /// Otherwise assign next available ref number and return it.
-    /// Returns the ref_id string (e.g. "e1", "e5").
+    /// Returns the `ref_id` string (e.g. "e1", "e5").
     pub fn assign_or_reuse(&mut self, selector: &str, role: &str, name: &str) -> String {
         if let Some(existing) = self.selector_to_ref.get(selector) {
             return existing.clone();
@@ -51,7 +52,8 @@ impl RefMap {
         ref_id
     }
 
-    /// Look up a RefEntry by ref_id (e.g. "e1").
+    /// Look up a `RefEntry` by `ref_id` (e.g. "e1").
+    #[must_use]
     pub fn get(&self, ref_id: &str) -> Option<&RefEntry> {
         self.map.get(ref_id)
     }
@@ -70,9 +72,10 @@ impl Default for RefMap {
     }
 }
 
-/// Parse @eN or bare eN → returns Some("eN") or None.
+/// Parse @eN or bare eN → returns `Some("eN")` or None.
 /// Accepts: @e1, @e99, @e123, e1, e99, e123
 /// Rejects: @ex, @e, #foo, .bar, empty string
+#[must_use]
 pub fn parse_ref(input: &str) -> Option<String> {
     let stripped = input.strip_prefix('@').unwrap_or(input);
     if stripped.starts_with('e') && stripped.len() > 1 {

--- a/crates/browser/src/testing.rs
+++ b/crates/browser/src/testing.rs
@@ -1,0 +1,94 @@
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::{BridgeError, BrowserBackend, BrowserState, PageInfo, ScreenshotOptions};
+
+#[derive(Debug, Default)]
+pub struct NopBridge;
+
+#[async_trait]
+impl BrowserBackend for NopBridge {
+    async fn navigate(&mut self, _url: &str) -> Result<PageInfo, BridgeError> {
+        Err(BridgeError::Protocol("NopBridge".into()))
+    }
+    async fn new_page(&mut self, _url: Option<&str>) -> Result<usize, BridgeError> {
+        Err(BridgeError::Protocol("NopBridge".into()))
+    }
+    async fn close_page(&mut self, _page_index: usize) -> Result<(), BridgeError> {
+        Err(BridgeError::Protocol("NopBridge".into()))
+    }
+    async fn scroll(&mut self, _direction: &str, _pixels: i64) -> Result<(), BridgeError> {
+        Err(BridgeError::Protocol("NopBridge".into()))
+    }
+    async fn page_map(&mut self, _scope: Option<&str>) -> Result<Value, BridgeError> {
+        Err(BridgeError::Protocol("NopBridge".into()))
+    }
+    async fn read_content(
+        &mut self,
+        _heading: Option<&str>,
+        _selector: Option<&str>,
+        _offset: usize,
+        _max_chars: usize,
+    ) -> Result<Value, BridgeError> {
+        Err(BridgeError::Protocol("NopBridge".into()))
+    }
+    async fn wait_for_selector(
+        &mut self,
+        _selector: &str,
+        _timeout_ms: u64,
+        _state: Option<&str>,
+    ) -> Result<bool, BridgeError> {
+        Err(BridgeError::Protocol("NopBridge".into()))
+    }
+    async fn select_option(&mut self, _selector: &str, _value: &str) -> Result<(), BridgeError> {
+        Err(BridgeError::Protocol("NopBridge".into()))
+    }
+    async fn evaluate(&mut self, _script: &str) -> Result<Value, BridgeError> {
+        Err(BridgeError::Protocol("NopBridge".into()))
+    }
+    async fn hover(&mut self, _selector: &str) -> Result<(), BridgeError> {
+        Err(BridgeError::Protocol("NopBridge".into()))
+    }
+    async fn press_key(&mut self, _key: &str, _selector: Option<&str>) -> Result<(), BridgeError> {
+        Err(BridgeError::Protocol("NopBridge".into()))
+    }
+    async fn switch_tab(&mut self, _index: i64) -> Result<Value, BridgeError> {
+        Err(BridgeError::Protocol("NopBridge".into()))
+    }
+    async fn export_cookies(&mut self) -> Result<BrowserState, BridgeError> {
+        Err(BridgeError::Protocol("NopBridge".into()))
+    }
+    async fn import_cookies(&mut self, _state: &BrowserState) -> Result<(), BridgeError> {
+        Err(BridgeError::Protocol("NopBridge".into()))
+    }
+    async fn import_cookies_only(&mut self, _state: &BrowserState) -> Result<(), BridgeError> {
+        Err(BridgeError::Protocol("NopBridge".into()))
+    }
+    async fn import_local_storage(&mut self, _state: &BrowserState) -> Result<(), BridgeError> {
+        Err(BridgeError::Protocol("NopBridge".into()))
+    }
+    async fn list_resources(&mut self) -> Result<Value, BridgeError> {
+        Err(BridgeError::Protocol("NopBridge".into()))
+    }
+    async fn save_file(&mut self, _url: &str, _path: &str) -> Result<String, BridgeError> {
+        Err(BridgeError::Protocol("NopBridge".into()))
+    }
+    async fn click(&mut self, _selector: &str) -> Result<(), BridgeError> {
+        Err(BridgeError::Protocol("NopBridge".into()))
+    }
+    async fn click_at(&mut self, _x: f64, _y: f64) -> Result<(), BridgeError> {
+        Err(BridgeError::Protocol("NopBridge".into()))
+    }
+    async fn fill(&mut self, _selector: &str, _value: &str) -> Result<(), BridgeError> {
+        Err(BridgeError::Protocol("NopBridge".into()))
+    }
+    async fn screenshot(
+        &mut self,
+        _options: &ScreenshotOptions<'_>,
+    ) -> Result<(String, usize), BridgeError> {
+        Err(BridgeError::Protocol("NopBridge".into()))
+    }
+    async fn go_back(&mut self) -> Result<String, BridgeError> {
+        Err(BridgeError::Protocol("NopBridge".into()))
+    }
+}

--- a/extension/commands/page_map.js
+++ b/extension/commands/page_map.js
@@ -288,9 +288,55 @@ function pageMapScript(scope) {
         if (ariaExpanded) entry.aria_expanded = ariaExpanded;
         const ariaSelected = el.getAttribute('aria-selected');
         if (ariaSelected) entry.aria_selected = ariaSelected;
-        const role = el.getAttribute('role');
-        if (role) entry.role = role;
         if (el.checked) entry.checked = true;
+
+        // Computed ARIA role (always set, based on element type)
+        const ariaRoleAttr = el.getAttribute('role');
+        if (ariaRoleAttr) {
+          entry.role = ariaRoleAttr;
+        } else {
+          const tag = el.tagName;
+          const inputType = (el.type || '').toLowerCase();
+          if (tag === 'BUTTON' || (tag === 'INPUT' && inputType === 'button') || (tag === 'INPUT' && inputType === 'submit') || (tag === 'INPUT' && inputType === 'reset') || (tag === 'INPUT' && inputType === 'image')) {
+            entry.role = 'button';
+          } else if (tag === 'A') {
+            entry.role = 'link';
+          } else if (tag === 'INPUT' && (inputType === 'checkbox')) {
+            entry.role = 'checkbox';
+          } else if (tag === 'INPUT' && (inputType === 'radio')) {
+            entry.role = 'radio';
+          } else if (tag === 'INPUT' && (inputType === 'range')) {
+            entry.role = 'slider';
+          } else if (tag === 'INPUT') {
+            entry.role = 'textbox';
+          } else if (tag === 'SELECT') {
+            entry.role = 'combobox';
+          } else if (tag === 'TEXTAREA') {
+            entry.role = 'textbox';
+          } else {
+            entry.role = tag.toLowerCase();
+          }
+        }
+
+        // Accessible name: prefer aria-label > aria-labelledby > innerText > placeholder > title > name attr
+        const ariaLabel = el.getAttribute('aria-label');
+        const ariaLabelledBy = el.getAttribute('aria-labelledby');
+        let elName = '';
+        if (ariaLabel) {
+          elName = ariaLabel.trim().slice(0, 60);
+        } else if (ariaLabelledBy) {
+          const labelEl = document.getElementById(ariaLabelledBy);
+          if (labelEl) elName = (labelEl.innerText || '').trim().slice(0, 60);
+        }
+        if (!elName) {
+          const innerTxt = (el.innerText || '').trim();
+          if (innerTxt) elName = innerTxt.slice(0, 60);
+        }
+        if (!elName && el.placeholder) elName = el.placeholder.slice(0, 60);
+        if (!elName && el.title) elName = el.title.slice(0, 60);
+        if (!elName && el.name) elName = el.name.slice(0, 60);
+        if (elName) entry.name = elName;
+
         interactiveEls.push(entry);
       }
     }


### PR DESCRIPTION
## Summary

Adds a stable element reference system (\@eN\ refs) that gives the LLM short, reusable handles for interactive elements instead of fragile CSS selectors.

## What's included

### Core feature (5 commits)
- **RefMap** data structure in \rowser\ crate — maps integer IDs to CSS selectors with lifecycle management
- **page_map** annotates interactive elements with \@eN\ markers
- **Interaction tools** (click, hover, fill_form, press_key, select_option) resolve \@eN\ syntax in selector fields
- **Tool documentation** updated to explain ref usage

### Lifecycle fixes (1 commit)
- **Ref invalidation on navigation** — \ef_map.clear()\ wired into \
avigate\, \go_back\, \switch_tab\ to prevent stale refs from clicking wrong elements on different pages
- **Navigate embedded page_map gets refs** — first page view the LLM sees already has \@eN\ markers (no extra \page_map\ call needed)
- **Scoped page_map gets refs** — modal/dialog workflows now benefit from stable handles
- **Shared helpers** — extracted \
ormalize_url\ and \nnotate_refs\; removed duplicate \url_without_hash\
- **NopBridge** test utility for \BrowserContext\ unit tests without a real browser
- **Lifecycle integration tests** — ref injection, stability, stale ref invalidation

## Files changed

| Area | Files | Changes |
|------|-------|---------|
| Browser | \ef_map.rs\, \context.rs\, \lib.rs\, \	esting.rs\, \ridge_script.rs\ | RefMap, NopBridge, page_map ref annotations |
| Agent tools | \page_map.rs\, \
avigate.rs\, \go_back.rs\, \switch_tab.rs\, \eedback.rs\ | Ref lifecycle, annotation, shared helpers |
| Agent core | \ef_resolve.rs\, \mod.rs\, \lib.rs\ | Resolution module, tool spec updates |
| Interaction | \click.rs\, \hover.rs\, \ill_form.rs\, \press_key.rs\, \select_option.rs\ | \@eN\ resolution wiring |
| Extension | \extension/commands/page_map.js\ | Role + name emission for ref annotation |

## Testing

- 166 agent tools tests pass (including 4 new lifecycle tests)
- 85 browser tests pass
- Clippy clean (\-D warnings\, pedantic)
- \cargo fmt --check\ clean
