### PR TITLE
feat(browser): add fit_markdown DOM pruning content filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,6 +483,7 @@ dependencies = [
  "htmd",
  "rand 0.8.5",
  "reqwest 0.12.28",
+ "scraper",
  "serde",
  "serde_json",
  "socket2 0.5.10",
@@ -501,6 +502,12 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "byteorder-lite"
@@ -745,7 +752,7 @@ checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
  "bitflags 2.11.0",
  "crossterm_winapi",
- "derive_more",
+ "derive_more 2.1.1",
  "document-features",
  "mio",
  "parking_lot",
@@ -788,6 +795,29 @@ checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
  "phf 0.11.3",
+]
+
+[[package]]
+name = "cssparser"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c66d1cd8ed61bf80b38432613a7a2f09401ab8d0501110655f8b341484a3e3"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.11.3",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -869,6 +899,17 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
@@ -944,10 +985,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ego-tree"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
 
 [[package]]
 name = "either"
@@ -1135,6 +1197,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,6 +1301,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
 dependencies = [
  "thread_local",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1410,9 +1491,21 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eee9b00ee2e599b4f86507157e3db786e7a3319fc225f0e9584151dbea2291d"
 dependencies = [
- "html5ever",
+ "html5ever 0.38.0",
  "markup5ever_rcdom",
  "phf 0.13.1",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.14.1",
+ "match_token",
 ]
 
 [[package]]
@@ -1422,7 +1515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
 dependencies = [
  "log",
- "markup5ever",
+ "markup5ever 0.38.0",
 ]
 
 [[package]]
@@ -1905,6 +1998,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
 name = "mac_address"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1916,12 +2015,26 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
+dependencies = [
+ "log",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+ "string_cache 0.8.9",
+ "string_cache_codegen 0.5.4",
+ "tendril 0.4.3",
+]
+
+[[package]]
+name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
 dependencies = [
  "log",
- "tendril",
+ "tendril 0.5.0",
  "web_atoms",
 ]
 
@@ -1931,10 +2044,21 @@ version = "0.38.0+unofficial"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "333171ccdf66e915257740d44e38ea5b1b19ce7b45d33cc35cb6f118fbd981ff"
 dependencies = [
- "html5ever",
- "markup5ever",
- "tendril",
+ "html5ever 0.38.0",
+ "markup5ever 0.38.0",
+ "tendril 0.5.0",
  "xml5ever",
+]
+
+[[package]]
+name = "match_token"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3071,6 +3195,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc3d051b884f40e309de6c149734eab57aa8cc1347992710dc80bcc1c2194c15"
+dependencies = [
+ "cssparser",
+ "ego-tree",
+ "getopts",
+ "html5ever 0.29.1",
+ "precomputed-hash",
+ "selectors",
+ "tendril 0.4.3",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3091,6 +3230,25 @@ checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "selectors"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd568a4c9bb598e291a08244a5c1f5a8a6650bee243b5b0f8dbb3d9cc1d87fe8"
+dependencies = [
+ "bitflags 2.11.0",
+ "cssparser",
+ "derive_more 0.99.20",
+ "fxhash",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+ "precomputed-hash",
+ "servo_arc",
+ "smallvec",
 ]
 
 [[package]]
@@ -3152,6 +3310,15 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -3283,6 +3450,19 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.11.3",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
@@ -3292,6 +3472,18 @@ dependencies = [
  "phf_shared 0.13.1",
  "precomputed-hash",
  "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -3392,6 +3584,17 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
 ]
 
 [[package]]
@@ -4134,8 +4337,8 @@ checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
 dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
- "string_cache",
- "string_cache_codegen",
+ "string_cache 0.9.0",
+ "string_cache_codegen 0.6.1",
 ]
 
 [[package]]
@@ -4589,7 +4792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dc9559429edf0cd3f327cc0afd9d6b36fa8cec6d93107b7fbe64f806b5f2d9"
 dependencies = [
  "log",
- "markup5ever",
+ "markup5ever 0.38.0",
 ]
 
 [[package]]

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -23,7 +23,7 @@ pub use acrawl_core::effect::{
 pub use acrawl_core::error::ToolExecutionError;
 pub use acrawl_core::ToolSpec;
 pub use browser::{
-    generate_bridge_token, markdown, ws_server, BridgeCommand, BridgeError, BridgeResponse,
+    generate_bridge_token, markdown, prune, ws_server, BridgeCommand, BridgeError, BridgeResponse,
     BrowserBackend, BrowserContext, BrowserState, ExtensionBridge, FetchError, FetchRouter,
     FetchedPage, PageInfo, PlaywrightBridge, ScreenshotOptions, SharedBridge, WsBridgeError,
     WsBridgeServer,
@@ -56,14 +56,14 @@ pub fn mvp_tool_specs() -> Vec<acrawl_core::ToolSpec> {
                 "type": "object",
                 "properties": {
                     "url": { "type": "string" },
-                    "format": { "type": "string", "enum": ["markdown", "text", "html"] },
+                    "format": { "type": "string", "enum": ["markdown", "text", "html", "fit_markdown"] },
                     "content_depth": { "type": "string", "enum": ["full", "main", "slim", "none"], "default": "main" },
                     "strip_images": { "type": "boolean", "default": true }
                 },
                 "required": ["url"],
                 "additionalProperties": false
             }),
-            instructions: Some("Always use full URLs including the protocol (https://). Returns page content with an embedded page_map showing page structure. Use content_depth to control context size: 'main' (default) extracts article/main content only, 'full' returns everything, 'slim' gives first 2000 chars of main content, 'none' skips content (page_map only). Images are stripped by default (strip_images=true) since they waste context \u{2014} set false only when you need image URLs. The page_map.links array lets you navigate to linked pages without clicking."),
+            instructions: Some("Always use full URLs including the protocol (https://). Returns page content with an embedded page_map showing page structure. Use content_depth to control context size: 'main' (default) extracts article/main content only, 'full' returns everything, 'slim' gives first 2000 chars of main content, 'none' skips content (page_map only). Images are stripped by default (strip_images=true) since they waste context \u{2014} set false only when you need image URLs. The page_map.links array lets you navigate to linked pages without clicking. Use format='fit_markdown' to filter low-value DOM nodes before conversion, reducing token consumption on noisy pages."),
         },
         ToolSpec {
             name: "click",

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -63,7 +63,7 @@ pub fn mvp_tool_specs() -> Vec<acrawl_core::ToolSpec> {
                 "required": ["url"],
                 "additionalProperties": false
             }),
-            instructions: Some("Always use full URLs including the protocol (https://). Returns page content with an embedded page_map showing page structure. Use content_depth to control context size: 'main' (default) extracts article/main content only, 'full' returns everything, 'slim' gives first 2000 chars of main content, 'none' skips content (page_map only). Images are stripped by default (strip_images=true) since they waste context \u{2014} set false only when you need image URLs. The page_map.links array lets you navigate to linked pages without clicking. Use format='fit_markdown' to filter low-value DOM nodes before conversion, reducing token consumption on noisy pages."),
+            instructions: Some("Always use full URLs including the protocol (https://). Returns page content with an embedded page_map showing page structure. Use content_depth to control context size: 'main' (default) extracts article/main content only, 'full' returns everything, 'slim' gives first 2000 chars of main content, 'none' skips content (page_map only). Images are stripped by default (strip_images=true) since they waste context \u{2014} set false only when you need image URLs. The page_map.links array lets you navigate to linked pages without clicking. PREFER format='fit_markdown' \u{2014} it prunes boilerplate (ads, navs, sidebars) before conversion, saving tokens. Fall back to 'markdown' or 'text' only if content seems missing."),
         },
         ToolSpec {
             name: "click",

--- a/crates/agent/src/tools/navigate.rs
+++ b/crates/agent/src/tools/navigate.rs
@@ -602,9 +602,10 @@ mod tests {
         let markdown = html_to_markdown(html);
         let (content, _) =
             resolve_content(html, text, &markdown, "fit_markdown", &ContentDepth::Main);
+        // Pruning removes all content (ads class) → must fall back to text
         assert!(
-            content.is_empty() || content.contains("advertisement"),
-            "should either fall back to text or return empty, got: {content}"
+            content.contains("fallback text"),
+            "should fall back to text when pruning removes all content, got: {content}"
         );
     }
 }

--- a/crates/agent/src/tools/navigate.rs
+++ b/crates/agent/src/tools/navigate.rs
@@ -274,11 +274,12 @@ pub async fn execute(
         &params.content_depth,
     );
 
-    let content = if params.strip_images && matches!(params.format.as_str(), "markdown" | "fit_markdown") {
-        strip_markdown_images(&content)
-    } else {
-        content
-    };
+    let content =
+        if params.strip_images && matches!(params.format.as_str(), "markdown" | "fit_markdown") {
+            strip_markdown_images(&content)
+        } else {
+            content
+        };
 
     browser.set_navigated_url(&page.url, page.fetched_via_browser);
     browser.ref_map_mut().clear();
@@ -563,5 +564,47 @@ mod tests {
         let input = json!({"url": "https://x.com", "strip_images": false});
         let result = parse_input(&input).unwrap();
         assert!(!result.strip_images);
+    }
+
+    #[test]
+    fn fit_markdown_prunes_noisy_content() {
+        let html = r#"<html><body><article><p>Main content here</p></article><div class="sidebar-ads"><span>Buy now!</span></div><nav>menu</nav></body></html>"#;
+        let text = "Main content here Buy now! menu";
+        let markdown = html_to_markdown(html);
+        let (content, _) =
+            resolve_content(html, text, &markdown, "fit_markdown", &ContentDepth::Main);
+        assert!(
+            content.contains("Main content"),
+            "main content should survive pruning"
+        );
+        assert!(!content.contains("Buy now"), "sidebar ads should be pruned");
+    }
+
+    #[test]
+    fn fit_markdown_full_depth_works() {
+        let html = r"<html><body><article><h1>Title</h1><p>Quality paragraph content.</p></article></body></html>";
+        let text = "Title Quality paragraph content.";
+        let markdown = html_to_markdown(html);
+        let (content, truncated) =
+            resolve_content(html, text, &markdown, "fit_markdown", &ContentDepth::Full);
+        assert!(
+            !content.is_empty(),
+            "full depth fit_markdown should return content"
+        );
+        assert!(!truncated, "short content should not be truncated");
+        assert!(content.contains("Title"), "title should survive");
+    }
+
+    #[test]
+    fn fit_markdown_fallback_to_text() {
+        let html = r#"<html><body><div class="ads"><span class="ads">advertisement</span></div></body></html>"#;
+        let text = "advertisement fallback text";
+        let markdown = html_to_markdown(html);
+        let (content, _) =
+            resolve_content(html, text, &markdown, "fit_markdown", &ContentDepth::Main);
+        assert!(
+            content.is_empty() || content.contains("advertisement"),
+            "should either fall back to text or return empty, got: {content}"
+        );
     }
 }

--- a/crates/agent/src/tools/navigate.rs
+++ b/crates/agent/src/tools/navigate.rs
@@ -1,6 +1,7 @@
 use serde_json::{json, Value};
 
 use crate::markdown::{extract_main_html, html_to_markdown, DEFAULT_MAX_MARKDOWN_CHARS};
+use crate::prune::prune_html;
 use crate::tools::page_map::{annotate_refs, apply_page_map_caps, normalize_url};
 use crate::BrowserContext;
 use crate::FetchRouter;
@@ -59,9 +60,9 @@ fn parse_input(input: &Value) -> Result<NavigateInput, CrawlError> {
         .and_then(Value::as_str)
         .unwrap_or("markdown");
 
-    if !matches!(format, "markdown" | "text" | "html") {
+    if !matches!(format, "markdown" | "text" | "html" | "fit_markdown") {
         return Err(CrawlError::new(
-            "format must be one of: markdown, text, html",
+            "format must be one of: markdown, text, html, fit_markdown",
         ));
     }
 
@@ -205,6 +206,15 @@ fn resolve_content(
             "markdown" => cap_content(markdown, max_chars),
             "text" => cap_content(text, max_chars),
             "html" => cap_content(html, max_chars),
+            "fit_markdown" => {
+                let pruned = prune_html(html);
+                let md = html_to_markdown(&pruned);
+                if md.trim().is_empty() && !text.trim().is_empty() {
+                    cap_content(text, max_chars)
+                } else {
+                    cap_content(&md, max_chars)
+                }
+            }
             _ => unreachable!(),
         },
         ContentDepth::Main | ContentDepth::Slim => {
@@ -224,6 +234,15 @@ fn resolve_content(
                         cap_content(html, max_chars)
                     } else {
                         cap_content(&main_html, max_chars)
+                    }
+                }
+                "fit_markdown" => {
+                    let pruned = prune_html(&main_html);
+                    let md = html_to_markdown(&pruned);
+                    if md.trim().is_empty() && !text.trim().is_empty() {
+                        cap_content(text, max_chars)
+                    } else {
+                        cap_content(&md, max_chars)
                     }
                 }
                 _ => unreachable!(),
@@ -255,7 +274,7 @@ pub async fn execute(
         &params.content_depth,
     );
 
-    let content = if params.strip_images && params.format == "markdown" {
+    let content = if params.strip_images && matches!(params.format.as_str(), "markdown" | "fit_markdown") {
         strip_markdown_images(&content)
     } else {
         content
@@ -341,7 +360,7 @@ mod tests {
 
     #[test]
     fn navigate_parse_format_accepts_text_html_markdown() {
-        for format in ["text", "html", "markdown"] {
+        for format in ["text", "html", "markdown", "fit_markdown"] {
             let input = json!({"url": "https://example.com", "format": format});
             let result = parse_input(&input).unwrap();
             assert_eq!(result.format, format);

--- a/crates/browser/Cargo.toml
+++ b/crates/browser/Cargo.toml
@@ -11,6 +11,7 @@ async-trait = "0.1"
 base64 = "0.22"
 futures-util = "0.3"
 htmd = "0.5"
+scraper = "0.22"
 rand = "0.8"
 encoding_rs = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "gzip", "deflate", "brotli"] }

--- a/crates/browser/src/lib.rs
+++ b/crates/browser/src/lib.rs
@@ -4,6 +4,7 @@ pub mod extension;
 pub mod fetch;
 pub mod markdown;
 pub mod playwright;
+pub mod prune;
 pub mod ref_map;
 pub mod testing;
 pub mod ws_server;

--- a/crates/browser/src/prune.rs
+++ b/crates/browser/src/prune.rs
@@ -3,6 +3,7 @@ use std::fmt::Write;
 use std::sync::LazyLock;
 
 static BODY_SELECTOR: LazyLock<Option<Selector>> = LazyLock::new(|| Selector::parse("body").ok());
+static ANCHOR_SELECTOR: LazyLock<Option<Selector>> = LazyLock::new(|| Selector::parse("a").ok());
 
 const THRESHOLD: f64 = 0.48;
 const NEGATIVE_PATTERNS: [&str; 10] = [
@@ -62,9 +63,10 @@ fn prune_node(element: ElementRef<'_>) -> Option<String> {
 }
 
 fn score_element(element: ElementRef<'_>) -> f64 {
-    let text_len = normalized_text_len(element);
+    let text: String = element.text().collect();
+    let text_len = text.trim().len();
     let tag_len = element.inner_html().len();
-    let link_text_len = direct_link_text_len(element);
+    let link_text_len = descendant_link_text_len(element);
     let text_density = if tag_len > 0 {
         usize_to_f64(text_len) / usize_to_f64(tag_len)
     } else {
@@ -89,16 +91,13 @@ fn score_element(element: ElementRef<'_>) -> f64 {
         + 0.1 * ln_term
 }
 
-fn normalized_text_len(element: ElementRef<'_>) -> usize {
-    element.text().collect::<String>().trim().len()
-}
-
-fn direct_link_text_len(element: ElementRef<'_>) -> usize {
+fn descendant_link_text_len(element: ElementRef<'_>) -> usize {
+    let Some(selector) = ANCHOR_SELECTOR.as_ref() else {
+        return 0;
+    };
     element
-        .children()
-        .filter_map(ElementRef::wrap)
-        .filter(|child| child.value().name() == "a")
-        .map(|child| child.text().collect::<String>().trim().len())
+        .select(selector)
+        .map(|anchor| anchor.text().collect::<String>().trim().len())
         .sum()
 }
 
@@ -246,6 +245,23 @@ mod tests {
                 r#"<html><body><div class="ads"><span class="ads">x</span></div></body></html>"#
             ),
             ""
+        );
+    }
+
+    #[test]
+    fn nested_link_sidebar_pruned() {
+        let html = r#"<html><body>
+            <div class="menu"><ul><li><a href="/a">Link A</a></li><li><a href="/b">Link B</a></li><li><a href="/c">Link C</a></li></ul></div>
+            <article><p>This is a substantial paragraph of real content that should survive pruning.</p></article>
+        </body></html>"#;
+        let result = prune_html(html);
+        assert!(
+            result.contains("substantial paragraph"),
+            "article content should survive"
+        );
+        assert!(
+            !result.contains("Link A"),
+            "nested link-heavy sidebar should be pruned"
         );
     }
 }

--- a/crates/browser/src/prune.rs
+++ b/crates/browser/src/prune.rs
@@ -210,7 +210,7 @@ mod tests {
     #[test]
     fn threshold_boundary() {
         let low_html = r#"<html><body><div class="nav footer ads"><br></div></body></html>"#;
-        let high_html = r#"<html><body><div>abc</div></body></html>"#;
+        let high_html = r"<html><body><div>abc</div></body></html>";
         let low_score = first_body_child_score(low_html);
         let high_score = first_body_child_score(high_html);
 

--- a/crates/browser/src/prune.rs
+++ b/crates/browser/src/prune.rs
@@ -1,0 +1,251 @@
+use scraper::{node::Node, ElementRef, Html, Selector};
+use std::fmt::Write;
+use std::sync::LazyLock;
+
+static BODY_SELECTOR: LazyLock<Option<Selector>> = LazyLock::new(|| Selector::parse("body").ok());
+
+const THRESHOLD: f64 = 0.48;
+const NEGATIVE_PATTERNS: [&str; 10] = [
+    "nav", "footer", "header", "sidebar", "ads", "comment", "promo", "advert", "social", "share",
+];
+const VOID_ELEMENTS: [&str; 14] = [
+    "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source",
+    "track", "wbr",
+];
+
+#[must_use]
+pub fn prune_html(html: &str) -> String {
+    if html.trim().is_empty() {
+        return String::new();
+    }
+
+    let Some(body_selector) = BODY_SELECTOR.as_ref() else {
+        return String::new();
+    };
+
+    let document = Html::parse_document(html);
+    let Some(body) = document.select(body_selector).next() else {
+        return String::new();
+    };
+
+    body.children()
+        .filter_map(ElementRef::wrap)
+        .filter_map(prune_node)
+        .collect::<String>()
+}
+
+fn prune_node(element: ElementRef<'_>) -> Option<String> {
+    if has_negative_class_id_pattern(element) {
+        return None;
+    }
+
+    if score_element(element) < THRESHOLD {
+        return None;
+    }
+
+    if is_void_element(element.value().name()) {
+        return Some(element.html());
+    }
+
+    let tag_name = element.value().name();
+    let attrs = build_attributes(element);
+    let inner = element
+        .children()
+        .filter_map(|child| match child.value() {
+            Node::Text(text) => Some(escape_text(text.as_ref())),
+            Node::Element(_) => ElementRef::wrap(child).and_then(prune_node),
+            _ => None,
+        })
+        .collect::<String>();
+
+    Some(format!("<{tag_name}{attrs}>{inner}</{tag_name}>"))
+}
+
+fn score_element(element: ElementRef<'_>) -> f64 {
+    let text_len = normalized_text_len(element);
+    let tag_len = element.inner_html().len();
+    let link_text_len = direct_link_text_len(element);
+    let text_density = if tag_len > 0 {
+        usize_to_f64(text_len) / usize_to_f64(tag_len)
+    } else {
+        0.0
+    };
+    let link_density_complement = if text_len > 0 {
+        1.0 - (usize_to_f64(link_text_len) / usize_to_f64(text_len)).min(1.0)
+    } else {
+        0.0
+    };
+    let class_id_score = class_id_score(element);
+    let ln_term = if text_len > 0 {
+        (usize_to_f64(text_len) + 1.0).ln()
+    } else {
+        0.0
+    };
+
+    0.4 * text_density
+        + 0.2 * link_density_complement
+        + 0.2 * tag_weight(element.value().name())
+        + 0.1 * f64::max(0.0, class_id_score)
+        + 0.1 * ln_term
+}
+
+fn normalized_text_len(element: ElementRef<'_>) -> usize {
+    element.text().collect::<String>().trim().len()
+}
+
+fn direct_link_text_len(element: ElementRef<'_>) -> usize {
+    element
+        .children()
+        .filter_map(ElementRef::wrap)
+        .filter(|child| child.value().name() == "a")
+        .map(|child| child.text().collect::<String>().trim().len())
+        .sum()
+}
+
+fn class_id_score(element: ElementRef<'_>) -> f64 {
+    [element.value().attr("class"), element.value().attr("id")]
+        .into_iter()
+        .flatten()
+        .map(str::to_ascii_lowercase)
+        .map(|value| {
+            usize_to_f64(
+                NEGATIVE_PATTERNS
+                    .iter()
+                    .filter(|pattern| value.contains(**pattern))
+                    .count(),
+            ) * -0.5
+        })
+        .sum()
+}
+
+fn has_negative_class_id_pattern(element: ElementRef<'_>) -> bool {
+    [element.value().attr("class"), element.value().attr("id")]
+        .into_iter()
+        .flatten()
+        .map(str::to_ascii_lowercase)
+        .any(|value| {
+            NEGATIVE_PATTERNS
+                .iter()
+                .any(|pattern| value.contains(pattern))
+        })
+}
+
+fn tag_weight(tag: &str) -> f64 {
+    if matches!(tag, "div" | "li" | "ul" | "ol") {
+        return 0.5;
+    }
+
+    match tag {
+        "article" => 1.5,
+        "h1" => 1.2,
+        "h2" => 1.1,
+        "h3" | "p" | "section" => 1.0,
+        "h4" => 0.9,
+        "h5" | "table" => 0.8,
+        "h6" => 0.7,
+        "span" => 0.3,
+        _ => 0.5,
+    }
+}
+
+fn is_void_element(tag: &str) -> bool {
+    VOID_ELEMENTS.contains(&tag)
+}
+
+fn build_attributes(element: ElementRef<'_>) -> String {
+    let mut attrs = String::new();
+
+    for (key, value) in element.value().attrs() {
+        let _ = write!(attrs, r#" {key}="{}""#, escape_attr(value));
+    }
+
+    attrs
+}
+
+fn usize_to_f64(value: usize) -> f64 {
+    f64::from(u32::try_from(value).unwrap_or(u32::MAX))
+}
+
+fn escape_attr(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('"', "&quot;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+fn escape_text(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn first_body_child_score(html: &str) -> f64 {
+        let document = Html::parse_document(html);
+        let body_selector = Selector::parse("body").expect("body selector should parse");
+        let body = document
+            .select(&body_selector)
+            .next()
+            .expect("body should exist in test html");
+        let element = body
+            .children()
+            .find_map(ElementRef::wrap)
+            .expect("body should have a child element");
+
+        score_element(element)
+    }
+
+    #[test]
+    fn score_calculation_correct() {
+        let result = prune_html("<html><body><p>Hello World</p></body></html>");
+        assert!(!result.is_empty(), "p tag with content should survive");
+        assert!(result.contains("Hello World"));
+    }
+
+    #[test]
+    fn threshold_boundary() {
+        let low_html = r#"<html><body><div class="nav footer ads"><br></div></body></html>"#;
+        let high_html = r#"<html><body><div>abc</div></body></html>"#;
+        let low_score = first_body_child_score(low_html);
+        let high_score = first_body_child_score(high_html);
+
+        assert!(
+            low_score < THRESHOLD,
+            "expected low score below threshold, got {low_score}"
+        );
+        assert!(
+            high_score >= THRESHOLD,
+            "expected high score above threshold, got {high_score}"
+        );
+        assert!(prune_html(high_html).contains("abc"));
+        assert_eq!(prune_html(low_html), "");
+    }
+
+    #[test]
+    fn negative_class_pattern() {
+        let html = r#"<html><body>
+            <div class="main-content"><p>content</p></div>
+            <div class="sidebar-nav"><p>content</p></div>
+        </body></html>"#;
+        let result = prune_html(html);
+
+        assert!(result.contains(r#"<div class="main-content"><p>content</p></div>"#));
+        assert!(!result.contains("sidebar-nav"));
+    }
+
+    #[test]
+    fn edge_cases() {
+        assert_eq!(prune_html(""), "");
+        assert_eq!(
+            prune_html(
+                r#"<html><body><div class="ads"><span class="ads">x</span></div></body></html>"#
+            ),
+            ""
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `fit_markdown` format option to the navigate tool that prunes low-value DOM nodes (ads, navs, sidebars, footers) before markdown conversion, reducing token consumption on noisy pages.

## Changes

- **`crates/browser/src/prune.rs`** (new) - DOM pruning algorithm scoring elements by text density, descendant link density, tag weight, and class/id patterns
- **`crates/agent/src/tools/navigate.rs`** - integrate `fit_markdown` as a format option with text fallback when pruning removes all content
- **`crates/agent/src/lib.rs`** - export prune module, add `fit_markdown` to tool schema enum, update tool instructions to prefer it by default
- **`crates/browser/Cargo.toml`** - add `scraper = "0.22"` dependency

## How it works

1. Agent passes `format: "fit_markdown"` in navigate tool call
2. HTML is parsed and each body child is scored on: text density (0.4), link density complement (0.2), semantic tag weight (0.2), class/id signal (0.1), content length (0.1)
3. Elements below threshold (0.48) or matching negative class/id patterns are pruned
4. Surviving HTML is converted to markdown
5. If pruning removes all content, falls back to plain text

## Design decisions

- **Opt-in via format param** - agent explicitly chooses `fit_markdown`; can fall back to `markdown`/`text` if content seems missing
- **Descendant link density** - counts all nested `<a>` text (not just direct children) to correctly identify link-heavy sidebars
- **Placed on navigate, not page_map** - navigate returns rendered text content; page_map returns structural metadata only
- **Tool instructions prefer fit_markdown** - guides the agent to use it by default for token savings

## Tests

- Unit tests for scoring, threshold boundaries, negative patterns, edge cases, nested link sidebar pruning
- Integration tests for `fit_markdown` with full/main content depth and text fallback behavior
