### PR TITLE
feat(script): Autonomous Script Protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,7 @@ dependencies = [
  "script",
  "serde_json",
  "tempfile",
+ "time",
  "tokio",
  "tokio-tungstenite",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,9 +96,11 @@ dependencies = [
  "futures-util",
  "regex",
  "runtime",
+ "script",
  "serde_json",
  "tokio",
  "tokio-tungstenite",
+ "tokio-util",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3218,6 +3218,7 @@ dependencies = [
  "acrawl-core",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 1.0.69",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3210,6 +3210,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "script"
+version = "0.8.7"
+dependencies = [
+ "acrawl-core",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,7 @@ dependencies = [
  "runtime",
  "script",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-tungstenite",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/browser",
     "crates/tui",
     "crates/ui",
+    "crates/script",
 ]
 resolver = "2"
 

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -21,6 +21,7 @@ url = "2"
 [dev-dependencies]
 async-trait = "0.1"
 futures-util = "0.3"
+tempfile = "3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "sync"] }
 tokio-tungstenite = "0.26"
 

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -14,6 +14,7 @@ regex = "1"
 runtime = { path = "../runtime" }
 script = { path = "../script" }
 serde_json = "1"
+time = { version = "0.3", features = ["formatting"] }
 tokio = { version = "1", features = ["sync", "time", "fs"] }
 tokio-util = { version = "0.7", default-features = false }
 url = "2"

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -12,8 +12,10 @@ browser = { path = "../browser" }
 csv = "1"
 regex = "1"
 runtime = { path = "../runtime" }
+script = { path = "../script" }
 serde_json = "1"
 tokio = { version = "1", features = ["sync", "time", "fs"] }
+tokio-util = { version = "0.7", default-features = false }
 url = "2"
 
 [dev-dependencies]

--- a/crates/agent/src/implementation/mod.rs
+++ b/crates/agent/src/implementation/mod.rs
@@ -468,9 +468,7 @@ impl CrawlerAgent {
             ToolEffect::RunScript(_spec) => {
                 Err(ToolError::new("script execution not yet implemented"))
             }
-            ToolEffect::ScriptWait(_spec) => {
-                Err(ToolError::new("script wait not yet implemented"))
-            }
+            ToolEffect::ScriptWait(_spec) => Err(ToolError::new("script wait not yet implemented")),
             ToolEffect::ScriptCancel(_spec) => {
                 Err(ToolError::new("script cancel not yet implemented"))
             }

--- a/crates/agent/src/implementation/mod.rs
+++ b/crates/agent/src/implementation/mod.rs
@@ -465,6 +465,18 @@ impl CrawlerAgent {
             ToolEffect::Wait(spec) => self.handle_wait_effect(spec).await,
             ToolEffect::Cancel(spec) => self.handle_cancel_effect(spec).await,
             ToolEffect::Status(spec) => self.handle_status_effect(spec).await,
+            ToolEffect::RunScript(_spec) => {
+                Err(ToolError::new("script execution not yet implemented"))
+            }
+            ToolEffect::ScriptWait(_spec) => {
+                Err(ToolError::new("script wait not yet implemented"))
+            }
+            ToolEffect::ScriptCancel(_spec) => {
+                Err(ToolError::new("script cancel not yet implemented"))
+            }
+            ToolEffect::ScriptStatus(_spec) => {
+                Err(ToolError::new("script status not yet implemented"))
+            }
         }
     }
 }

--- a/crates/agent/src/implementation/mod.rs
+++ b/crates/agent/src/implementation/mod.rs
@@ -11,6 +11,7 @@ use tokio::sync::Mutex;
 use crate::manager::SharedAgentManager;
 use crate::prompt::build_system_prompt;
 use crate::registry::ToolRegistry;
+use crate::script_manager::{ScriptError, ScriptManager};
 use crate::state::CrawlState;
 use crate::tool_effect::ToolEffect;
 use crate::{mvp_tool_specs, AgentManager, BrowserContext, SharedApiClient, SharedBridge};
@@ -108,6 +109,7 @@ pub struct CrawlerAgent {
     /// being reused after children are drained/waited on.
     pub(super) child_id_counter: std::sync::atomic::AtomicU64,
     pub(super) api_client_arc: Option<SharedApiClient>,
+    script_manager: ScriptManager,
     control_state: Option<Arc<ControlState>>,
     child_event_tx: Option<std::sync::mpsc::Sender<crate::child_events::ChildEvent>>,
     child_control_registry: Option<crate::child_events::ChildControlRegistry>,
@@ -145,6 +147,7 @@ impl CrawlerAgent {
             child_tasks: HashMap::new(),
             child_id_counter: std::sync::atomic::AtomicU64::new(0),
             api_client_arc: None,
+            script_manager: default_script_manager(),
             control_state: None,
             child_event_tx: None,
             child_control_registry: None,
@@ -173,6 +176,7 @@ impl CrawlerAgent {
             child_tasks: HashMap::new(),
             child_id_counter: std::sync::atomic::AtomicU64::new(0),
             api_client_arc: None,
+            script_manager: default_script_manager(),
             control_state: None,
             child_event_tx: None,
             child_control_registry: None,
@@ -201,6 +205,7 @@ impl CrawlerAgent {
             child_tasks: HashMap::new(),
             child_id_counter: std::sync::atomic::AtomicU64::new(0),
             api_client_arc: None,
+            script_manager: default_script_manager(),
             control_state: None,
             child_event_tx: None,
             child_control_registry: None,
@@ -465,17 +470,128 @@ impl CrawlerAgent {
             ToolEffect::Wait(spec) => self.handle_wait_effect(spec).await,
             ToolEffect::Cancel(spec) => self.handle_cancel_effect(spec).await,
             ToolEffect::Status(spec) => self.handle_status_effect(spec).await,
-            ToolEffect::RunScript(_spec) => {
-                Err(ToolError::new("script execution not yet implemented"))
-            }
-            ToolEffect::ScriptWait(_spec) => Err(ToolError::new("script wait not yet implemented")),
-            ToolEffect::ScriptCancel(_spec) => {
-                Err(ToolError::new("script cancel not yet implemented"))
-            }
-            ToolEffect::ScriptStatus(_spec) => {
-                Err(ToolError::new("script status not yet implemented"))
-            }
+            ToolEffect::RunScript(task) => self.handle_run_script_effect(task).await,
+            ToolEffect::ScriptWait(spec) => self.handle_script_wait_effect(spec).await,
+            ToolEffect::ScriptCancel(spec) => self.handle_script_cancel_effect(spec),
+            ToolEffect::ScriptStatus(spec) => self.handle_script_status_effect(spec),
         }
+    }
+
+    async fn handle_run_script_effect(
+        &mut self,
+        mut task: acrawl_core::ScriptTask,
+    ) -> Result<String, ToolError> {
+        self.ensure_browser().await?;
+
+        if task
+            .script
+            .get("__load_from_disk")
+            .and_then(Value::as_str)
+            .is_some()
+        {
+            task.script = self.load_script_from_disk(&task)?;
+        }
+
+        let current_url = self.crawl_state.current_url.clone();
+        let cloned_context = self
+            .clone_browser_context_for_script(current_url.as_deref())
+            .await?;
+        let script_id = self
+            .script_manager
+            .spawn_script(task, cloned_context)
+            .map_err(script_error_to_tool)?;
+
+        Ok(format!("Script started: {script_id}"))
+    }
+
+    async fn handle_script_wait_effect(
+        &mut self,
+        spec: acrawl_core::ScriptWaitSpec,
+    ) -> Result<String, ToolError> {
+        let results = self
+            .script_manager
+            .wait_for_scripts(spec.script_ids)
+            .await
+            .map_err(script_error_to_tool)?;
+        serde_json::to_string(&results)
+            .map_err(|error| ToolError::new(format!("failed to serialize script results: {error}")))
+    }
+
+    fn handle_script_cancel_effect(
+        &mut self,
+        spec: acrawl_core::ScriptCancelSpec,
+    ) -> Result<String, ToolError> {
+        self.script_manager
+            .cancel_script(&spec.script_id)
+            .map_err(script_error_to_tool)?;
+        Ok(format!("Script cancelled: {}", spec.script_id))
+    }
+
+    fn handle_script_status_effect(
+        &mut self,
+        spec: acrawl_core::ScriptStatusSpec,
+    ) -> Result<String, ToolError> {
+        let status = self
+            .script_manager
+            .get_status(&spec.script_id)
+            .map_err(script_error_to_tool)?;
+        serde_json::to_string(&status)
+            .map_err(|error| ToolError::new(format!("failed to serialize script status: {error}")))
+    }
+
+    async fn clone_browser_context_for_script(
+        &mut self,
+        target_url: Option<&str>,
+    ) -> Result<BrowserContext, ToolError> {
+        let shared_bridge = self
+            .shared_bridge
+            .clone()
+            .or_else(|| {
+                self.browser
+                    .as_ref()
+                    .map(|browser| browser.bridge().clone())
+            })
+            .ok_or_else(|| ToolError::new("script: browser bridge not initialized"))?;
+        let page_index = {
+            let mut bridge = shared_bridge.lock().await;
+            bridge
+                .new_page(target_url)
+                .await
+                .map_err(|error| ToolError::new(error.to_string()))?
+        };
+
+        let mut browser = BrowserContext::new_shared(shared_bridge, page_index);
+        if let Some(url) = target_url {
+            browser.set_navigated_url(url, true);
+        }
+        Ok(browser)
+    }
+
+    fn load_script_from_disk(&self, task: &acrawl_core::ScriptTask) -> Result<Value, ToolError> {
+        let script_name = task
+            .script
+            .get("__load_from_disk")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ToolError::new("script loader requires __load_from_disk string"))?;
+        let script_settings = self.script_manager.settings.clone();
+        let scripts_dir = script_settings.scripts_dir.unwrap_or_else(|| {
+            runtime::settings::ScriptSettings::default()
+                .scripts_dir
+                .unwrap_or_else(|| acrawl_core::config_home_dir().join("scripts"))
+        });
+        let script_path = scripts_dir.join(format!("{script_name}.json"));
+        let script_text = std::fs::read_to_string(&script_path).map_err(|error| {
+            ToolError::new(format!(
+                "failed to read script `{script_name}` from {}: {error}",
+                script_path.display()
+            ))
+        })?;
+        serde_json::from_str(&script_text).map_err(|error| {
+            ToolError::new(format!(
+                "failed to parse script `{script_name}` from {}: {error}",
+                script_path.display()
+            ))
+        })
     }
 }
 
@@ -485,6 +601,15 @@ fn default_agent_manager() -> SharedAgentManager {
         DEFAULT_MAX_FORK_DEPTH,
         DEFAULT_MAX_TOTAL_AGENTS,
     )))
+}
+
+fn default_script_manager() -> ScriptManager {
+    let settings = runtime::load_settings();
+    ScriptManager::new(settings.script.unwrap_or_default())
+}
+
+fn script_error_to_tool(error: ScriptError) -> ToolError {
+    ToolError::new(error.to_string())
 }
 
 fn generate_agent_id() -> String {

--- a/crates/agent/src/implementation/mod.rs
+++ b/crates/agent/src/implementation/mod.rs
@@ -517,6 +517,7 @@ impl CrawlerAgent {
             .map_err(|error| ToolError::new(format!("failed to serialize script results: {error}")))
     }
 
+    #[allow(clippy::needless_pass_by_value)]
     fn handle_script_cancel_effect(
         &mut self,
         spec: acrawl_core::ScriptCancelSpec,
@@ -527,6 +528,7 @@ impl CrawlerAgent {
         Ok(format!("Script cancelled: {}", spec.script_id))
     }
 
+    #[allow(clippy::needless_pass_by_value)]
     fn handle_script_status_effect(
         &mut self,
         spec: acrawl_core::ScriptStatusSpec,
@@ -608,6 +610,7 @@ fn default_script_manager() -> ScriptManager {
     ScriptManager::new(settings.script.unwrap_or_default())
 }
 
+#[allow(clippy::needless_pass_by_value)]
 fn script_error_to_tool(error: ScriptError) -> ToolError {
     ToolError::new(error.to_string())
 }

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -4,6 +4,7 @@ pub mod manager;
 pub mod output;
 pub mod prompt;
 pub mod registry;
+pub mod script_executor;
 mod shared_client;
 pub mod state;
 pub mod tools;

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -484,6 +484,124 @@ fn agent_control_tools() -> Vec<ToolSpec> {
     ]
 }
 
+fn script_management_tools() -> Vec<ToolSpec> {
+    vec![
+        ToolSpec {
+            name: "run_script",
+            description: "Generate and execute a deterministic multi-step script without per-step LLM round-trips",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "script": {
+                        "type": "object",
+                        "description": "Script definition object with version, steps, and limits"
+                    },
+                    "__load_from_disk": {
+                        "type": "string",
+                        "description": "Internal: load a saved script by name instead of inline definition"
+                    }
+                },
+                "additionalProperties": false
+            }),
+            instructions: Some("Generate and execute a deterministic multi-step script without per-step LLM round-trips. Use when you detect a repetitive pattern (same operation on 3+ pages/items). Workflow: navigate manually first to understand the pattern, then generate a script with for/while loops. Scripts support: tool calls, for/while/if/try-catch/parallel branches, yield checkpoints, and variable capture. Scripts run on a cloned browser tab. Returns a script_id; use wait_for_scripts to collect results. Script definition must include: version (\"1.0\"), steps (array of nodes), and limits (max_steps, max_script_size_bytes, max_nesting_depth, max_parallel_branches). Each step is a node: ToolCall (invoke a tool), Assign (set variable), Collect (append to results), Yield (checkpoint), ForLoop/ForEach/WhileLoop (iteration), IfElse (conditional), TryCatch (error handling), or Parallel (concurrent branches)."),
+        },
+        ToolSpec {
+            name: "script_status",
+            description: "Check the status of a running or completed script",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "script_id": {
+                        "type": "string",
+                        "description": "Script ID returned by run_script (format: scr_XXXXXXXX)"
+                    }
+                },
+                "required": ["script_id"],
+                "additionalProperties": false
+            }),
+            instructions: Some("Returns the current status of a script: running, completed, failed, or cancelled. Includes step count, extracted data so far, and any error message. Use this to monitor long-running scripts without blocking."),
+        },
+        ToolSpec {
+            name: "wait_for_scripts",
+            description: "Wait for one or more scripts to finish and collect their results",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "script_ids": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Optional list of script IDs to wait for. If omitted, waits for all active scripts."
+                    }
+                },
+                "additionalProperties": false
+            }),
+            instructions: Some("Blocks until the specified scripts finish (or all active scripts if script_ids is omitted). Returns a JSON array of ScriptResult objects, each containing: script_id, status (completed/failed/cancelled), extracted_data (array of values), yielded_data (checkpoints), step_count, and error (if failed). Use this after run_script to collect results."),
+        },
+        ToolSpec {
+            name: "cancel_script",
+            description: "Abort a running script immediately",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "script_id": {
+                        "type": "string",
+                        "description": "Script ID to cancel (format: scr_XXXXXXXX)"
+                    }
+                },
+                "required": ["script_id"],
+                "additionalProperties": false
+            }),
+            instructions: Some("Cancels a running script. The script's browser page is closed and any partial results are discarded. Returns confirmation of cancellation."),
+        },
+        ToolSpec {
+            name: "save_script",
+            description: "Save a script definition to disk for later reuse",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Name to save the script under (alphanumeric + underscore, no extension)"
+                    },
+                    "script": {
+                        "type": "object",
+                        "description": "Script definition object (same format as run_script)"
+                    }
+                },
+                "required": ["name", "script"],
+                "additionalProperties": false
+            }),
+            instructions: Some("Saves a script definition to ~/.acrawl/scripts/<name>.json for later reuse. Once saved, you can run it again with run_script using __load_from_disk: \"name\" instead of providing the full script object inline. Useful for complex patterns you want to reuse across multiple crawl sessions."),
+        },
+        ToolSpec {
+            name: "list_scripts",
+            description: "List all saved scripts",
+            input_schema: json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }),
+            instructions: Some("Returns a JSON array of saved script names and their metadata (creation date, last modified, size). Use this to discover available scripts before running them with run_script + __load_from_disk."),
+        },
+        ToolSpec {
+            name: "read_script",
+            description: "Read a saved script definition",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Name of the saved script to read"
+                    }
+                },
+                "required": ["name"],
+                "additionalProperties": false
+            }),
+            instructions: Some("Returns the full script definition (JSON) for a saved script. Use this to inspect or modify a script before running it, or to understand what a saved script does."),
+        },
+    ]
+}
+
 /// Returns the built-in tool specifications.
 #[must_use]
 pub fn mvp_tool_specs() -> Vec<acrawl_core::ToolSpec> {
@@ -491,6 +609,7 @@ pub fn mvp_tool_specs() -> Vec<acrawl_core::ToolSpec> {
     specs.extend(interaction_tools());
     specs.extend(extraction_tools());
     specs.extend(agent_control_tools());
+    specs.extend(script_management_tools());
     specs
 }
 
@@ -501,12 +620,12 @@ mod tests {
     use super::mvp_tool_specs;
 
     #[test]
-    fn mvp_tool_specs_contains_expected_21_tools() {
+    fn mvp_tool_specs_contains_expected_28_tools() {
         let specs = mvp_tool_specs();
-        assert_eq!(specs.len(), 21);
+        assert_eq!(specs.len(), 28);
 
         let names: BTreeSet<_> = specs.iter().map(|spec| spec.name).collect();
-        assert_eq!(names.len(), 21, "tool names should be unique");
+        assert_eq!(names.len(), 28, "tool names should be unique");
         assert!(names.contains("navigate"));
         assert!(names.contains("click_at"));
         assert!(names.contains("save_file"));
@@ -514,6 +633,13 @@ mod tests {
         assert!(names.contains("wait_for_subagents"));
         assert!(names.contains("cancel_subagent"));
         assert!(names.contains("subagent_status"));
+        assert!(names.contains("run_script"));
+        assert!(names.contains("script_status"));
+        assert!(names.contains("wait_for_scripts"));
+        assert!(names.contains("cancel_script"));
+        assert!(names.contains("save_script"));
+        assert!(names.contains("list_scripts"));
+        assert!(names.contains("read_script"));
     }
 
     #[test]

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -5,6 +5,7 @@ pub mod output;
 pub mod prompt;
 pub mod registry;
 pub mod script_executor;
+pub mod script_manager;
 mod shared_client;
 pub mod state;
 pub mod tools;

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -495,16 +495,24 @@ fn script_management_tools() -> Vec<ToolSpec> {
                 "properties": {
                     "script": {
                         "type": "object",
-                        "description": "Script definition object with version, steps, and limits"
+                        "description": "Inline script definition object (use instead of `name`)"
                     },
-                    "__load_from_disk": {
+                    "name": {
                         "type": "string",
-                        "description": "Internal: load a saved script by name instead of inline definition"
+                        "description": "Name of a previously saved script to run (alternative to inline `script`)"
+                    },
+                    "save_as": {
+                        "type": "string",
+                        "description": "Save the script under this name after execution for future reuse"
+                    },
+                    "limits": {
+                        "type": "object",
+                        "description": "Override default execution limits (max_steps, max_timeout_secs, max_output_bytes, max_parallel_branches, per_step_timeout_secs)"
                     }
                 },
                 "additionalProperties": false
             }),
-            instructions: Some("Generate and execute a deterministic multi-step script without per-step LLM round-trips. Use when you detect a repetitive pattern (same operation on 3+ pages/items). Workflow: navigate manually first to understand the pattern, then generate a script with for/while loops. Scripts support: tool calls, for/while/if/try-catch/parallel branches, yield checkpoints, and variable capture. Scripts run on a cloned browser tab. Returns a script_id; use wait_for_scripts to collect results. Script definition must include: version (\"1.0\"), steps (array of nodes), and limits (max_steps, max_script_size_bytes, max_nesting_depth, max_parallel_branches). Each step is a node: ToolCall (invoke a tool), Assign (set variable), Collect (append to results), Yield (checkpoint), ForLoop/ForEach/WhileLoop (iteration), IfElse (conditional), TryCatch (error handling), or Parallel (concurrent branches)."),
+            instructions: Some("Generate and execute a deterministic multi-step script without per-step LLM round-trips. Use when you detect a repetitive pattern (same operation on 3+ pages/items). Workflow: navigate manually first to understand the pattern, then generate a script with for/while loops. Scripts support: tool calls, for/while/if/try-catch/parallel branches, yield checkpoints, and variable capture. Scripts run on a cloned browser tab. Returns a script_id; use wait_for_scripts to collect results. Provide either an inline `script` definition or `name` to load a previously saved script. You can also set `save_as` to persist the executed script and `limits` to override execution limits. Script definition must include: version (\"1.0\"), steps (array of nodes), and limits (max_steps, max_script_size_bytes, max_nesting_depth, max_parallel_branches). Each step is a node: ToolCall (invoke a tool), Assign (set variable), Collect (append to results), Yield (checkpoint), ForLoop/ForEach/WhileLoop (iteration), IfElse (conditional), TryCatch (error handling), or Parallel (concurrent branches)."),
         },
         ToolSpec {
             name: "script_status",
@@ -572,7 +580,7 @@ fn script_management_tools() -> Vec<ToolSpec> {
                 "required": ["name", "script"],
                 "additionalProperties": false
             }),
-            instructions: Some("Saves a script definition to ~/.acrawl/scripts/<name>.json for later reuse. Once saved, you can run it again with run_script using __load_from_disk: \"name\" instead of providing the full script object inline. Useful for complex patterns you want to reuse across multiple crawl sessions."),
+            instructions: Some("Saves a script definition to ~/.acrawl/scripts/<name>.json for later reuse. Once saved, you can run it again with run_script using name: \"name\" instead of providing the full script object inline. Useful for complex patterns you want to reuse across multiple crawl sessions."),
         },
         ToolSpec {
             name: "list_scripts",
@@ -582,7 +590,7 @@ fn script_management_tools() -> Vec<ToolSpec> {
                 "properties": {},
                 "additionalProperties": false
             }),
-            instructions: Some("Returns a JSON array of saved script names and their metadata (creation date, last modified, size). Use this to discover available scripts before running them with run_script + __load_from_disk."),
+            instructions: Some("Returns a JSON array of saved script names and their metadata (creation date, last modified, size). Use this to discover available scripts before running them with run_script + name."),
         },
         ToolSpec {
             name: "read_script",

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -484,6 +484,7 @@ fn agent_control_tools() -> Vec<ToolSpec> {
     ]
 }
 
+#[allow(clippy::too_many_lines)]
 fn script_management_tools() -> Vec<ToolSpec> {
     vec![
         ToolSpec {

--- a/crates/agent/src/prompt.rs
+++ b/crates/agent/src/prompt.rs
@@ -173,7 +173,7 @@ fn section_parallel_exploration() -> String {
        - Each subagent gets a copy of your history and works independently.\n\
        - You can fork multiple subagents at once (up to the configured limit).\n\
        - After forking, continue your own work — subagents run in parallel.\n\
-         - Use `wait_for_subagents` to block and collect results when you need them.\n\
+       - Use `wait_for_subagents` to block and collect results when you need them.\n\
        - Prefer forking over sequential navigation when visiting multiple independent pages.\n\
        - Example: Scraping 5 product pages? Fork 5 subagents, each visiting one page, then wait for their results."
          .to_string()

--- a/crates/agent/src/prompt.rs
+++ b/crates/agent/src/prompt.rs
@@ -42,6 +42,7 @@ pub fn build_system_prompt(tool_specs: &[ToolSpec]) -> Vec<String> {
         section_error_recovery(),
         section_completion(),
         section_parallel_exploration(),
+        section_autonomous_scripts(),
     ]
 }
 
@@ -172,10 +173,50 @@ fn section_parallel_exploration() -> String {
        - Each subagent gets a copy of your history and works independently.\n\
        - You can fork multiple subagents at once (up to the configured limit).\n\
        - After forking, continue your own work — subagents run in parallel.\n\
-        - Use `wait_for_subagents` to block and collect results when you need them.\n\
+         - Use `wait_for_subagents` to block and collect results when you need them.\n\
        - Prefer forking over sequential navigation when visiting multiple independent pages.\n\
        - Example: Scraping 5 product pages? Fork 5 subagents, each visiting one page, then wait for their results."
          .to_string()
+}
+
+fn section_autonomous_scripts() -> String {
+    "Autonomous scripts:\n\
+      When you detect a **repetitive page pattern** (same structure across 3+ URLs/items), switch from per-step LLM navigation to a **deterministic script**. Scripts execute browser tools in loops without LLM round-trips — dramatically faster and cheaper for batch operations.\n\n\
+      When to use scripts:\n\
+      - After manually navigating 2–3 similar pages and identifying a consistent extraction pattern\n\
+      - For pagination scraping (50 product pages with identical structure)\n\
+      - For repeated actions across a list (filling N forms, clicking N buttons)\n\n\
+      Workflow:\n\
+      1. Navigate manually to 2–3 sample pages to understand the pattern\n\
+      2. Write the script inline in `run_script` using the patterns you observed\n\
+      3. The script returns a `script_id` immediately (non-blocking)\n\
+      4. Poll `script_status` to monitor progress or use `wait_for_scripts` to block until done\n\
+      5. Collect results from the final `ScriptResult`\n\n\
+      Script tools:\n\
+      - **`run_script`** — Execute a script inline or by saved name. Returns `script_id`.\n\
+      - **`script_status`** — Check real-time status, step count, and yielded data.\n\
+      - **`wait_for_scripts`** — Block until script(s) complete. Returns all results.\n\
+      - **`cancel_script`** — Abort a running script.\n\
+      - **`save_script`** — Save a script definition for reuse.\n\
+      - **`list_scripts`** — Show all saved scripts.\n\
+      - **`read_script`** — Read a saved script definition.\n\n\
+      Example: Scrape 50 product pages\n\
+      ```json\n\
+      {\n\
+        \"schema_version\": 1,\n\
+        \"steps\": [\n\
+          {\"type\": \"assign\", \"variable\": \"urls\", \"value\": {\"kind\": \"literal\", \"value\": [\"https://shop.example.com/p/1\", \"...\"]}},\n\
+          {\"type\": \"for_each\", \"variable\": \"url\", \"iterable\": {\"kind\": \"variable\", \"value\": \"urls\"}, \"steps\": [\n\
+            {\"type\": \"tool_call\", \"tool\": \"navigate\", \"input\": {\"url\": \"$url\"}, \"output\": \"page\"},\n\
+            {\"type\": \"tool_call\", \"tool\": \"read_content\", \"input\": {\"selector\": \".product-title\"}, \"output\": \"title\"},\n\
+            {\"type\": \"collect\", \"value\": {\"kind\": \"variable\", \"value\": \"title\"}},\n\
+            {\"type\": \"yield\", \"value\": {\"kind\": \"variable\", \"value\": \"title\"}}\n\
+          ]}\n\
+        ]\n\
+      }\n\
+      ```\n\n\
+      Scripts support: `for`/`foreach`/`while` loops, `if`/`else` branches, `try`/`catch`/`finally`, `parallel` branches, `yield` checkpoints, `assign` variables, and inline JS via `execute_js`."
+        .to_string()
 }
 
 #[cfg(test)]
@@ -275,6 +316,7 @@ mod tests {
         assert!(joined.contains("Error recovery by situation:"));
         assert!(joined.contains("Completion:"));
         assert!(joined.contains("Parallel exploration:"));
+        assert!(joined.contains("Autonomous scripts:"));
     }
 
     #[test]
@@ -303,6 +345,37 @@ mod tests {
             joined.contains("wait_for_subagents"),
             "should mention wait_for_subagents"
         );
-        assert_eq!(prompt.len(), 7, "should have 7 sections");
+        assert_eq!(prompt.len(), 8, "should have 8 sections");
+    }
+
+    #[test]
+    fn test_system_prompt_contains_autonomous_scripts() {
+        let specs = crate::mvp_tool_specs();
+        let prompt = build_system_prompt(&specs);
+        let joined = prompt.join("\n");
+        assert!(
+            joined.contains("Autonomous scripts:"),
+            "should mention autonomous scripts"
+        );
+        assert!(joined.contains("run_script"), "should mention run_script");
+        assert!(
+            joined.contains("script_status"),
+            "should mention script_status"
+        );
+        assert!(
+            joined.contains("wait_for_scripts"),
+            "should mention wait_for_scripts"
+        );
+        assert!(
+            joined.contains("cancel_script"),
+            "should mention cancel_script"
+        );
+        assert!(joined.contains("save_script"), "should mention save_script");
+        assert!(
+            joined.contains("list_scripts"),
+            "should mention list_scripts"
+        );
+        assert!(joined.contains("read_script"), "should mention read_script");
+        assert_eq!(prompt.len(), 8, "should have 8 sections");
     }
 }

--- a/crates/agent/src/script_executor/control_flow.rs
+++ b/crates/agent/src/script_executor/control_flow.rs
@@ -1,0 +1,195 @@
+use script::grammar::{Expression, ScriptNode};
+use serde_json::{Number, Value};
+use std::future::Future;
+use std::pin::Pin;
+
+use super::{ScriptExecutionError, ScriptExecutor};
+
+impl ScriptExecutor {
+    pub(super) fn execute_for_loop<'a>(
+        &'a mut self,
+        variable: &'a str,
+        from: &'a Expression,
+        to: &'a Expression,
+        steps: &'a [ScriptNode],
+    ) -> Pin<Box<dyn Future<Output = Result<(), ScriptExecutionError>> + Send + 'a>> {
+        Box::pin(async move {
+            let start = Self::value_to_i64(
+                self.evaluate_expression(from).await?,
+                "for loop `from`",
+            )?;
+            let end = Self::value_to_i64(self.evaluate_expression(to).await?, "for loop `to`")?;
+
+            for value in start..end {
+                self.check_limits()?;
+                self.variables.insert(
+                    variable.to_string(),
+                    Value::Number(Number::from(value)),
+                );
+
+                for step in steps {
+                    self.execute_node(step).await?;
+                }
+            }
+
+            Ok(())
+        })
+    }
+
+    pub(super) fn execute_for_each<'a>(
+        &'a mut self,
+        variable: &'a str,
+        iterable: &'a Expression,
+        steps: &'a [ScriptNode],
+    ) -> Pin<Box<dyn Future<Output = Result<(), ScriptExecutionError>> + Send + 'a>> {
+        Box::pin(async move {
+            match self.evaluate_expression(iterable).await? {
+                Value::Array(items) => {
+                    for item in items {
+                        self.check_limits()?;
+                        self.variables.insert(variable.to_string(), item);
+
+                        for step in steps {
+                            self.execute_node(step).await?;
+                        }
+                    }
+                }
+                Value::Object(map) => {
+                    for (key, value) in map {
+                        self.check_limits()?;
+                        self.variables.insert(
+                            variable.to_string(),
+                            Value::Object(serde_json::Map::from_iter([
+                                (String::from("key"), Value::String(key)),
+                                (String::from("value"), value),
+                            ])),
+                        );
+
+                        for step in steps {
+                            self.execute_node(step).await?;
+                        }
+                    }
+                }
+                value => {
+                    return Err(ScriptExecutionError::ToolError(format!(
+                        "for_each iterable must evaluate to an array or object, got {value}"
+                    )));
+                }
+            }
+
+            Ok(())
+        })
+    }
+
+    pub(super) fn execute_while_loop<'a>(
+        &'a mut self,
+        condition: &'a Expression,
+        steps: &'a [ScriptNode],
+    ) -> Pin<Box<dyn Future<Output = Result<(), ScriptExecutionError>> + Send + 'a>> {
+        Box::pin(async move {
+            while Self::is_truthy(&self.evaluate_expression(condition).await?) {
+                self.check_limits()?;
+
+                for step in steps {
+                    self.execute_node(step).await?;
+                }
+            }
+
+            Ok(())
+        })
+    }
+
+    pub(super) fn execute_if_else<'a>(
+        &'a mut self,
+        condition: &'a Expression,
+        then_steps: &'a [ScriptNode],
+        else_steps: Option<&'a [ScriptNode]>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), ScriptExecutionError>> + Send + 'a>> {
+        Box::pin(async move {
+            let steps = if Self::is_truthy(&self.evaluate_expression(condition).await?) {
+                then_steps
+            } else {
+                else_steps.unwrap_or_default()
+            };
+
+            for step in steps {
+                self.execute_node(step).await?;
+            }
+
+            Ok(())
+        })
+    }
+
+    pub(super) fn execute_try_catch<'a>(
+        &'a mut self,
+        try_steps: &'a [ScriptNode],
+        catch_steps: Option<&'a [ScriptNode]>,
+        finally_steps: Option<&'a [ScriptNode]>,
+        error_var: Option<&'a str>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), ScriptExecutionError>> + Send + 'a>> {
+        Box::pin(async move {
+            let mut pending_error = None;
+
+            for step in try_steps {
+                match self.execute_node(step).await {
+                    Ok(()) => {}
+                    Err(error @ (ScriptExecutionError::StepLimitExceeded
+                    | ScriptExecutionError::WallClockTimeout
+                    | ScriptExecutionError::PerStepTimeout)) => {
+                        pending_error = Some(error);
+                        break;
+                    }
+                    Err(error @ (ScriptExecutionError::ToolError(_)
+                    | ScriptExecutionError::VariableNotFound(_))) => {
+                        self.state.errors_caught += 1;
+
+                        if let Some(name) = error_var {
+                            self.variables
+                                .insert(name.to_string(), Value::String(error.to_string()));
+                        }
+
+                        if let Some(steps) = catch_steps {
+                            for step in steps {
+                                if let Err(catch_error) = self.execute_node(step).await {
+                                    pending_error = Some(catch_error);
+                                    break;
+                                }
+                            }
+                        }
+
+                        break;
+                    }
+                }
+            }
+
+            if let Some(steps) = finally_steps {
+                for step in steps {
+                    self.execute_node(step).await?;
+                }
+            }
+
+            if let Some(error) = pending_error {
+                return Err(error);
+            }
+
+            Ok(())
+        })
+    }
+
+    fn is_truthy(value: &Value) -> bool {
+        match value {
+            Value::Null => false,
+            Value::Bool(boolean) => *boolean,
+            Value::Number(number) => number.as_f64().is_some_and(|value| value != 0.0),
+            Value::String(text) => !text.is_empty(),
+            Value::Array(values) => !values.is_empty(),
+            Value::Object(map) => !map.is_empty(),
+        }
+    }
+
+    fn value_to_i64(value: Value, context: &str) -> Result<i64, ScriptExecutionError> {
+        value.as_i64().ok_or_else(|| {
+            ScriptExecutionError::ToolError(format!("{context} must evaluate to an integer"))
+        })
+    }
+}

--- a/crates/agent/src/script_executor/control_flow.rs
+++ b/crates/agent/src/script_executor/control_flow.rs
@@ -14,18 +14,14 @@ impl ScriptExecutor {
         steps: &'a [ScriptNode],
     ) -> Pin<Box<dyn Future<Output = Result<(), ScriptExecutionError>> + Send + 'a>> {
         Box::pin(async move {
-            let start = Self::value_to_i64(
-                self.evaluate_expression(from).await?,
-                "for loop `from`",
-            )?;
+            let start =
+                Self::value_to_i64(self.evaluate_expression(from).await?, "for loop `from`")?;
             let end = Self::value_to_i64(self.evaluate_expression(to).await?, "for loop `to`")?;
 
             for value in start..end {
                 self.check_limits()?;
-                self.variables.insert(
-                    variable.to_string(),
-                    Value::Number(Number::from(value)),
-                );
+                self.variables
+                    .insert(variable.to_string(), Value::Number(Number::from(value)));
 
                 for step in steps {
                     self.execute_node(step).await?;
@@ -133,14 +129,19 @@ impl ScriptExecutor {
             for step in try_steps {
                 match self.execute_node(step).await {
                     Ok(()) => {}
-                    Err(error @ (ScriptExecutionError::StepLimitExceeded
-                    | ScriptExecutionError::WallClockTimeout
-                    | ScriptExecutionError::PerStepTimeout)) => {
+                    Err(
+                        error @ (ScriptExecutionError::StepLimitExceeded
+                        | ScriptExecutionError::WallClockTimeout
+                        | ScriptExecutionError::PerStepTimeout
+                        | ScriptExecutionError::Cancelled),
+                    ) => {
                         pending_error = Some(error);
                         break;
                     }
-                    Err(error @ (ScriptExecutionError::ToolError(_)
-                    | ScriptExecutionError::VariableNotFound(_))) => {
+                    Err(
+                        error @ (ScriptExecutionError::ToolError(_)
+                        | ScriptExecutionError::VariableNotFound(_)),
+                    ) => {
                         self.state.errors_caught += 1;
 
                         if let Some(name) = error_var {

--- a/crates/agent/src/script_executor/control_flow.rs
+++ b/crates/agent/src/script_executor/control_flow.rs
@@ -188,6 +188,7 @@ impl ScriptExecutor {
         }
     }
 
+    #[allow(clippy::needless_pass_by_value)]
     fn value_to_i64(value: Value, context: &str) -> Result<i64, ScriptExecutionError> {
         value.as_i64().ok_or_else(|| {
             ScriptExecutionError::ToolError(format!("{context} must evaluate to an integer"))

--- a/crates/agent/src/script_executor/data.rs
+++ b/crates/agent/src/script_executor/data.rs
@@ -1,0 +1,141 @@
+//! Data accumulation and variable management for script execution.
+//!
+//! This module documents and provides helper methods for the data model used by the script executor.
+//!
+//! ## Data Model
+//!
+//! The script executor maintains several data structures during execution:
+//!
+//! ### Variables (`HashMap<String, Value>`)
+//! - Stores named values that can be referenced in expressions using `$varname` syntax.
+//! - Populated by:
+//!   - `Assign` nodes: `{ "type": "assign", "variable": "name", "value": {...} }`
+//!   - `ToolCall` output capture: when a tool call has an `output` field, its result is stored as a variable
+//!   - Loop variables: `ForLoop`, `ForEach`, and `TryCatch` bind loop/error variables
+//! - Variable substitution is recursive: arrays and objects are traversed, and any string value
+//!   matching the pattern `$varname` is replaced with the variable's value.
+//! - Undefined variable references cause `VariableNotFound` errors.
+//!
+//! ### Extracted Data (`Vec<Value>`)
+//! - Accumulates values collected via `Collect` nodes.
+//! - Each `Collect` node evaluates an expression and appends the result to this vector.
+//! - Returned in `ScriptResult.extracted_data` when execution completes.
+//! - Represents the primary output of a data-extraction script.
+//!
+//! ### Yielded Data (`Arc<RwLock<Vec<Value>>>`)
+//! - Stores values emitted via `Yield` nodes.
+//! - Wrapped in `Arc<RwLock<>>` to allow concurrent reads during execution (e.g., via `script_status` queries).
+//! - Each `Yield` node:
+//!   1. Evaluates its expression
+//!   2. Appends to both `state.yielded_data` (for the final result) and `self.yielded_data` (for concurrent access)
+//! - Returned in `ScriptResult.yielded_data` when execution completes.
+//! - Useful for streaming results or monitoring progress during long-running scripts.
+//!
+//! ### Tool Output Capture
+//! - When a `ToolCall` node has an `output` field (e.g., `"output": "result"`), the tool's result
+//!   is automatically stored in the variables map under that name.
+//! - The tool result is converted from `ToolEffect::Reply` to a `Value` via JSON deserialization.
+//! - Subsequent expressions can reference this value using `$result` syntax.
+//!
+//! ## Expression Evaluation
+//!
+//! Expressions are evaluated recursively and support:
+//! - **Literal**: JSON values (strings, numbers, objects, arrays)
+//! - **Variable**: `{ "kind": "variable", "name": "varname" }` → looks up `$varname` in the variables map
+//! - **JsEval**: `{ "kind": "js_eval", "script": "..." }` → executes JavaScript in the browser context
+//! - **FieldAccess**: `{ "kind": "field_access", "object": {...}, "field": "key" }` → accesses object properties
+//! - **ArrayIndex**: `{ "kind": "array_index", "array": {...}, "index": {...} }` → accesses array elements by index
+//!
+//! ## Variable Substitution Pattern
+//!
+//! When a string value exactly matches `$varname` (where `varname` is a valid identifier),
+//! it is replaced with the variable's value. This allows tool inputs to reference variables:
+//!
+//! ```json
+//! {
+//!   "type": "tool_call",
+//!   "tool": "navigate",
+//!   "input": { "url": "$base_url" },
+//!   "output": "page_content"
+//! }
+//! ```
+//!
+//! If `base_url` is `"https://example.com"`, the input becomes `{ "url": "https://example.com" }`.
+
+use super::ScriptExecutor;
+use serde_json::Value;
+
+#[allow(dead_code)]
+impl ScriptExecutor {
+    /// Store a variable in the executor's variable map.
+    ///
+    /// # Arguments
+    /// * `name` - The variable name (without the `$` prefix)
+    /// * `value` - The value to store
+    ///
+    /// # Example
+    /// ```ignore
+    /// executor.store_variable("page_title".to_string(), Value::String("Example".to_string()));
+    /// // Later: expressions can reference $page_title
+    /// ```
+    pub(super) fn store_variable(&mut self, name: String, value: Value) {
+        self.variables.insert(name, value);
+    }
+
+    /// Push a value to the extracted data collection.
+    ///
+    /// Called by `Collect` nodes to accumulate extracted values.
+    ///
+    /// # Arguments
+    /// * `value` - The value to append to extracted_data
+    ///
+    /// # Example
+    /// ```ignore
+    /// executor.push_extracted(Value::String("item 1".to_string()));
+    /// executor.push_extracted(Value::String("item 2".to_string()));
+    /// // Later: ScriptResult.extracted_data contains both values
+    /// ```
+    pub(super) fn push_extracted(&mut self, value: Value) {
+        self.extracted_data.push(value);
+        self.state.items_collected = self.extracted_data.len();
+    }
+
+    /// Push a value to the yielded data collection.
+    ///
+    /// Called by `Yield` nodes to emit values for concurrent access.
+    /// Updates both the state's yielded_data and the Arc<RwLock<>> for concurrent reads.
+    ///
+    /// # Arguments
+    /// * `value` - The value to yield
+    ///
+    /// # Errors
+    /// Returns a tool error if the RwLock is poisoned (should not happen in normal operation).
+    ///
+    /// # Example
+    /// ```ignore
+    /// executor.push_yielded(Value::String("progress update".to_string()))?;
+    /// // Value is now available for concurrent reads via script_status
+    /// ```
+    pub(super) fn push_yielded(&mut self, value: Value) -> Result<(), String> {
+        self.state.yielded_data.push(value.clone());
+        let mut yielded_data = self.yielded_data.write().map_err(|error| {
+            format!("yield buffer lock poisoned: {error}")
+        })?;
+        yielded_data.push(value);
+        Ok(())
+    }
+
+    /// Get a reference to the current variables map.
+    ///
+    /// Useful for debugging or inspecting the current variable state.
+    pub(super) fn variables(&self) -> &std::collections::HashMap<String, Value> {
+        &self.variables
+    }
+
+    /// Get a reference to the extracted data collection.
+    ///
+    /// Useful for debugging or inspecting collected values during execution.
+    pub(super) fn extracted_data(&self) -> &[Value] {
+        &self.extracted_data
+    }
+}

--- a/crates/agent/src/script_executor/data.rs
+++ b/crates/agent/src/script_executor/data.rs
@@ -41,10 +41,10 @@
 //!
 //! Expressions are evaluated recursively and support:
 //! - **Literal**: JSON values (strings, numbers, objects, arrays)
-//! - **Variable**: `{ "kind": "variable", "name": "varname" }` → looks up `$varname` in the variables map
-//! - **`JsEval`**: `{ "kind": "js_eval", "script": "..." }` → executes JavaScript in the browser context
-//! - **`FieldAccess`**: `{ "kind": "field_access", "object": {...}, "field": "key" }` → accesses object properties
-//! - **`ArrayIndex`**: `{ "kind": "array_index", "array": {...}, "index": {...} }` → accesses array elements by index
+//! - **Variable**: `{ "kind": "variable", "value": "varname" }` → looks up `$varname` in the variables map
+//! - **`JsEval`**: `{ "kind": "js_eval", "value": "..." }` → executes JavaScript in the browser context
+//! - **`FieldAccess`**: `{ "kind": "field_access", "value": {"object": {...}, "field": "key"} }` → accesses object properties
+//! - **`ArrayIndex`**: `{ "kind": "array_index", "value": {"array": {...}, "index": {...}} }` → accesses array elements by index
 //!
 //! ## Variable Substitution Pattern
 //!
@@ -62,26 +62,10 @@
 //!
 //! If `base_url` is `"https://example.com"`, the input becomes `{ "url": "https://example.com" }`.
 
-use super::ScriptExecutor;
+use super::{ScriptExecutionError, ScriptExecutor};
 use serde_json::Value;
 
-#[allow(dead_code)]
 impl ScriptExecutor {
-    /// Store a variable in the executor's variable map.
-    ///
-    /// # Arguments
-    /// * `name` - The variable name (without the `$` prefix)
-    /// * `value` - The value to store
-    ///
-    /// # Example
-    /// ```ignore
-    /// executor.store_variable("page_title".to_string(), Value::String("Example".to_string()));
-    /// // Later: expressions can reference $page_title
-    /// ```
-    pub(super) fn store_variable(&mut self, name: String, value: Value) {
-        self.variables.insert(name, value);
-    }
-
     /// Push a value to the extracted data collection.
     ///
     /// Called by `Collect` nodes to accumulate extracted values.
@@ -91,13 +75,22 @@ impl ScriptExecutor {
     ///
     /// # Example
     /// ```ignore
-    /// executor.push_extracted(Value::String("item 1".to_string()));
-    /// executor.push_extracted(Value::String("item 2".to_string()));
+    /// executor.push_extracted(Value::String("item 1".to_string()))?;
+    /// executor.push_extracted(Value::String("item 2".to_string()))?;
     /// // Later: ScriptResult.extracted_data contains both values
     /// ```
-    pub(super) fn push_extracted(&mut self, value: Value) {
+    pub(super) fn push_extracted(&mut self, value: Value) -> Result<(), ScriptExecutionError> {
+        let item_bytes = value.to_string().len();
+        if self.output_bytes + item_bytes > self.limits.max_output_bytes {
+            return Err(ScriptExecutionError::ToolError(format!(
+                "output size limit exceeded: {} bytes accumulated, {} bytes new, {} bytes max",
+                self.output_bytes, item_bytes, self.limits.max_output_bytes
+            )));
+        }
+        self.output_bytes += item_bytes;
         self.extracted_data.push(value);
         self.state.items_collected = self.extracted_data.len();
+        Ok(())
     }
 
     /// Push a value to the yielded data collection.
@@ -109,34 +102,27 @@ impl ScriptExecutor {
     /// * `value` - The value to yield
     ///
     /// # Errors
-    /// Returns a tool error if the `RwLock` is poisoned (should not happen in normal operation).
+    /// Returns a tool error if the output limit is exceeded or the `RwLock` is poisoned.
     ///
     /// # Example
     /// ```ignore
     /// executor.push_yielded(Value::String("progress update".to_string()))?;
     /// // Value is now available for concurrent reads via script_status
     /// ```
-    pub(super) fn push_yielded(&mut self, value: Value) -> Result<(), String> {
+    pub(super) fn push_yielded(&mut self, value: Value) -> Result<(), ScriptExecutionError> {
+        let item_bytes = value.to_string().len();
+        if self.output_bytes + item_bytes > self.limits.max_output_bytes {
+            return Err(ScriptExecutionError::ToolError(format!(
+                "output size limit exceeded: {} bytes accumulated, {} bytes new, {} bytes max",
+                self.output_bytes, item_bytes, self.limits.max_output_bytes
+            )));
+        }
+        self.output_bytes += item_bytes;
         self.state.yielded_data.push(value.clone());
-        let mut yielded_data = self
-            .yielded_data
-            .write()
-            .map_err(|error| format!("yield buffer lock poisoned: {error}"))?;
+        let mut yielded_data = self.yielded_data.write().map_err(|error| {
+            ScriptExecutionError::ToolError(format!("yield buffer lock poisoned: {error}"))
+        })?;
         yielded_data.push(value);
         Ok(())
-    }
-
-    /// Get a reference to the current variables map.
-    ///
-    /// Useful for debugging or inspecting the current variable state.
-    pub(super) fn variables(&self) -> &std::collections::HashMap<String, Value> {
-        &self.variables
-    }
-
-    /// Get a reference to the extracted data collection.
-    ///
-    /// Useful for debugging or inspecting collected values during execution.
-    pub(super) fn extracted_data(&self) -> &[Value] {
-        &self.extracted_data
     }
 }

--- a/crates/agent/src/script_executor/data.rs
+++ b/crates/agent/src/script_executor/data.rs
@@ -118,9 +118,10 @@ impl ScriptExecutor {
     /// ```
     pub(super) fn push_yielded(&mut self, value: Value) -> Result<(), String> {
         self.state.yielded_data.push(value.clone());
-        let mut yielded_data = self.yielded_data.write().map_err(|error| {
-            format!("yield buffer lock poisoned: {error}")
-        })?;
+        let mut yielded_data = self
+            .yielded_data
+            .write()
+            .map_err(|error| format!("yield buffer lock poisoned: {error}"))?;
         yielded_data.push(value);
         Ok(())
     }

--- a/crates/agent/src/script_executor/data.rs
+++ b/crates/agent/src/script_executor/data.rs
@@ -42,9 +42,9 @@
 //! Expressions are evaluated recursively and support:
 //! - **Literal**: JSON values (strings, numbers, objects, arrays)
 //! - **Variable**: `{ "kind": "variable", "name": "varname" }` → looks up `$varname` in the variables map
-//! - **JsEval**: `{ "kind": "js_eval", "script": "..." }` → executes JavaScript in the browser context
-//! - **FieldAccess**: `{ "kind": "field_access", "object": {...}, "field": "key" }` → accesses object properties
-//! - **ArrayIndex**: `{ "kind": "array_index", "array": {...}, "index": {...} }` → accesses array elements by index
+//! - **`JsEval`**: `{ "kind": "js_eval", "script": "..." }` → executes JavaScript in the browser context
+//! - **`FieldAccess`**: `{ "kind": "field_access", "object": {...}, "field": "key" }` → accesses object properties
+//! - **`ArrayIndex`**: `{ "kind": "array_index", "array": {...}, "index": {...} }` → accesses array elements by index
 //!
 //! ## Variable Substitution Pattern
 //!
@@ -87,7 +87,7 @@ impl ScriptExecutor {
     /// Called by `Collect` nodes to accumulate extracted values.
     ///
     /// # Arguments
-    /// * `value` - The value to append to extracted_data
+    /// * `value` - The value to append to `extracted_data`
     ///
     /// # Example
     /// ```ignore
@@ -103,13 +103,13 @@ impl ScriptExecutor {
     /// Push a value to the yielded data collection.
     ///
     /// Called by `Yield` nodes to emit values for concurrent access.
-    /// Updates both the state's yielded_data and the Arc<RwLock<>> for concurrent reads.
+    /// Updates both the state's `yielded_data` and the `Arc<RwLock<>>` for concurrent reads.
     ///
     /// # Arguments
     /// * `value` - The value to yield
     ///
     /// # Errors
-    /// Returns a tool error if the RwLock is poisoned (should not happen in normal operation).
+    /// Returns a tool error if the `RwLock` is poisoned (should not happen in normal operation).
     ///
     /// # Example
     /// ```ignore

--- a/crates/agent/src/script_executor/mod.rs
+++ b/crates/agent/src/script_executor/mod.rs
@@ -8,6 +8,9 @@ mod control_flow;
 mod data;
 mod parallel;
 
+#[cfg(test)]
+mod tests;
+
 use acrawl_core::{ScriptLimits, ScriptResult, ScriptState, ScriptStatus};
 use script::grammar::{Expression, ScriptDefinition, ScriptNode, ALLOWED_TOOLS};
 use serde_json::{json, Value};

--- a/crates/agent/src/script_executor/mod.rs
+++ b/crates/agent/src/script_executor/mod.rs
@@ -252,6 +252,7 @@ impl ScriptExecutor {
         Ok(())
     }
 
+    #[must_use]
     pub fn substitute_variables(&self, value: &Value) -> Value {
         self.try_substitute_variables(value)
             .unwrap_or_else(|_| value.clone())
@@ -418,6 +419,7 @@ impl ScriptExecutor {
         }
     }
 
+    #[allow(clippy::needless_pass_by_value)]
     fn map_tool_error(error: ToolExecutionError) -> ScriptExecutionError {
         ScriptExecutionError::ToolError(error.to_string())
     }

--- a/crates/agent/src/script_executor/mod.rs
+++ b/crates/agent/src/script_executor/mod.rs
@@ -1,0 +1,389 @@
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
+
+mod control_flow;
+mod data;
+mod parallel;
+
+use acrawl_core::{ScriptLimits, ScriptResult, ScriptState, ScriptStatus};
+use script::grammar::{Expression, ScriptDefinition, ScriptNode, ALLOWED_TOOLS};
+use serde_json::{json, Value};
+use tokio::time::timeout;
+
+use crate::{BrowserContext, ToolEffect, ToolExecutionError, ToolRegistry};
+
+#[derive(Debug)]
+pub enum ScriptExecutionError {
+    StepLimitExceeded,
+    WallClockTimeout,
+    PerStepTimeout,
+    ToolError(String),
+    VariableNotFound(String),
+}
+
+impl std::fmt::Display for ScriptExecutionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::StepLimitExceeded => write!(f, "script step limit exceeded"),
+            Self::WallClockTimeout => write!(f, "script wall-clock timeout exceeded"),
+            Self::PerStepTimeout => write!(f, "script step timed out"),
+            Self::ToolError(message) => write!(f, "tool error: {message}"),
+            Self::VariableNotFound(name) => write!(f, "variable not found: {name}"),
+        }
+    }
+}
+
+impl std::error::Error for ScriptExecutionError {}
+
+pub struct ScriptExecutor {
+    browser: BrowserContext,
+    state: ScriptState,
+    limits: ScriptLimits,
+    variables: HashMap<String, Value>,
+    extracted_data: Vec<Value>,
+    pub yielded_data: Arc<RwLock<Vec<Value>>>,
+    start_time: Instant,
+    step_counter: Arc<AtomicUsize>,
+}
+
+impl ScriptExecutor {
+    #[must_use]
+    pub fn new(script_id: String, browser: BrowserContext, limits: ScriptLimits) -> Self {
+        Self {
+            browser,
+            state: ScriptState {
+                script_id,
+                status: ScriptStatus::Pending,
+                step: 0,
+                total_steps: None,
+                current_url: None,
+                items_collected: 0,
+                elapsed_secs: 0.0,
+                errors_caught: 0,
+                yielded_data: Vec::new(),
+            },
+            limits,
+            variables: HashMap::new(),
+            extracted_data: Vec::new(),
+            yielded_data: Arc::new(RwLock::new(Vec::new())),
+            start_time: Instant::now(),
+            step_counter: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    pub async fn execute(mut self, script: ScriptDefinition) -> ScriptResult {
+        self.start_time = Instant::now();
+        self.state.status = ScriptStatus::Running;
+        self.state.total_steps = Some(script.steps.len());
+
+        let execution_result = async {
+            for node in &script.steps {
+                self.execute_node(node).await?;
+                self.state.step = self.step_counter.load(Ordering::Relaxed);
+                self.state.elapsed_secs = self.start_time.elapsed().as_secs_f64();
+            }
+            Ok::<(), ScriptExecutionError>(())
+        }
+        .await;
+
+        self.state.step = self.step_counter.load(Ordering::Relaxed);
+        self.state.elapsed_secs = self.start_time.elapsed().as_secs_f64();
+
+        let (status, error) = match execution_result {
+            Ok(()) => (ScriptStatus::Completed, None),
+            Err(error) => (ScriptStatus::Failed, Some(error.to_string())),
+        };
+        self.state.status = status;
+
+        let yielded_data = self
+            .yielded_data
+            .read()
+            .map_or_else(|_| self.state.yielded_data.clone(), |data| data.clone());
+
+        ScriptResult {
+            script_id: self.state.script_id.clone(),
+            status,
+            extracted_data: self.extracted_data,
+            yielded_data,
+            steps_executed: self.state.step,
+            elapsed_secs: self.state.elapsed_secs,
+            error,
+        }
+    }
+
+    async fn execute_node(&mut self, node: &ScriptNode) -> Result<(), ScriptExecutionError> {
+        match node {
+            ScriptNode::ToolCall {
+                tool,
+                input,
+                output,
+            } => {
+                self.state.step = self.step_counter.fetch_add(1, Ordering::Relaxed) + 1;
+                self.check_limits()?;
+                self.execute_tool_call(tool, input, output.as_deref()).await
+            }
+            ScriptNode::Assign { variable, value } => {
+                let resolved = self.evaluate_expression(value).await?;
+                self.variables.insert(variable.clone(), resolved);
+                Ok(())
+            }
+            ScriptNode::Collect { value } => {
+                let resolved = self.evaluate_expression(value).await?;
+                self.extracted_data.push(resolved);
+                self.state.items_collected = self.extracted_data.len();
+                Ok(())
+            }
+            ScriptNode::Yield { value } => {
+                let resolved = self.evaluate_expression(value).await?;
+                self.state.yielded_data.push(resolved.clone());
+                let mut yielded_data = self.yielded_data.write().map_err(|error| {
+                    ScriptExecutionError::ToolError(format!("yield buffer lock poisoned: {error}"))
+                })?;
+                yielded_data.push(resolved);
+                Ok(())
+            }
+            ScriptNode::ForLoop {
+                variable,
+                from,
+                to,
+                steps,
+            } => self.execute_for_loop(variable, from, to, steps).await,
+            ScriptNode::ForEach {
+                variable,
+                iterable,
+                steps,
+            } => self.execute_for_each(variable, iterable, steps).await,
+            ScriptNode::WhileLoop { condition, steps } => {
+                self.execute_while_loop(condition, steps).await
+            }
+            ScriptNode::IfElse {
+                condition,
+                then_steps,
+                else_steps,
+            } => self.execute_if_else(condition, then_steps, else_steps.as_deref()).await,
+            ScriptNode::TryCatch {
+                try_steps,
+                catch_steps,
+                finally_steps,
+                error_var,
+            } => {
+                self.execute_try_catch(
+                    try_steps,
+                    catch_steps.as_deref(),
+                    finally_steps.as_deref(),
+                    error_var.as_deref(),
+                )
+                .await
+            }
+            ScriptNode::Parallel { branches } => self.execute_parallel(branches).await,
+        }
+    }
+
+    async fn execute_tool_call(
+        &mut self,
+        tool: &str,
+        input: &Value,
+        output_var: Option<&str>,
+    ) -> Result<(), ScriptExecutionError> {
+        if !ALLOWED_TOOLS.contains(&tool) {
+            return Err(ScriptExecutionError::ToolError(format!(
+                "tool `{tool}` is not allowed in scripts"
+            )));
+        }
+
+        let registry = ToolRegistry::new_with_core_tools();
+        let resolved_input = self.try_substitute_variables(input)?;
+
+        let tool_effect = if let Some(handler) = registry.get(tool) {
+            match handler(&resolved_input) {
+                Ok(effect) => effect,
+                Err(error) if error.is_requires_async() => {
+                    self.execute_async_tool(&registry, tool, &resolved_input)
+                        .await?
+                }
+                Err(error) => return Err(Self::map_tool_error(error)),
+            }
+        } else {
+            return Err(ScriptExecutionError::ToolError(format!(
+                "unknown tool: `{tool}`"
+            )));
+        };
+
+        let output_value = Self::tool_effect_to_value(tool_effect)?;
+        self.update_current_url(&output_value);
+
+        if let Some(name) = output_var {
+            self.variables.insert(name.to_string(), output_value);
+        }
+
+        Ok(())
+    }
+
+    pub fn substitute_variables(&self, value: &Value) -> Value {
+        self.try_substitute_variables(value)
+            .unwrap_or_else(|_| value.clone())
+    }
+
+    fn check_limits(&self) -> Result<(), ScriptExecutionError> {
+        let steps = self.step_counter.load(Ordering::Relaxed);
+
+        if steps > self.limits.max_steps {
+            return Err(ScriptExecutionError::StepLimitExceeded);
+        }
+
+        if self.start_time.elapsed().as_secs() >= self.limits.max_timeout_secs {
+            return Err(ScriptExecutionError::WallClockTimeout);
+        }
+
+        Ok(())
+    }
+
+    fn evaluate_expression<'a>(
+        &'a mut self,
+        expression: &'a Expression,
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<Value, ScriptExecutionError>> + Send + 'a>> {
+        Box::pin(async move {
+            match expression {
+                Expression::Literal(value) => self.try_substitute_variables(value),
+                Expression::Variable(name) => self
+                    .variables
+                    .get(name)
+                    .cloned()
+                    .ok_or_else(|| ScriptExecutionError::VariableNotFound(name.clone())),
+                Expression::JsEval(script) => {
+                    let output = self.run_execute_js(script).await?;
+                    Ok(output.get("result").cloned().unwrap_or(Value::Null))
+                }
+                Expression::FieldAccess { object, field } => {
+                    let value = self.evaluate_expression(object).await?;
+                    Ok(value.get(field).cloned().unwrap_or(Value::Null))
+                }
+                Expression::ArrayIndex { array, index } => {
+                    let array_value = self.evaluate_expression(array).await?;
+                    let index_value = self.evaluate_expression(index).await?;
+                    let index = index_value
+                        .as_u64()
+                        .and_then(|value| usize::try_from(value).ok())
+                        .ok_or_else(|| {
+                            ScriptExecutionError::ToolError(
+                                "array index must evaluate to a non-negative integer".to_string(),
+                            )
+                        })?;
+
+                    match array_value {
+                        Value::Array(values) => {
+                            Ok(values.get(index).cloned().unwrap_or(Value::Null))
+                        }
+                        _ => Err(ScriptExecutionError::ToolError(
+                            "array index target did not evaluate to an array".to_string(),
+                        )),
+                    }
+                }
+            }
+        })
+    }
+
+    async fn run_execute_js(&mut self, script: &str) -> Result<Value, ScriptExecutionError> {
+        self.execute_async_tool(
+            &ToolRegistry::new_with_core_tools(),
+            "execute_js",
+            &json!({
+                "script": script,
+            }),
+        )
+        .await
+        .and_then(Self::tool_effect_to_value)
+    }
+
+    async fn execute_async_tool(
+        &mut self,
+        registry: &ToolRegistry,
+        tool: &str,
+        input: &Value,
+    ) -> Result<ToolEffect, ScriptExecutionError> {
+        timeout(
+            Duration::from_secs(self.limits.per_step_timeout_secs),
+            registry.execute_async(tool, input, &mut self.browser),
+        )
+        .await
+        .map_err(|_| ScriptExecutionError::PerStepTimeout)?
+        .map_err(Self::map_tool_error)
+    }
+
+    fn try_substitute_variables(&self, value: &Value) -> Result<Value, ScriptExecutionError> {
+        match value {
+            Value::String(text) => {
+                if let Some(variable_name) = Self::variable_name(text) {
+                    self.variables.get(variable_name).cloned().ok_or_else(|| {
+                        ScriptExecutionError::VariableNotFound(variable_name.to_string())
+                    })
+                } else {
+                    Ok(Value::String(text.clone()))
+                }
+            }
+            Value::Array(values) => values
+                .iter()
+                .map(|value| self.try_substitute_variables(value))
+                .collect::<Result<Vec<_>, _>>()
+                .map(Value::Array),
+            Value::Object(map) => map
+                .iter()
+                .map(|(key, value)| Ok((key.clone(), self.try_substitute_variables(value)?)))
+                .collect::<Result<serde_json::Map<String, Value>, ScriptExecutionError>>()
+                .map(Value::Object),
+            _ => Ok(value.clone()),
+        }
+    }
+
+    fn variable_name(value: &str) -> Option<&str> {
+        let candidate = value.strip_prefix('$')?;
+        if candidate.is_empty() {
+            return None;
+        }
+
+        let mut chars = candidate.chars();
+        let first = chars.next()?;
+        if !(first == '_' || first.is_ascii_alphabetic()) {
+            return None;
+        }
+
+        if chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric()) {
+            Some(candidate)
+        } else {
+            None
+        }
+    }
+
+    fn tool_effect_to_value(tool_effect: ToolEffect) -> Result<Value, ScriptExecutionError> {
+        match tool_effect {
+            ToolEffect::Reply(reply) => {
+                Ok(serde_json::from_str(&reply).unwrap_or(Value::String(reply)))
+            }
+            effect => Err(ScriptExecutionError::ToolError(format!(
+                "script executor does not support tool effect: {effect:?}"
+            ))),
+        }
+    }
+
+    fn update_current_url(&mut self, output: &Value) {
+        if let Some(url) = output.get("url").and_then(Value::as_str) {
+            self.state.current_url = Some(url.to_string());
+            return;
+        }
+
+        if let Some(url) = output
+            .get("page_state")
+            .and_then(|page_state| page_state.get("url"))
+            .and_then(Value::as_str)
+        {
+            self.state.current_url = Some(url.to_string());
+        }
+    }
+
+    fn map_tool_error(error: ToolExecutionError) -> ScriptExecutionError {
+        ScriptExecutionError::ToolError(error.to_string())
+    }
+}

--- a/crates/agent/src/script_executor/mod.rs
+++ b/crates/agent/src/script_executor/mod.rs
@@ -12,6 +12,7 @@ use acrawl_core::{ScriptLimits, ScriptResult, ScriptState, ScriptStatus};
 use script::grammar::{Expression, ScriptDefinition, ScriptNode, ALLOWED_TOOLS};
 use serde_json::{json, Value};
 use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
 
 use crate::{BrowserContext, ToolEffect, ToolExecutionError, ToolRegistry};
 
@@ -20,6 +21,7 @@ pub enum ScriptExecutionError {
     StepLimitExceeded,
     WallClockTimeout,
     PerStepTimeout,
+    Cancelled,
     ToolError(String),
     VariableNotFound(String),
 }
@@ -30,6 +32,7 @@ impl std::fmt::Display for ScriptExecutionError {
             Self::StepLimitExceeded => write!(f, "script step limit exceeded"),
             Self::WallClockTimeout => write!(f, "script wall-clock timeout exceeded"),
             Self::PerStepTimeout => write!(f, "script step timed out"),
+            Self::Cancelled => write!(f, "script cancelled"),
             Self::ToolError(message) => write!(f, "tool error: {message}"),
             Self::VariableNotFound(name) => write!(f, "variable not found: {name}"),
         }
@@ -41,17 +44,25 @@ impl std::error::Error for ScriptExecutionError {}
 pub struct ScriptExecutor {
     browser: BrowserContext,
     state: ScriptState,
+    shared_state: Arc<RwLock<ScriptState>>,
     limits: ScriptLimits,
     variables: HashMap<String, Value>,
     extracted_data: Vec<Value>,
     pub yielded_data: Arc<RwLock<Vec<Value>>>,
     start_time: Instant,
     step_counter: Arc<AtomicUsize>,
+    cancel_token: CancellationToken,
 }
 
 impl ScriptExecutor {
     #[must_use]
-    pub fn new(script_id: String, browser: BrowserContext, limits: ScriptLimits) -> Self {
+    pub fn new(
+        script_id: String,
+        browser: BrowserContext,
+        limits: ScriptLimits,
+        shared_state: Arc<RwLock<ScriptState>>,
+        cancel_token: CancellationToken,
+    ) -> Self {
         Self {
             browser,
             state: ScriptState {
@@ -65,12 +76,14 @@ impl ScriptExecutor {
                 errors_caught: 0,
                 yielded_data: Vec::new(),
             },
+            shared_state,
             limits,
             variables: HashMap::new(),
             extracted_data: Vec::new(),
             yielded_data: Arc::new(RwLock::new(Vec::new())),
             start_time: Instant::now(),
             step_counter: Arc::new(AtomicUsize::new(0)),
+            cancel_token,
         }
     }
 
@@ -78,12 +91,15 @@ impl ScriptExecutor {
         self.start_time = Instant::now();
         self.state.status = ScriptStatus::Running;
         self.state.total_steps = Some(script.steps.len());
+        self.sync_shared_state();
 
         let execution_result = async {
             for node in &script.steps {
+                self.check_limits()?;
                 self.execute_node(node).await?;
                 self.state.step = self.step_counter.load(Ordering::Relaxed);
                 self.state.elapsed_secs = self.start_time.elapsed().as_secs_f64();
+                self.sync_shared_state();
             }
             Ok::<(), ScriptExecutionError>(())
         }
@@ -94,9 +110,11 @@ impl ScriptExecutor {
 
         let (status, error) = match execution_result {
             Ok(()) => (ScriptStatus::Completed, None),
+            Err(ScriptExecutionError::Cancelled) => (ScriptStatus::Cancelled, None),
             Err(error) => (ScriptStatus::Failed, Some(error.to_string())),
         };
         self.state.status = status;
+        self.sync_shared_state();
 
         let yielded_data = self
             .yielded_data
@@ -123,17 +141,21 @@ impl ScriptExecutor {
             } => {
                 self.state.step = self.step_counter.fetch_add(1, Ordering::Relaxed) + 1;
                 self.check_limits()?;
-                self.execute_tool_call(tool, input, output.as_deref()).await
+                let result = self.execute_tool_call(tool, input, output.as_deref()).await;
+                self.sync_shared_state();
+                result
             }
             ScriptNode::Assign { variable, value } => {
                 let resolved = self.evaluate_expression(value).await?;
                 self.variables.insert(variable.clone(), resolved);
+                self.sync_shared_state();
                 Ok(())
             }
             ScriptNode::Collect { value } => {
                 let resolved = self.evaluate_expression(value).await?;
                 self.extracted_data.push(resolved);
                 self.state.items_collected = self.extracted_data.len();
+                self.sync_shared_state();
                 Ok(())
             }
             ScriptNode::Yield { value } => {
@@ -143,6 +165,8 @@ impl ScriptExecutor {
                     ScriptExecutionError::ToolError(format!("yield buffer lock poisoned: {error}"))
                 })?;
                 yielded_data.push(resolved);
+                drop(yielded_data);
+                self.sync_shared_state();
                 Ok(())
             }
             ScriptNode::ForLoop {
@@ -163,7 +187,10 @@ impl ScriptExecutor {
                 condition,
                 then_steps,
                 else_steps,
-            } => self.execute_if_else(condition, then_steps, else_steps.as_deref()).await,
+            } => {
+                self.execute_if_else(condition, then_steps, else_steps.as_deref())
+                    .await
+            }
             ScriptNode::TryCatch {
                 try_steps,
                 catch_steps,
@@ -228,6 +255,10 @@ impl ScriptExecutor {
     }
 
     fn check_limits(&self) -> Result<(), ScriptExecutionError> {
+        if self.cancel_token.is_cancelled() {
+            return Err(ScriptExecutionError::Cancelled);
+        }
+
         let steps = self.step_counter.load(Ordering::Relaxed);
 
         if steps > self.limits.max_steps {
@@ -244,7 +275,8 @@ impl ScriptExecutor {
     fn evaluate_expression<'a>(
         &'a mut self,
         expression: &'a Expression,
-    ) -> std::pin::Pin<Box<dyn Future<Output = Result<Value, ScriptExecutionError>> + Send + 'a>> {
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<Value, ScriptExecutionError>> + Send + 'a>>
+    {
         Box::pin(async move {
             match expression {
                 Expression::Literal(value) => self.try_substitute_variables(value),
@@ -385,5 +417,11 @@ impl ScriptExecutor {
 
     fn map_tool_error(error: ToolExecutionError) -> ScriptExecutionError {
         ScriptExecutionError::ToolError(error.to_string())
+    }
+
+    fn sync_shared_state(&self) {
+        if let Ok(mut state) = self.shared_state.write() {
+            *state = self.state.clone();
+        }
     }
 }

--- a/crates/agent/src/script_executor/mod.rs
+++ b/crates/agent/src/script_executor/mod.rs
@@ -49,6 +49,7 @@ pub struct ScriptExecutor {
     state: ScriptState,
     shared_state: Arc<RwLock<ScriptState>>,
     limits: ScriptLimits,
+    output_bytes: usize,
     variables: HashMap<String, Value>,
     extracted_data: Vec<Value>,
     pub yielded_data: Arc<RwLock<Vec<Value>>>,
@@ -81,6 +82,7 @@ impl ScriptExecutor {
             },
             shared_state,
             limits,
+            output_bytes: 0,
             variables: HashMap::new(),
             extracted_data: Vec::new(),
             yielded_data: Arc::new(RwLock::new(Vec::new())),
@@ -156,19 +158,13 @@ impl ScriptExecutor {
             }
             ScriptNode::Collect { value } => {
                 let resolved = self.evaluate_expression(value).await?;
-                self.extracted_data.push(resolved);
-                self.state.items_collected = self.extracted_data.len();
+                self.push_extracted(resolved)?;
                 self.sync_shared_state();
                 Ok(())
             }
             ScriptNode::Yield { value } => {
                 let resolved = self.evaluate_expression(value).await?;
-                self.state.yielded_data.push(resolved.clone());
-                let mut yielded_data = self.yielded_data.write().map_err(|error| {
-                    ScriptExecutionError::ToolError(format!("yield buffer lock poisoned: {error}"))
-                })?;
-                yielded_data.push(resolved);
-                drop(yielded_data);
+                self.push_yielded(resolved)?;
                 self.sync_shared_state();
                 Ok(())
             }

--- a/crates/agent/src/script_executor/parallel.rs
+++ b/crates/agent/src/script_executor/parallel.rs
@@ -1,0 +1,150 @@
+use std::sync::atomic::Ordering;
+use std::{future::Future, pin::Pin};
+
+use script::grammar::ScriptNode;
+use serde_json::Value;
+use tokio::task::JoinSet;
+
+use super::{ScriptExecutionError, ScriptExecutor};
+use crate::BrowserContext;
+
+struct ParallelBranchResult {
+    index: usize,
+    extracted_data: Vec<Value>,
+}
+
+impl ScriptExecutor {
+    pub(super) fn execute_parallel<'a>(
+        &'a mut self,
+        branches: &'a [Vec<ScriptNode>],
+    ) -> Pin<Box<dyn Future<Output = Result<(), ScriptExecutionError>> + Send + 'a>> {
+        Box::pin(async move {
+            if branches.len() > self.limits.max_parallel_branches {
+                return Err(ScriptExecutionError::ToolError(format!(
+                    "parallel branch count {} exceeds limit {}",
+                    branches.len(),
+                    self.limits.max_parallel_branches
+                )));
+            }
+
+            if branches.is_empty() {
+                return Ok(());
+            }
+
+            let shared_bridge = self.browser.bridge().clone();
+            let current_url = self.state.current_url.clone();
+            let mut page_indices = Vec::with_capacity(branches.len());
+            let mut join_set = JoinSet::new();
+
+            for (index, branch) in branches.iter().enumerate() {
+                let page_index = {
+                    let mut bridge = shared_bridge.lock().await;
+                    bridge
+                        .new_page(current_url.as_deref())
+                        .await
+                        .map_err(|error| ScriptExecutionError::ToolError(error.to_string()))?
+                };
+                page_indices.push(page_index);
+
+                let mut browser = BrowserContext::new_shared(shared_bridge.clone(), page_index);
+                if let Some(url) = current_url.as_deref() {
+                    browser.set_navigated_url(url, true);
+                }
+
+                let branch_executor = Self {
+                    browser,
+                    state: self.state.clone(),
+                    limits: self.limits.clone(),
+                    variables: self.variables.clone(),
+                    extracted_data: Vec::new(),
+                    yielded_data: self.yielded_data.clone(),
+                    start_time: self.start_time,
+                    step_counter: self.step_counter.clone(),
+                };
+                let branch_steps = branch.clone();
+
+                join_set.spawn(async move {
+                    Self::run_parallel_branch(branch_executor, index, branch_steps).await
+                });
+            }
+
+            let mut branch_results = vec![None; branches.len()];
+            let mut first_error = None;
+
+            while let Some(result) = join_set.join_next().await {
+                match result {
+                    Ok(Ok(branch_result)) => {
+                        branch_results[branch_result.index] = Some(branch_result.extracted_data);
+                    }
+                    Ok(Err(error)) => {
+                        if first_error.is_none() {
+                            first_error = Some(error);
+                            join_set.abort_all();
+                        }
+                    }
+                    Err(error) => {
+                        if first_error.is_none() {
+                            first_error = Some(ScriptExecutionError::ToolError(format!(
+                                "parallel branch task failed: {error}"
+                            )));
+                            join_set.abort_all();
+                        }
+                    }
+                }
+            }
+
+            let cleanup_error = Self::close_parallel_pages(shared_bridge, &page_indices).await.err();
+            self.state.step = self.step_counter.load(Ordering::Relaxed);
+
+            if let Some(error) = first_error.or(cleanup_error) {
+                return Err(error);
+            }
+
+            for extracted_data in branch_results.into_iter().flatten() {
+                self.extracted_data.extend(extracted_data);
+            }
+            self.state.items_collected = self.extracted_data.len();
+
+            Ok(())
+        })
+    }
+
+    async fn run_parallel_branch(
+        mut executor: ScriptExecutor,
+        index: usize,
+        branch_steps: Vec<ScriptNode>,
+    ) -> Result<ParallelBranchResult, ScriptExecutionError> {
+        for step in &branch_steps {
+            executor.execute_node(step).await?;
+            executor.state.step = executor.step_counter.load(Ordering::Relaxed);
+            executor.state.elapsed_secs = executor.start_time.elapsed().as_secs_f64();
+        }
+
+        Ok(ParallelBranchResult {
+            index,
+            extracted_data: executor.extracted_data,
+        })
+    }
+
+    async fn close_parallel_pages(
+        shared_bridge: crate::SharedBridge,
+        page_indices: &[usize],
+    ) -> Result<(), ScriptExecutionError> {
+        let mut cleanup_errors = Vec::new();
+
+        for &page_index in page_indices {
+            if let Err(error) = shared_bridge.lock().await.close_page(page_index).await {
+                cleanup_errors.push(format!("page {page_index}: {error}"));
+            }
+        }
+
+        if cleanup_errors.is_empty() {
+            Ok(())
+        } else {
+            Err(ScriptExecutionError::ToolError(format!(
+                "failed to close parallel pages: {}",
+                cleanup_errors.join(", ")
+            )))
+        }
+    }
+}

--- a/crates/agent/src/script_executor/parallel.rs
+++ b/crates/agent/src/script_executor/parallel.rs
@@ -54,12 +54,14 @@ impl ScriptExecutor {
                 let branch_executor = Self {
                     browser,
                     state: self.state.clone(),
+                    shared_state: self.shared_state.clone(),
                     limits: self.limits.clone(),
                     variables: self.variables.clone(),
                     extracted_data: Vec::new(),
                     yielded_data: self.yielded_data.clone(),
                     start_time: self.start_time,
                     step_counter: self.step_counter.clone(),
+                    cancel_token: self.cancel_token.clone(),
                 };
                 let branch_steps = branch.clone();
 
@@ -93,7 +95,9 @@ impl ScriptExecutor {
                 }
             }
 
-            let cleanup_error = Self::close_parallel_pages(shared_bridge, &page_indices).await.err();
+            let cleanup_error = Self::close_parallel_pages(shared_bridge, &page_indices)
+                .await
+                .err();
             self.state.step = self.step_counter.load(Ordering::Relaxed);
 
             if let Some(error) = first_error.or(cleanup_error) {
@@ -115,9 +119,11 @@ impl ScriptExecutor {
         branch_steps: Vec<ScriptNode>,
     ) -> Result<ParallelBranchResult, ScriptExecutionError> {
         for step in &branch_steps {
+            executor.check_limits()?;
             executor.execute_node(step).await?;
             executor.state.step = executor.step_counter.load(Ordering::Relaxed);
             executor.state.elapsed_secs = executor.start_time.elapsed().as_secs_f64();
+            executor.sync_shared_state();
         }
 
         Ok(ParallelBranchResult {

--- a/crates/agent/src/script_executor/parallel.rs
+++ b/crates/agent/src/script_executor/parallel.rs
@@ -8,9 +8,12 @@ use tokio::task::JoinSet;
 use super::{ScriptExecutionError, ScriptExecutor};
 use crate::BrowserContext;
 
+#[derive(Clone)]
 struct ParallelBranchResult {
     index: usize,
     extracted_data: Vec<Value>,
+    errors_caught: usize,
+    output_bytes: usize,
 }
 
 impl ScriptExecutor {
@@ -56,6 +59,7 @@ impl ScriptExecutor {
                     state: self.state.clone(),
                     shared_state: self.shared_state.clone(),
                     limits: self.limits.clone(),
+                    output_bytes: self.output_bytes,
                     variables: self.variables.clone(),
                     extracted_data: Vec::new(),
                     yielded_data: self.yielded_data.clone(),
@@ -70,13 +74,14 @@ impl ScriptExecutor {
                 });
             }
 
-            let mut branch_results = vec![None; branches.len()];
+            let mut branch_results: Vec<Option<ParallelBranchResult>> = vec![None; branches.len()];
             let mut first_error = None;
 
             while let Some(result) = join_set.join_next().await {
                 match result {
                     Ok(Ok(branch_result)) => {
-                        branch_results[branch_result.index] = Some(branch_result.extracted_data);
+                        let index = branch_result.index;
+                        branch_results[index] = Some(branch_result);
                     }
                     Ok(Err(error)) => {
                         if first_error.is_none() {
@@ -104,8 +109,10 @@ impl ScriptExecutor {
                 return Err(error);
             }
 
-            for extracted_data in branch_results.into_iter().flatten() {
-                self.extracted_data.extend(extracted_data);
+            for result in branch_results.into_iter().flatten() {
+                self.extracted_data.extend(result.extracted_data);
+                self.state.errors_caught += result.errors_caught;
+                self.output_bytes += result.output_bytes;
             }
             self.state.items_collected = self.extracted_data.len();
 
@@ -129,6 +136,8 @@ impl ScriptExecutor {
         Ok(ParallelBranchResult {
             index,
             extracted_data: executor.extracted_data,
+            errors_caught: executor.state.errors_caught,
+            output_bytes: executor.output_bytes,
         })
     }
 

--- a/crates/agent/src/script_executor/tests.rs
+++ b/crates/agent/src/script_executor/tests.rs
@@ -1127,3 +1127,58 @@ async fn shared_state_reflects_progress() {
     assert_eq!(state.status, ScriptStatus::Completed);
     assert_eq!(state.items_collected, 2);
 }
+
+#[tokio::test]
+async fn collect_over_output_byte_limit_fails() {
+    let tiny_limits = ScriptLimits {
+        max_output_bytes: 10,
+        ..default_limits()
+    };
+    let bridge = make_shared_bridge(MockBridge::new());
+    let executor = make_executor(bridge, tiny_limits);
+
+    let result = executor
+        .execute(script(vec![ScriptNode::Collect {
+            value: literal(json!("hello world")),
+        }]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Failed);
+    assert!(
+        result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("output size limit exceeded"),
+        "expected 'output size limit exceeded' in: {:?}",
+        result.error
+    );
+    assert_eq!(result.extracted_data.len(), 0);
+}
+
+#[tokio::test]
+async fn yield_over_output_byte_limit_fails() {
+    let tiny_limits = ScriptLimits {
+        max_output_bytes: 5,
+        ..default_limits()
+    };
+    let bridge = make_shared_bridge(MockBridge::new());
+    let executor = make_executor(bridge, tiny_limits);
+
+    let result = executor
+        .execute(script(vec![ScriptNode::Yield {
+            value: literal(json!("too long")),
+        }]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Failed);
+    assert!(
+        result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("output size limit exceeded"),
+        "expected 'output size limit exceeded' in: {:?}",
+        result.error
+    );
+}

--- a/crates/agent/src/script_executor/tests.rs
+++ b/crates/agent/src/script_executor/tests.rs
@@ -3,7 +3,10 @@ use std::sync::{Arc, Mutex, RwLock};
 
 use acrawl_core::{ScriptLimits, ScriptState, ScriptStatus};
 use async_trait::async_trait;
-use browser::{BridgeError, BrowserBackend, BrowserContext, BrowserState, PageInfo, ScreenshotOptions, SharedBridge};
+use browser::{
+    BridgeError, BrowserBackend, BrowserContext, BrowserState, PageInfo, ScreenshotOptions,
+    SharedBridge,
+};
 use script::grammar::{Expression, ScriptDefinition, ScriptNode};
 use serde_json::{json, Value};
 use tokio_util::sync::CancellationToken;
@@ -47,7 +50,10 @@ impl MockBridge {
     }
 
     fn log(&self, method: &str, args: Value) {
-        self.call_log.lock().unwrap().push((method.to_string(), args));
+        self.call_log
+            .lock()
+            .unwrap()
+            .push((method.to_string(), args));
     }
 
     fn call_log(&self) -> Arc<Mutex<Vec<(String, Value)>>> {
@@ -123,12 +129,18 @@ impl BrowserBackend for MockBridge {
         timeout_ms: u64,
         state: Option<&str>,
     ) -> Result<bool, BridgeError> {
-        self.log("wait_for_selector", json!({"selector": selector, "timeout_ms": timeout_ms, "state": state}));
+        self.log(
+            "wait_for_selector",
+            json!({"selector": selector, "timeout_ms": timeout_ms, "state": state}),
+        );
         Ok(true)
     }
 
     async fn select_option(&mut self, selector: &str, value: &str) -> Result<(), BridgeError> {
-        self.log("select_option", json!({"selector": selector, "value": value}));
+        self.log(
+            "select_option",
+            json!({"selector": selector, "value": value}),
+        );
         Ok(())
     }
 
@@ -216,8 +228,6 @@ impl BrowserBackend for MockBridge {
         Ok("https://mock.test/previous".to_string())
     }
 }
-
-
 
 fn default_limits() -> ScriptLimits {
     ScriptLimits {
@@ -356,8 +366,7 @@ async fn sequential_three_tool_calls() {
 
 #[tokio::test]
 async fn variable_assignment_and_usage() {
-    let mock = MockBridge::new()
-        .with_evaluate_responses(vec![json!({"value": "hello world"})]);
+    let mock = MockBridge::new().with_evaluate_responses(vec![json!({"value": "hello world"})]);
     let bridge = make_shared_bridge(mock);
     let executor = make_executor(bridge, default_limits());
 
@@ -377,8 +386,7 @@ async fn variable_assignment_and_usage() {
 
 #[tokio::test]
 async fn tool_call_output_captured_as_variable() {
-    let mock = MockBridge::new()
-        .with_evaluate_responses(vec![json!({"value": "page title"})]);
+    let mock = MockBridge::new().with_evaluate_responses(vec![json!({"value": "page title"})]);
     let bridge = make_shared_bridge(mock);
     let executor = make_executor(bridge, default_limits());
 
@@ -572,25 +580,20 @@ async fn while_loop_exits_on_false_condition() {
 
 #[tokio::test]
 async fn while_loop_step_limit_terminates() {
-    let mock = MockBridge::new()
-        .with_evaluate_responses(vec![
-            json!({"value": true}),
-            json!({"value": true}),
-            json!({"value": true}),
-            json!({"value": true}),
-            json!({"value": true}),
-        ]);
+    let mock = MockBridge::new().with_evaluate_responses(vec![
+        json!({"value": true}),
+        json!({"value": true}),
+        json!({"value": true}),
+        json!({"value": true}),
+        json!({"value": true}),
+    ]);
     let bridge = make_shared_bridge(mock);
     let executor = make_executor(bridge, low_step_limits(3));
 
     let result = executor
         .execute(script(vec![ScriptNode::WhileLoop {
             condition: literal(json!(true)),
-            steps: vec![tool_call(
-                "execute_js",
-                json!({"script": "1+1"}),
-                None,
-            )],
+            steps: vec![tool_call("execute_js", json!({"script": "1+1"}), None)],
         }]))
         .await;
 
@@ -702,12 +705,11 @@ async fn try_catch_finally_always_runs() {
 
 #[tokio::test]
 async fn try_catch_step_limit_not_catchable() {
-    let mock = MockBridge::new()
-        .with_evaluate_responses(vec![
-            json!({"value": true}),
-            json!({"value": true}),
-            json!({"value": true}),
-        ]);
+    let mock = MockBridge::new().with_evaluate_responses(vec![
+        json!({"value": true}),
+        json!({"value": true}),
+        json!({"value": true}),
+    ]);
     let bridge = make_shared_bridge(mock);
     let executor = make_executor(bridge, low_step_limits(2));
 
@@ -783,23 +785,18 @@ async fn parallel_max_branches_enforced() {
         .await;
 
     assert_eq!(result.status, ScriptStatus::Failed);
-    assert!(result
-        .error
-        .as_ref()
-        .unwrap()
-        .contains("exceeds limit"));
+    assert!(result.error.as_ref().unwrap().contains("exceeds limit"));
 }
 
 #[tokio::test]
 async fn step_limit_stops_execution() {
-    let mock = MockBridge::new()
-        .with_evaluate_responses(vec![
-            json!({"value": 1}),
-            json!({"value": 2}),
-            json!({"value": 3}),
-            json!({"value": 4}),
-            json!({"value": 5}),
-        ]);
+    let mock = MockBridge::new().with_evaluate_responses(vec![
+        json!({"value": 1}),
+        json!({"value": 2}),
+        json!({"value": 3}),
+        json!({"value": 4}),
+        json!({"value": 5}),
+    ]);
     let bridge = make_shared_bridge(mock);
     let executor = make_executor(bridge, low_step_limits(2));
 
@@ -818,8 +815,7 @@ async fn step_limit_stops_execution() {
 
 #[tokio::test]
 async fn variable_substitution_in_tool_input() {
-    let mock = MockBridge::new()
-        .with_evaluate_responses(vec![json!({"value": "executed"})]);
+    let mock = MockBridge::new().with_evaluate_responses(vec![json!({"value": "executed"})]);
     let log = mock.call_log();
     let bridge = make_shared_bridge(mock);
     let executor = make_executor(bridge, default_limits());
@@ -897,11 +893,8 @@ async fn disallowed_tool_returns_error() {
 
 #[tokio::test]
 async fn cancellation_stops_execution() {
-    let mock = MockBridge::new()
-        .with_evaluate_responses(vec![
-            json!({"value": 1}),
-            json!({"value": 2}),
-        ]);
+    let mock =
+        MockBridge::new().with_evaluate_responses(vec![json!({"value": 1}), json!({"value": 2})]);
     let bridge = make_shared_bridge(mock);
     let (executor, cancel_token) = make_executor_with_cancel(bridge, default_limits());
 
@@ -939,8 +932,7 @@ async fn variable_not_found_error() {
 
 #[tokio::test]
 async fn js_eval_expression() {
-    let mock = MockBridge::new()
-        .with_evaluate_responses(vec![json!({"value": 42, "result": 42})]);
+    let mock = MockBridge::new().with_evaluate_responses(vec![json!({"value": 42, "result": 42})]);
     let bridge = make_shared_bridge(mock);
     let executor = make_executor(bridge, default_limits());
 
@@ -1077,11 +1069,7 @@ async fn try_catch_binds_error_var() {
 
     let result = executor
         .execute(script(vec![ScriptNode::TryCatch {
-            try_steps: vec![tool_call(
-                "click",
-                json!({"selector": "#btn"}),
-                None,
-            )],
+            try_steps: vec![tool_call("click", json!({"selector": "#btn"}), None)],
             catch_steps: Some(vec![ScriptNode::Collect {
                 value: variable("err_msg"),
             }]),

--- a/crates/agent/src/script_executor/tests.rs
+++ b/crates/agent/src/script_executor/tests.rs
@@ -1,0 +1,1141 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
+
+use acrawl_core::{ScriptLimits, ScriptState, ScriptStatus};
+use async_trait::async_trait;
+use browser::{BridgeError, BrowserBackend, BrowserContext, BrowserState, PageInfo, ScreenshotOptions, SharedBridge};
+use script::grammar::{Expression, ScriptDefinition, ScriptNode};
+use serde_json::{json, Value};
+use tokio_util::sync::CancellationToken;
+
+use super::ScriptExecutor;
+
+#[derive(Debug)]
+struct MockBridge {
+    call_log: Arc<Mutex<Vec<(String, Value)>>>,
+    next_page_index: AtomicUsize,
+    evaluate_responses: Mutex<Vec<Value>>,
+    navigate_responses: Mutex<Vec<PageInfo>>,
+    click_error: Mutex<Option<String>>,
+}
+
+#[allow(dead_code)]
+impl MockBridge {
+    fn new() -> Self {
+        Self {
+            call_log: Arc::new(Mutex::new(Vec::new())),
+            next_page_index: AtomicUsize::new(1),
+            evaluate_responses: Mutex::new(Vec::new()),
+            navigate_responses: Mutex::new(Vec::new()),
+            click_error: Mutex::new(None),
+        }
+    }
+
+    fn with_evaluate_responses(mut self, responses: Vec<Value>) -> Self {
+        self.evaluate_responses = Mutex::new(responses);
+        self
+    }
+
+    fn with_navigate_responses(mut self, responses: Vec<PageInfo>) -> Self {
+        self.navigate_responses = Mutex::new(responses);
+        self
+    }
+
+    fn with_click_error(mut self, error: &str) -> Self {
+        self.click_error = Mutex::new(Some(error.to_string()));
+        self
+    }
+
+    fn log(&self, method: &str, args: Value) {
+        self.call_log.lock().unwrap().push((method.to_string(), args));
+    }
+
+    fn call_log(&self) -> Arc<Mutex<Vec<(String, Value)>>> {
+        self.call_log.clone()
+    }
+
+    fn default_page_map() -> Value {
+        json!({
+            "headings": [],
+            "landmarks": [],
+            "links": [],
+            "interactive": {"counts": {"buttons": 0, "inputs": 0, "selects": 0, "textareas": 0, "total": 0}, "elements": []},
+            "meta": {"title": "Mock Page", "url": "https://mock.test", "description": ""},
+            "truncated_links": false,
+            "truncated_forms": false,
+            "truncated_landmarks": false
+        })
+    }
+}
+
+#[async_trait]
+impl BrowserBackend for MockBridge {
+    async fn navigate(&mut self, url: &str) -> Result<PageInfo, BridgeError> {
+        self.log("navigate", json!({"url": url}));
+        let mut responses = self.navigate_responses.lock().unwrap();
+        if responses.is_empty() {
+            Ok(PageInfo {
+                title: "Mock Page".to_string(),
+                html: format!(
+                    "<html><head><title>Mock Page</title></head><body><h1>Content for {url}</h1></body></html>"
+                ),
+            })
+        } else {
+            Ok(responses.remove(0))
+        }
+    }
+
+    async fn new_page(&mut self, url: Option<&str>) -> Result<usize, BridgeError> {
+        let index = self.next_page_index.fetch_add(1, Ordering::Relaxed);
+        self.log("new_page", json!({"url": url, "index": index}));
+        Ok(index)
+    }
+
+    async fn close_page(&mut self, page_index: usize) -> Result<(), BridgeError> {
+        self.log("close_page", json!({"page_index": page_index}));
+        Ok(())
+    }
+
+    async fn scroll(&mut self, direction: &str, pixels: i64) -> Result<(), BridgeError> {
+        self.log("scroll", json!({"direction": direction, "pixels": pixels}));
+        Ok(())
+    }
+
+    async fn page_map(&mut self, scope: Option<&str>) -> Result<Value, BridgeError> {
+        self.log("page_map", json!({"scope": scope}));
+        Ok(Self::default_page_map())
+    }
+
+    async fn read_content(
+        &mut self,
+        heading: Option<&str>,
+        selector: Option<&str>,
+        offset: usize,
+        max_chars: usize,
+    ) -> Result<Value, BridgeError> {
+        self.log("read_content", json!({"heading": heading, "selector": selector, "offset": offset, "max_chars": max_chars}));
+        Ok(json!({"content": "mock content", "total_chars": 12}))
+    }
+
+    async fn wait_for_selector(
+        &mut self,
+        selector: &str,
+        timeout_ms: u64,
+        state: Option<&str>,
+    ) -> Result<bool, BridgeError> {
+        self.log("wait_for_selector", json!({"selector": selector, "timeout_ms": timeout_ms, "state": state}));
+        Ok(true)
+    }
+
+    async fn select_option(&mut self, selector: &str, value: &str) -> Result<(), BridgeError> {
+        self.log("select_option", json!({"selector": selector, "value": value}));
+        Ok(())
+    }
+
+    async fn evaluate(&mut self, script: &str) -> Result<Value, BridgeError> {
+        self.log("evaluate", json!({"script": script}));
+        let mut responses = self.evaluate_responses.lock().unwrap();
+        if responses.is_empty() {
+            Ok(json!({"value": null}))
+        } else {
+            Ok(responses.remove(0))
+        }
+    }
+
+    async fn hover(&mut self, selector: &str) -> Result<(), BridgeError> {
+        self.log("hover", json!({"selector": selector}));
+        Ok(())
+    }
+
+    async fn press_key(&mut self, key: &str, selector: Option<&str>) -> Result<(), BridgeError> {
+        self.log("press_key", json!({"key": key, "selector": selector}));
+        Ok(())
+    }
+
+    async fn switch_tab(&mut self, index: i64) -> Result<Value, BridgeError> {
+        self.log("switch_tab", json!({"index": index}));
+        Ok(json!({"url": "https://mock.test", "title": "Mock Page"}))
+    }
+
+    async fn export_cookies(&mut self) -> Result<BrowserState, BridgeError> {
+        Err(BridgeError::Protocol("not supported in mock".into()))
+    }
+
+    async fn import_cookies(&mut self, _state: &BrowserState) -> Result<(), BridgeError> {
+        Err(BridgeError::Protocol("not supported in mock".into()))
+    }
+
+    async fn import_cookies_only(&mut self, _state: &BrowserState) -> Result<(), BridgeError> {
+        Err(BridgeError::Protocol("not supported in mock".into()))
+    }
+
+    async fn import_local_storage(&mut self, _state: &BrowserState) -> Result<(), BridgeError> {
+        Err(BridgeError::Protocol("not supported in mock".into()))
+    }
+
+    async fn list_resources(&mut self) -> Result<Value, BridgeError> {
+        self.log("list_resources", json!({}));
+        Ok(json!({"links": [], "images": [], "forms": []}))
+    }
+
+    async fn save_file(&mut self, url: &str, path: &str) -> Result<String, BridgeError> {
+        self.log("save_file", json!({"url": url, "path": path}));
+        Ok(path.to_string())
+    }
+
+    async fn click(&mut self, selector: &str) -> Result<(), BridgeError> {
+        self.log("click", json!({"selector": selector}));
+        let error = self.click_error.lock().unwrap();
+        if let Some(msg) = error.as_ref() {
+            Err(BridgeError::Protocol(msg.clone()))
+        } else {
+            Ok(())
+        }
+    }
+
+    async fn click_at(&mut self, x: f64, y: f64) -> Result<(), BridgeError> {
+        self.log("click_at", json!({"x": x, "y": y}));
+        Ok(())
+    }
+
+    async fn fill(&mut self, selector: &str, value: &str) -> Result<(), BridgeError> {
+        self.log("fill", json!({"selector": selector, "value": value}));
+        Ok(())
+    }
+
+    async fn screenshot(
+        &mut self,
+        _options: &ScreenshotOptions<'_>,
+    ) -> Result<(String, usize), BridgeError> {
+        self.log("screenshot", json!({}));
+        Ok(("base64data".to_string(), 10))
+    }
+
+    async fn go_back(&mut self) -> Result<String, BridgeError> {
+        self.log("go_back", json!({}));
+        Ok("https://mock.test/previous".to_string())
+    }
+}
+
+
+
+fn default_limits() -> ScriptLimits {
+    ScriptLimits {
+        max_steps: 100,
+        max_timeout_secs: 300,
+        max_output_bytes: 1_048_576,
+        max_script_size_bytes: 1_048_576,
+        max_parallel_branches: 4,
+        max_nesting_depth: 10,
+        per_step_timeout_secs: 30,
+    }
+}
+
+fn low_step_limits(max_steps: usize) -> ScriptLimits {
+    ScriptLimits {
+        max_steps,
+        max_timeout_secs: 300,
+        max_output_bytes: 1_048_576,
+        max_script_size_bytes: 1_048_576,
+        max_parallel_branches: 4,
+        max_nesting_depth: 10,
+        per_step_timeout_secs: 30,
+    }
+}
+
+fn make_shared_bridge(mock: MockBridge) -> SharedBridge {
+    Arc::new(tokio::sync::Mutex::new(
+        Box::new(mock) as Box<dyn BrowserBackend + Send>
+    ))
+}
+
+fn make_executor(bridge: SharedBridge, limits: ScriptLimits) -> ScriptExecutor {
+    let shared_state = Arc::new(RwLock::new(ScriptState {
+        script_id: "test_script".to_string(),
+        status: ScriptStatus::Pending,
+        step: 0,
+        total_steps: None,
+        current_url: None,
+        items_collected: 0,
+        elapsed_secs: 0.0,
+        errors_caught: 0,
+        yielded_data: Vec::new(),
+    }));
+    let browser = BrowserContext::new(bridge);
+    let cancel_token = CancellationToken::new();
+
+    ScriptExecutor::new(
+        "test_script".to_string(),
+        browser,
+        limits,
+        shared_state,
+        cancel_token,
+    )
+}
+
+fn make_executor_with_cancel(
+    bridge: SharedBridge,
+    limits: ScriptLimits,
+) -> (ScriptExecutor, CancellationToken) {
+    let shared_state = Arc::new(RwLock::new(ScriptState {
+        script_id: "test_script".to_string(),
+        status: ScriptStatus::Pending,
+        step: 0,
+        total_steps: None,
+        current_url: None,
+        items_collected: 0,
+        elapsed_secs: 0.0,
+        errors_caught: 0,
+        yielded_data: Vec::new(),
+    }));
+    let browser = BrowserContext::new(bridge);
+    let cancel_token = CancellationToken::new();
+    let token_clone = cancel_token.clone();
+
+    let executor = ScriptExecutor::new(
+        "test_script".to_string(),
+        browser,
+        limits,
+        shared_state,
+        cancel_token,
+    );
+    (executor, token_clone)
+}
+
+fn script(steps: Vec<ScriptNode>) -> ScriptDefinition {
+    ScriptDefinition {
+        schema_version: 1,
+        name: Some("test".to_string()),
+        steps,
+    }
+}
+
+fn literal(value: Value) -> Expression {
+    Expression::Literal(value)
+}
+
+fn variable(name: &str) -> Expression {
+    Expression::Variable(name.to_string())
+}
+
+fn js_eval(code: &str) -> Expression {
+    Expression::JsEval(code.to_string())
+}
+
+fn tool_call(tool: &str, input: Value, output: Option<&str>) -> ScriptNode {
+    ScriptNode::ToolCall {
+        tool: tool.to_string(),
+        input,
+        output: output.map(String::from),
+    }
+}
+
+#[tokio::test]
+async fn sequential_three_tool_calls() {
+    let mock = MockBridge::new();
+    let log = mock.call_log();
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, default_limits());
+
+    let result = executor
+        .execute(script(vec![
+            tool_call("scroll", json!({"direction": "down", "pixels": 300}), None),
+            tool_call("scroll", json!({"direction": "down", "pixels": 500}), None),
+            tool_call("scroll", json!({"direction": "up", "pixels": 200}), None),
+        ]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Completed);
+    assert_eq!(result.steps_executed, 3);
+    assert!(result.error.is_none());
+
+    let calls = log.lock().unwrap();
+    let scroll_calls: Vec<_> = calls.iter().filter(|(m, _)| m == "scroll").collect();
+    assert_eq!(scroll_calls.len(), 3);
+}
+
+#[tokio::test]
+async fn variable_assignment_and_usage() {
+    let mock = MockBridge::new()
+        .with_evaluate_responses(vec![json!({"value": "hello world"})]);
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, default_limits());
+
+    let result = executor
+        .execute(script(vec![
+            ScriptNode::Assign {
+                variable: "greeting".to_string(),
+                value: literal(json!("hello")),
+            },
+            tool_call("execute_js", json!({"script": "$greeting"}), None),
+        ]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Completed);
+    assert!(result.error.is_none());
+}
+
+#[tokio::test]
+async fn tool_call_output_captured_as_variable() {
+    let mock = MockBridge::new()
+        .with_evaluate_responses(vec![json!({"value": "page title"})]);
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, default_limits());
+
+    let result = executor
+        .execute(script(vec![
+            tool_call(
+                "execute_js",
+                json!({"script": "document.title"}),
+                Some("title"),
+            ),
+            ScriptNode::Collect {
+                value: variable("title"),
+            },
+        ]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Completed);
+    assert_eq!(result.extracted_data.len(), 1);
+    let collected = &result.extracted_data[0];
+    assert!(collected.get("success").is_some() || collected.get("result").is_some());
+}
+
+#[tokio::test]
+async fn collect_accumulates_extracted_data() {
+    let mock = MockBridge::new();
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, default_limits());
+
+    let result = executor
+        .execute(script(vec![
+            ScriptNode::Collect {
+                value: literal(json!({"item": "first"})),
+            },
+            ScriptNode::Collect {
+                value: literal(json!({"item": "second"})),
+            },
+            ScriptNode::Collect {
+                value: literal(json!({"item": "third"})),
+            },
+        ]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Completed);
+    assert_eq!(result.extracted_data.len(), 3);
+    assert_eq!(result.extracted_data[0], json!({"item": "first"}));
+    assert_eq!(result.extracted_data[1], json!({"item": "second"}));
+    assert_eq!(result.extracted_data[2], json!({"item": "third"}));
+}
+
+#[tokio::test]
+async fn yield_appends_to_yielded_data() {
+    let mock = MockBridge::new();
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, default_limits());
+    let yielded = executor.yielded_data.clone();
+
+    let result = executor
+        .execute(script(vec![
+            ScriptNode::Yield {
+                value: literal(json!("row_1")),
+            },
+            ScriptNode::Yield {
+                value: literal(json!("row_2")),
+            },
+        ]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Completed);
+    assert_eq!(result.yielded_data.len(), 2);
+    assert_eq!(result.yielded_data[0], json!("row_1"));
+    assert_eq!(result.yielded_data[1], json!("row_2"));
+
+    let live = yielded.read().unwrap();
+    assert_eq!(live.len(), 2);
+}
+
+#[tokio::test]
+async fn for_loop_correct_iterations() {
+    let mock = MockBridge::new();
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, default_limits());
+
+    let result = executor
+        .execute(script(vec![ScriptNode::ForLoop {
+            variable: "i".to_string(),
+            from: literal(json!(0)),
+            to: literal(json!(5)),
+            steps: vec![ScriptNode::Collect {
+                value: variable("i"),
+            }],
+        }]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Completed);
+    assert_eq!(result.extracted_data.len(), 5);
+    for (idx, item) in result.extracted_data.iter().enumerate() {
+        assert_eq!(*item, json!(idx));
+    }
+}
+
+#[tokio::test]
+async fn for_each_iterates_array() {
+    let mock = MockBridge::new();
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, default_limits());
+
+    let result = executor
+        .execute(script(vec![
+            ScriptNode::Assign {
+                variable: "items".to_string(),
+                value: literal(json!(["apple", "banana", "cherry"])),
+            },
+            ScriptNode::ForEach {
+                variable: "fruit".to_string(),
+                iterable: variable("items"),
+                steps: vec![ScriptNode::Collect {
+                    value: variable("fruit"),
+                }],
+            },
+        ]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Completed);
+    assert_eq!(result.extracted_data.len(), 3);
+    assert_eq!(result.extracted_data[0], json!("apple"));
+    assert_eq!(result.extracted_data[1], json!("banana"));
+    assert_eq!(result.extracted_data[2], json!("cherry"));
+}
+
+#[tokio::test]
+async fn for_each_iterates_object() {
+    let mock = MockBridge::new();
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, default_limits());
+
+    let result = executor
+        .execute(script(vec![
+            ScriptNode::Assign {
+                variable: "data".to_string(),
+                value: literal(json!({"a": 1, "b": 2})),
+            },
+            ScriptNode::ForEach {
+                variable: "entry".to_string(),
+                iterable: variable("data"),
+                steps: vec![ScriptNode::Collect {
+                    value: variable("entry"),
+                }],
+            },
+        ]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Completed);
+    assert_eq!(result.extracted_data.len(), 2);
+    for item in &result.extracted_data {
+        assert!(item.get("key").is_some());
+        assert!(item.get("value").is_some());
+    }
+}
+
+#[tokio::test]
+async fn while_loop_exits_on_false_condition() {
+    let mock = MockBridge::new();
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, default_limits());
+
+    // Given counter=3 (truthy), loop body collects then sets counter=0 (falsy) → one iteration
+    let result = executor
+        .execute(script(vec![
+            ScriptNode::Assign {
+                variable: "counter".to_string(),
+                value: literal(json!(3)),
+            },
+            ScriptNode::WhileLoop {
+                condition: variable("counter"),
+                steps: vec![
+                    ScriptNode::Collect {
+                        value: variable("counter"),
+                    },
+                    ScriptNode::Assign {
+                        variable: "counter".to_string(),
+                        value: literal(json!(0)),
+                    },
+                ],
+            },
+        ]))
+        .await;
+
+    assert_eq!(result.extracted_data.len(), 1);
+    assert_eq!(result.extracted_data[0], json!(3));
+}
+
+#[tokio::test]
+async fn while_loop_step_limit_terminates() {
+    let mock = MockBridge::new()
+        .with_evaluate_responses(vec![
+            json!({"value": true}),
+            json!({"value": true}),
+            json!({"value": true}),
+            json!({"value": true}),
+            json!({"value": true}),
+        ]);
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, low_step_limits(3));
+
+    let result = executor
+        .execute(script(vec![ScriptNode::WhileLoop {
+            condition: literal(json!(true)),
+            steps: vec![tool_call(
+                "execute_js",
+                json!({"script": "1+1"}),
+                None,
+            )],
+        }]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Failed);
+    assert!(result.error.as_ref().unwrap().contains("step limit"));
+}
+
+#[tokio::test]
+async fn if_else_then_branch() {
+    let mock = MockBridge::new();
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, default_limits());
+
+    let result = executor
+        .execute(script(vec![ScriptNode::IfElse {
+            condition: literal(json!(true)),
+            then_steps: vec![ScriptNode::Collect {
+                value: literal(json!("then_executed")),
+            }],
+            else_steps: Some(vec![ScriptNode::Collect {
+                value: literal(json!("else_executed")),
+            }]),
+        }]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Completed);
+    assert_eq!(result.extracted_data.len(), 1);
+    assert_eq!(result.extracted_data[0], json!("then_executed"));
+}
+
+#[tokio::test]
+async fn if_else_else_branch() {
+    let mock = MockBridge::new();
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, default_limits());
+
+    let result = executor
+        .execute(script(vec![ScriptNode::IfElse {
+            condition: literal(json!(false)),
+            then_steps: vec![ScriptNode::Collect {
+                value: literal(json!("then_executed")),
+            }],
+            else_steps: Some(vec![ScriptNode::Collect {
+                value: literal(json!("else_executed")),
+            }]),
+        }]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Completed);
+    assert_eq!(result.extracted_data.len(), 1);
+    assert_eq!(result.extracted_data[0], json!("else_executed"));
+}
+
+#[tokio::test]
+async fn try_catch_catches_tool_error() {
+    let mock = MockBridge::new().with_click_error("element not found");
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, default_limits());
+
+    let result = executor
+        .execute(script(vec![ScriptNode::TryCatch {
+            try_steps: vec![tool_call(
+                "click",
+                json!({"selector": "#nonexistent"}),
+                None,
+            )],
+            catch_steps: Some(vec![ScriptNode::Collect {
+                value: literal(json!("error_caught")),
+            }]),
+            finally_steps: Some(vec![ScriptNode::Collect {
+                value: literal(json!("finally_ran")),
+            }]),
+            error_var: Some("err".to_string()),
+        }]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Completed);
+    assert_eq!(result.extracted_data.len(), 2);
+    assert_eq!(result.extracted_data[0], json!("error_caught"));
+    assert_eq!(result.extracted_data[1], json!("finally_ran"));
+}
+
+#[tokio::test]
+async fn try_catch_finally_always_runs() {
+    let mock = MockBridge::new();
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, default_limits());
+
+    let result = executor
+        .execute(script(vec![ScriptNode::TryCatch {
+            try_steps: vec![ScriptNode::Collect {
+                value: literal(json!("try_ok")),
+            }],
+            catch_steps: Some(vec![ScriptNode::Collect {
+                value: literal(json!("catch_ran")),
+            }]),
+            finally_steps: Some(vec![ScriptNode::Collect {
+                value: literal(json!("finally_ran")),
+            }]),
+            error_var: None,
+        }]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Completed);
+    assert_eq!(result.extracted_data.len(), 2);
+    assert_eq!(result.extracted_data[0], json!("try_ok"));
+    assert_eq!(result.extracted_data[1], json!("finally_ran"));
+}
+
+#[tokio::test]
+async fn try_catch_step_limit_not_catchable() {
+    let mock = MockBridge::new()
+        .with_evaluate_responses(vec![
+            json!({"value": true}),
+            json!({"value": true}),
+            json!({"value": true}),
+        ]);
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, low_step_limits(2));
+
+    let result = executor
+        .execute(script(vec![ScriptNode::TryCatch {
+            try_steps: vec![
+                tool_call("execute_js", json!({"script": "1"}), None),
+                tool_call("execute_js", json!({"script": "2"}), None),
+                tool_call("execute_js", json!({"script": "3"}), None),
+            ],
+            catch_steps: Some(vec![ScriptNode::Collect {
+                value: literal(json!("should_not_catch")),
+            }]),
+            finally_steps: None,
+            error_var: None,
+        }]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Failed);
+    assert!(result.error.as_ref().unwrap().contains("step limit"));
+    assert!(result.extracted_data.is_empty());
+}
+
+#[tokio::test]
+async fn parallel_two_branches() {
+    let mock = MockBridge::new();
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, default_limits());
+
+    let result = executor
+        .execute(script(vec![ScriptNode::Parallel {
+            branches: vec![
+                vec![ScriptNode::Collect {
+                    value: literal(json!("branch_a")),
+                }],
+                vec![ScriptNode::Collect {
+                    value: literal(json!("branch_b")),
+                }],
+            ],
+        }]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Completed);
+    assert_eq!(result.extracted_data.len(), 2);
+    assert_eq!(result.extracted_data[0], json!("branch_a"));
+    assert_eq!(result.extracted_data[1], json!("branch_b"));
+}
+
+#[tokio::test]
+async fn parallel_max_branches_enforced() {
+    let mock = MockBridge::new();
+    let bridge = make_shared_bridge(mock);
+    let limits = ScriptLimits {
+        max_parallel_branches: 2,
+        ..default_limits()
+    };
+    let executor = make_executor(bridge, limits);
+
+    let result = executor
+        .execute(script(vec![ScriptNode::Parallel {
+            branches: vec![
+                vec![ScriptNode::Collect {
+                    value: literal(json!("a")),
+                }],
+                vec![ScriptNode::Collect {
+                    value: literal(json!("b")),
+                }],
+                vec![ScriptNode::Collect {
+                    value: literal(json!("c")),
+                }],
+            ],
+        }]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Failed);
+    assert!(result
+        .error
+        .as_ref()
+        .unwrap()
+        .contains("exceeds limit"));
+}
+
+#[tokio::test]
+async fn step_limit_stops_execution() {
+    let mock = MockBridge::new()
+        .with_evaluate_responses(vec![
+            json!({"value": 1}),
+            json!({"value": 2}),
+            json!({"value": 3}),
+            json!({"value": 4}),
+            json!({"value": 5}),
+        ]);
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, low_step_limits(2));
+
+    let result = executor
+        .execute(script(vec![
+            tool_call("execute_js", json!({"script": "1"}), None),
+            tool_call("execute_js", json!({"script": "2"}), None),
+            tool_call("execute_js", json!({"script": "3"}), None),
+        ]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Failed);
+    assert!(result.error.as_ref().unwrap().contains("step limit"));
+    assert!(result.steps_executed <= 3);
+}
+
+#[tokio::test]
+async fn variable_substitution_in_tool_input() {
+    let mock = MockBridge::new()
+        .with_evaluate_responses(vec![json!({"value": "executed"})]);
+    let log = mock.call_log();
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, default_limits());
+
+    let result = executor
+        .execute(script(vec![
+            ScriptNode::Assign {
+                variable: "my_script".to_string(),
+                value: literal(json!("document.title")),
+            },
+            tool_call("execute_js", json!({"script": "$my_script"}), None),
+        ]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Completed);
+
+    let calls = log.lock().unwrap();
+    let eval_calls: Vec<_> = calls.iter().filter(|(m, _)| m == "evaluate").collect();
+    assert_eq!(eval_calls.len(), 1);
+    assert_eq!(eval_calls[0].1["script"], "document.title");
+}
+
+#[tokio::test]
+async fn nested_for_loop_inside_for_each() {
+    let mock = MockBridge::new();
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, default_limits());
+
+    let result = executor
+        .execute(script(vec![
+            ScriptNode::Assign {
+                variable: "pages".to_string(),
+                value: literal(json!(["page1", "page2"])),
+            },
+            ScriptNode::ForEach {
+                variable: "page".to_string(),
+                iterable: variable("pages"),
+                steps: vec![ScriptNode::ForLoop {
+                    variable: "i".to_string(),
+                    from: literal(json!(0)),
+                    to: literal(json!(2)),
+                    steps: vec![ScriptNode::Collect {
+                        value: variable("page"),
+                    }],
+                }],
+            },
+        ]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Completed);
+    assert_eq!(result.extracted_data.len(), 4);
+    assert_eq!(result.extracted_data[0], json!("page1"));
+    assert_eq!(result.extracted_data[1], json!("page1"));
+    assert_eq!(result.extracted_data[2], json!("page2"));
+    assert_eq!(result.extracted_data[3], json!("page2"));
+}
+
+#[tokio::test]
+async fn disallowed_tool_returns_error() {
+    let mock = MockBridge::new();
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, default_limits());
+
+    let result = executor
+        .execute(script(vec![tool_call(
+            "fork",
+            json!({"goal": "hack the planet"}),
+            None,
+        )]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Failed);
+    assert!(result.error.as_ref().unwrap().contains("not allowed"));
+}
+
+#[tokio::test]
+async fn cancellation_stops_execution() {
+    let mock = MockBridge::new()
+        .with_evaluate_responses(vec![
+            json!({"value": 1}),
+            json!({"value": 2}),
+        ]);
+    let bridge = make_shared_bridge(mock);
+    let (executor, cancel_token) = make_executor_with_cancel(bridge, default_limits());
+
+    cancel_token.cancel();
+
+    let result = executor
+        .execute(script(vec![
+            tool_call("execute_js", json!({"script": "1"}), None),
+            tool_call("execute_js", json!({"script": "2"}), None),
+        ]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Cancelled);
+}
+
+#[tokio::test]
+async fn variable_not_found_error() {
+    let mock = MockBridge::new();
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, default_limits());
+
+    let result = executor
+        .execute(script(vec![ScriptNode::Collect {
+            value: variable("undefined_var"),
+        }]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Failed);
+    assert!(result
+        .error
+        .as_ref()
+        .unwrap()
+        .contains("variable not found"));
+}
+
+#[tokio::test]
+async fn js_eval_expression() {
+    let mock = MockBridge::new()
+        .with_evaluate_responses(vec![json!({"value": 42, "result": 42})]);
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, default_limits());
+
+    let result = executor
+        .execute(script(vec![ScriptNode::Collect {
+            value: js_eval("2 + 2"),
+        }]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Completed);
+    assert_eq!(result.extracted_data.len(), 1);
+    assert_eq!(result.extracted_data[0], json!(42));
+}
+
+#[tokio::test]
+async fn field_access_expression() {
+    let mock = MockBridge::new();
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, default_limits());
+
+    let result = executor
+        .execute(script(vec![
+            ScriptNode::Assign {
+                variable: "obj".to_string(),
+                value: literal(json!({"name": "acrawl", "version": "1.0"})),
+            },
+            ScriptNode::Collect {
+                value: Expression::FieldAccess {
+                    object: Box::new(variable("obj")),
+                    field: "name".to_string(),
+                },
+            },
+        ]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Completed);
+    assert_eq!(result.extracted_data[0], json!("acrawl"));
+}
+
+#[tokio::test]
+async fn if_else_null_is_falsy() {
+    let mock = MockBridge::new();
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, default_limits());
+
+    let result = executor
+        .execute(script(vec![
+            ScriptNode::Assign {
+                variable: "val".to_string(),
+                value: literal(Value::Null),
+            },
+            ScriptNode::IfElse {
+                condition: variable("val"),
+                then_steps: vec![ScriptNode::Collect {
+                    value: literal(json!("truthy")),
+                }],
+                else_steps: Some(vec![ScriptNode::Collect {
+                    value: literal(json!("falsy")),
+                }]),
+            },
+        ]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Completed);
+    assert_eq!(result.extracted_data[0], json!("falsy"));
+}
+
+#[tokio::test]
+async fn if_else_empty_string_is_falsy() {
+    let mock = MockBridge::new();
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, default_limits());
+
+    let result = executor
+        .execute(script(vec![ScriptNode::IfElse {
+            condition: literal(json!("")),
+            then_steps: vec![ScriptNode::Collect {
+                value: literal(json!("truthy")),
+            }],
+            else_steps: Some(vec![ScriptNode::Collect {
+                value: literal(json!("falsy")),
+            }]),
+        }]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Completed);
+    assert_eq!(result.extracted_data[0], json!("falsy"));
+}
+
+#[tokio::test]
+async fn if_else_nonempty_array_is_truthy() {
+    let mock = MockBridge::new();
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, default_limits());
+
+    let result = executor
+        .execute(script(vec![ScriptNode::IfElse {
+            condition: literal(json!([1, 2, 3])),
+            then_steps: vec![ScriptNode::Collect {
+                value: literal(json!("truthy")),
+            }],
+            else_steps: Some(vec![ScriptNode::Collect {
+                value: literal(json!("falsy")),
+            }]),
+        }]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Completed);
+    assert_eq!(result.extracted_data[0], json!("truthy"));
+}
+
+#[tokio::test]
+async fn completed_script_reports_elapsed_time() {
+    let mock = MockBridge::new();
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, default_limits());
+
+    let result = executor
+        .execute(script(vec![ScriptNode::Collect {
+            value: literal(json!("done")),
+        }]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Completed);
+    assert!(result.elapsed_secs >= 0.0);
+    assert_eq!(result.script_id, "test_script");
+}
+
+#[tokio::test]
+async fn try_catch_binds_error_var() {
+    let mock = MockBridge::new().with_click_error("click failed: timeout");
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, default_limits());
+
+    let result = executor
+        .execute(script(vec![ScriptNode::TryCatch {
+            try_steps: vec![tool_call(
+                "click",
+                json!({"selector": "#btn"}),
+                None,
+            )],
+            catch_steps: Some(vec![ScriptNode::Collect {
+                value: variable("err_msg"),
+            }]),
+            finally_steps: None,
+            error_var: Some("err_msg".to_string()),
+        }]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Completed);
+    assert_eq!(result.extracted_data.len(), 1);
+    let err_str = result.extracted_data[0].as_str().unwrap();
+    assert!(err_str.contains("click failed"), "got: {err_str}");
+}
+
+#[tokio::test]
+async fn shared_state_reflects_progress() {
+    let mock = MockBridge::new();
+    let bridge = make_shared_bridge(mock);
+    let shared_state = Arc::new(RwLock::new(ScriptState {
+        script_id: "progress_test".to_string(),
+        status: ScriptStatus::Pending,
+        step: 0,
+        total_steps: None,
+        current_url: None,
+        items_collected: 0,
+        elapsed_secs: 0.0,
+        errors_caught: 0,
+        yielded_data: Vec::new(),
+    }));
+    let browser = BrowserContext::new(bridge);
+    let cancel_token = CancellationToken::new();
+
+    let executor = ScriptExecutor::new(
+        "progress_test".to_string(),
+        browser,
+        default_limits(),
+        shared_state.clone(),
+        cancel_token,
+    );
+
+    let result = executor
+        .execute(script(vec![
+            ScriptNode::Collect {
+                value: literal(json!("a")),
+            },
+            ScriptNode::Collect {
+                value: literal(json!("b")),
+            },
+        ]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Completed);
+
+    let state = shared_state.read().unwrap();
+    assert_eq!(state.status, ScriptStatus::Completed);
+    assert_eq!(state.items_collected, 2);
+}

--- a/crates/agent/src/script_manager.rs
+++ b/crates/agent/src/script_manager.rs
@@ -1,0 +1,275 @@
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, RwLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use acrawl_core::{ScriptLimits, ScriptResult, ScriptState, ScriptStatus, ScriptTask};
+use runtime::settings::ScriptSettings;
+use script::parser::{parse_script, validate_script};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::script_executor::ScriptExecutor;
+use crate::BrowserContext;
+
+#[derive(Debug)]
+pub struct RunningScript {
+    pub script_id: String,
+    pub state: Arc<RwLock<ScriptState>>,
+    pub handle: JoinHandle<ScriptResult>,
+    pub cancel_token: CancellationToken,
+}
+
+#[derive(Debug)]
+pub struct ScriptManager {
+    pub scripts: HashMap<String, RunningScript>,
+    pub settings: ScriptSettings,
+    pub max_concurrent: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScriptError {
+    NotFound(String),
+    ConcurrentLimitExceeded,
+    ParseError(String),
+    Other(String),
+}
+
+impl std::fmt::Display for ScriptError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound(script_id) => write!(f, "script `{script_id}` not found"),
+            Self::ConcurrentLimitExceeded => write!(f, "script concurrent limit exceeded"),
+            Self::ParseError(message) => write!(f, "script parse/validation failed: {message}"),
+            Self::Other(message) => f.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for ScriptError {}
+
+impl ScriptManager {
+    #[must_use]
+    pub fn new(settings: ScriptSettings) -> Self {
+        let max_concurrent = settings
+            .max_concurrent_scripts
+            .or_else(|| ScriptSettings::default().max_concurrent_scripts)
+            .unwrap_or(5);
+
+        Self {
+            scripts: HashMap::new(),
+            settings,
+            max_concurrent,
+        }
+    }
+
+    pub fn spawn_script(
+        &mut self,
+        task: ScriptTask,
+        browser: BrowserContext,
+    ) -> Result<String, ScriptError> {
+        self.cleanup_completed();
+        self.check_can_spawn()?;
+
+        let script_id = self.generate_script_id();
+        let limits = self.effective_limits(&task.limits);
+        let script_definition = parse_script(&task.script)
+            .map_err(|error| ScriptError::ParseError(error.to_string()))?;
+        validate_script(&script_definition, &limits).map_err(|errors| {
+            let message = errors
+                .into_iter()
+                .map(|error| error.to_string())
+                .collect::<Vec<_>>()
+                .join("; ");
+            ScriptError::ParseError(message)
+        })?;
+
+        let initial_state = ScriptState {
+            script_id: script_id.clone(),
+            status: ScriptStatus::Pending,
+            step: 0,
+            total_steps: None,
+            current_url: None,
+            items_collected: 0,
+            elapsed_secs: 0.0,
+            errors_caught: 0,
+            yielded_data: Vec::new(),
+        };
+        let state = Arc::new(RwLock::new(initial_state));
+        let cancel_token = CancellationToken::new();
+        let executor = ScriptExecutor::new(
+            script_id.clone(),
+            browser,
+            limits,
+            state.clone(),
+            cancel_token.clone(),
+        );
+        let handle = tokio::task::spawn(executor.execute(script_definition));
+
+        self.scripts.insert(
+            script_id.clone(),
+            RunningScript {
+                script_id: script_id.clone(),
+                state,
+                handle,
+                cancel_token,
+            },
+        );
+
+        Ok(script_id)
+    }
+
+    pub fn get_status(&self, script_id: &str) -> Result<ScriptState, ScriptError> {
+        let running_script = self
+            .scripts
+            .get(script_id)
+            .ok_or_else(|| ScriptError::NotFound(script_id.to_string()))?;
+
+        running_script
+            .state
+            .read()
+            .map(|state| state.clone())
+            .map_err(|error| ScriptError::Other(format!("script state lock poisoned: {error}")))
+    }
+
+    pub async fn wait_for_scripts(
+        &mut self,
+        script_ids: Option<Vec<String>>,
+    ) -> Result<Vec<ScriptResult>, ScriptError> {
+        let target_ids = script_ids.unwrap_or_else(|| self.scripts.keys().cloned().collect());
+        let mut running = Vec::with_capacity(target_ids.len());
+
+        for script_id in target_ids {
+            let running_script = self
+                .scripts
+                .remove(&script_id)
+                .ok_or_else(|| ScriptError::NotFound(script_id.clone()))?;
+            running.push(running_script);
+        }
+
+        let mut results = Vec::with_capacity(running.len());
+        for running_script in running {
+            let result = running_script.handle.await.map_err(|error| {
+                ScriptError::Other(format!(
+                    "script `{}` task join failed: {error}",
+                    running_script.script_id
+                ))
+            })?;
+            results.push(result);
+        }
+
+        self.cleanup_completed();
+        Ok(results)
+    }
+
+    pub fn cancel_script(&self, script_id: &str) -> Result<(), ScriptError> {
+        let running_script = self
+            .scripts
+            .get(script_id)
+            .ok_or_else(|| ScriptError::NotFound(script_id.to_string()))?;
+
+        running_script.cancel_token.cancel();
+
+        running_script
+            .state
+            .write()
+            .map(|mut state| {
+                state.status = ScriptStatus::Cancelled;
+            })
+            .map_err(|error| ScriptError::Other(format!("script state lock poisoned: {error}")))
+    }
+
+    pub fn check_can_spawn(&self) -> Result<(), ScriptError> {
+        let active_scripts = self
+            .scripts
+            .values()
+            .filter(|running_script| !running_script.handle.is_finished())
+            .count();
+
+        if active_scripts >= self.max_concurrent {
+            return Err(ScriptError::ConcurrentLimitExceeded);
+        }
+
+        Ok(())
+    }
+
+    pub fn cleanup_completed(&mut self) {
+        self.scripts
+            .retain(|_, running_script| !running_script.handle.is_finished());
+    }
+
+    fn generate_script_id(&self) -> String {
+        for attempt in 0_u32..1024 {
+            let now_nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos();
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            now_nanos.hash(&mut hasher);
+            self.scripts.len().hash(&mut hasher);
+            attempt.hash(&mut hasher);
+            let candidate = format!("scr_{:08x}", (hasher.finish() as u32));
+
+            if !self.scripts.contains_key(&candidate) {
+                return candidate;
+            }
+        }
+
+        format!(
+            "scr_{:08x}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .subsec_nanos()
+        )
+    }
+
+    fn effective_limits(&self, requested: &ScriptLimits) -> ScriptLimits {
+        let defaults = ScriptSettings::default();
+
+        ScriptLimits {
+            max_steps: requested.max_steps.min(
+                self.settings
+                    .max_steps
+                    .or(defaults.max_steps)
+                    .unwrap_or(requested.max_steps),
+            ),
+            max_timeout_secs: requested.max_timeout_secs.min(
+                self.settings
+                    .max_timeout_secs
+                    .or(defaults.max_timeout_secs)
+                    .unwrap_or(requested.max_timeout_secs),
+            ),
+            max_output_bytes: requested.max_output_bytes.min(
+                self.settings
+                    .max_output_bytes
+                    .or(defaults.max_output_bytes)
+                    .unwrap_or(requested.max_output_bytes),
+            ),
+            max_script_size_bytes: requested.max_script_size_bytes.min(
+                self.settings
+                    .max_script_size_bytes
+                    .or(defaults.max_script_size_bytes)
+                    .unwrap_or(requested.max_script_size_bytes),
+            ),
+            max_parallel_branches: requested.max_parallel_branches.min(
+                self.settings
+                    .max_parallel_branches
+                    .or(defaults.max_parallel_branches)
+                    .unwrap_or(requested.max_parallel_branches),
+            ),
+            max_nesting_depth: requested.max_nesting_depth.min(
+                self.settings
+                    .max_nesting_depth
+                    .or(defaults.max_nesting_depth)
+                    .unwrap_or(requested.max_nesting_depth),
+            ),
+            per_step_timeout_secs: requested.per_step_timeout_secs.min(
+                self.settings
+                    .per_step_timeout_secs
+                    .or(defaults.per_step_timeout_secs)
+                    .unwrap_or(requested.per_step_timeout_secs),
+            ),
+        }
+    }
+}

--- a/crates/agent/src/script_manager.rs
+++ b/crates/agent/src/script_manager.rs
@@ -69,7 +69,6 @@ impl ScriptManager {
         task: ScriptTask,
         browser: BrowserContext,
     ) -> Result<String, ScriptError> {
-        self.cleanup_completed();
         self.check_can_spawn()?;
 
         let script_id = self.generate_script_id();

--- a/crates/agent/src/script_manager.rs
+++ b/crates/agent/src/script_manager.rs
@@ -274,3 +274,69 @@ impl ScriptManager {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, RwLock};
+
+    use acrawl_core::{ScriptResult, ScriptState, ScriptStatus};
+    use runtime::settings::ScriptSettings;
+    use tokio_util::sync::CancellationToken;
+
+    use super::{RunningScript, ScriptManager};
+
+    fn completed_script_entry(id: &str) -> RunningScript {
+        let state = Arc::new(RwLock::new(ScriptState {
+            script_id: id.to_string(),
+            status: ScriptStatus::Completed,
+            step: 1,
+            total_steps: Some(1),
+            current_url: None,
+            items_collected: 0,
+            elapsed_secs: 0.0,
+            errors_caught: 0,
+            yielded_data: Vec::new(),
+        }));
+        let handle = tokio::task::spawn(async {
+            ScriptResult {
+                script_id: "first".to_string(),
+                status: ScriptStatus::Completed,
+                extracted_data: vec![],
+                yielded_data: vec![],
+                steps_executed: 1,
+                elapsed_secs: 0.0,
+                error: None,
+            }
+        });
+        RunningScript {
+            script_id: id.to_string(),
+            state,
+            handle,
+            cancel_token: CancellationToken::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn completed_script_survives_subsequent_spawn_check() {
+        let mut manager = ScriptManager::new(ScriptSettings::default());
+        manager
+            .scripts
+            .insert("first".to_string(), completed_script_entry("first"));
+
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        assert!(manager.scripts["first"].handle.is_finished());
+        assert_eq!(manager.scripts.len(), 1, "completed entry must stay in map");
+
+        manager.check_can_spawn().expect("should be able to spawn");
+        assert!(
+            manager.scripts.contains_key("first"),
+            "check_can_spawn must not evict completed entry"
+        );
+
+        let status = manager
+            .get_status("first")
+            .expect("first must still be retrievable after spawn check");
+        assert_eq!(status.status, ScriptStatus::Completed);
+    }
+}

--- a/crates/agent/src/script_manager.rs
+++ b/crates/agent/src/script_manager.rs
@@ -63,6 +63,7 @@ impl ScriptManager {
         }
     }
 
+    #[allow(clippy::needless_pass_by_value)]
     pub fn spawn_script(
         &mut self,
         task: ScriptTask,
@@ -208,6 +209,7 @@ impl ScriptManager {
             now_nanos.hash(&mut hasher);
             self.scripts.len().hash(&mut hasher);
             attempt.hash(&mut hasher);
+            #[allow(clippy::cast_possible_truncation)]
             let candidate = format!("scr_{:08x}", (hasher.finish() as u32));
 
             if !self.scripts.contains_key(&candidate) {

--- a/crates/agent/src/tools/cancel_script.rs
+++ b/crates/agent/src/tools/cancel_script.rs
@@ -1,0 +1,52 @@
+use serde_json::Value;
+
+use acrawl_core::script_types::ScriptCancelSpec;
+
+use crate::{ToolEffect, ToolExecutionError};
+
+/// Parse the LLM's `cancel_script` tool input and return a `ScriptCancel` effect.
+///
+/// Input: `{ "script_id": "<id>" }`
+pub fn execute(input: &Value) -> Result<ToolEffect, ToolExecutionError> {
+    let script_id = input
+        .get("script_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            ToolExecutionError::new("cancel_script requires non-empty `script_id`".to_string())
+        })?
+        .to_string();
+
+    Ok(ToolEffect::ScriptCancel(ScriptCancelSpec { script_id }))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn cancel_script_returns_effect() {
+        let effect = execute(&json!({"script_id": "xyz-789"})).expect("should parse script_id");
+        match effect {
+            ToolEffect::ScriptCancel(spec) => {
+                assert_eq!(spec.script_id, "xyz-789");
+            }
+            _ => panic!("expected ScriptCancel effect"),
+        }
+    }
+
+    #[test]
+    fn cancel_script_rejects_missing_id() {
+        let err = execute(&json!({})).expect_err("should fail without script_id");
+        assert!(err.to_string().contains("script_id"));
+    }
+
+    #[test]
+    fn cancel_script_rejects_empty_id() {
+        let err = execute(&json!({"script_id": ""})).expect_err("should fail with empty script_id");
+        assert!(err.to_string().contains("script_id"));
+    }
+}

--- a/crates/agent/src/tools/list_scripts.rs
+++ b/crates/agent/src/tools/list_scripts.rs
@@ -12,19 +12,19 @@ pub fn execute(_input: &Value) -> Result<ToolEffect, ToolExecutionError> {
 
     if scripts_dir.exists() {
         let entries = fs::read_dir(&scripts_dir).map_err(|e| {
-            ToolExecutionError::new(format!("failed to read scripts directory: {}", e))
+            ToolExecutionError::new(format!("failed to read scripts directory: {e}"))
         })?;
 
         for entry in entries {
             let entry = entry.map_err(|e| {
-                ToolExecutionError::new(format!("failed to read directory entry: {}", e))
+                ToolExecutionError::new(format!("failed to read directory entry: {e}"))
             })?;
             let path = entry.path();
 
             if path.extension().and_then(|ext| ext.to_str()) == Some("json") {
                 if let Some(name) = path.file_stem().and_then(|stem| stem.to_str()) {
                     let metadata = fs::metadata(&path).map_err(|e| {
-                        ToolExecutionError::new(format!("failed to get file metadata: {}", e))
+                        ToolExecutionError::new(format!("failed to get file metadata: {e}"))
                     })?;
 
                     let size_bytes = metadata.len();
@@ -47,7 +47,7 @@ pub fn execute(_input: &Value) -> Result<ToolEffect, ToolExecutionError> {
     });
 
     let json_array = serde_json::to_string(&scripts)
-        .map_err(|e| ToolExecutionError::new(format!("failed to serialize scripts list: {}", e)))?;
+        .map_err(|e| ToolExecutionError::new(format!("failed to serialize scripts list: {e}")))?;
 
     Ok(ToolEffect::Reply(json_array))
 }
@@ -56,7 +56,7 @@ fn format_system_time(time: Option<SystemTime>) -> String {
     match time {
         Some(t) => match t.duration_since(SystemTime::UNIX_EPOCH) {
             Ok(_duration) => {
-                format!("{:?}", t)
+                format!("{t:?}")
             }
             Err(_) => "unknown".to_string(),
         },

--- a/crates/agent/src/tools/list_scripts.rs
+++ b/crates/agent/src/tools/list_scripts.rs
@@ -1,6 +1,8 @@
 use serde_json::{json, Value};
 use std::fs;
 use std::time::SystemTime;
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
 
 use crate::{ToolEffect, ToolExecutionError};
 use acrawl_core::config_home_dir;
@@ -56,7 +58,11 @@ fn format_system_time(time: Option<SystemTime>) -> String {
     match time {
         Some(t) => t
             .duration_since(SystemTime::UNIX_EPOCH)
-            .map_or_else(|_| "unknown".to_string(), |d| d.as_secs().to_string()),
+            .ok()
+            .and_then(|d| i64::try_from(d.as_secs()).ok())
+            .and_then(|secs| OffsetDateTime::from_unix_timestamp(secs).ok())
+            .and_then(|dt| dt.format(&Rfc3339).ok())
+            .unwrap_or_else(|| "unknown".to_string()),
         None => "unknown".to_string(),
     }
 }
@@ -72,11 +78,11 @@ mod tests {
     }
 
     #[test]
-    fn format_system_time_returns_unix_epoch_seconds() {
+    fn format_system_time_returns_iso8601() {
         use std::time::{Duration, UNIX_EPOCH};
 
         let t = UNIX_EPOCH + Duration::from_secs(1_700_000_000);
         let result = format_system_time(Some(t));
-        assert_eq!(result, "1700000000");
+        assert_eq!(result, "2023-11-14T22:13:20Z");
     }
 }

--- a/crates/agent/src/tools/list_scripts.rs
+++ b/crates/agent/src/tools/list_scripts.rs
@@ -54,12 +54,9 @@ pub fn execute(_input: &Value) -> Result<ToolEffect, ToolExecutionError> {
 
 fn format_system_time(time: Option<SystemTime>) -> String {
     match time {
-        Some(t) => match t.duration_since(SystemTime::UNIX_EPOCH) {
-            Ok(_duration) => {
-                format!("{t:?}")
-            }
-            Err(_) => "unknown".to_string(),
-        },
+        Some(t) => t
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map_or_else(|_| "unknown".to_string(), |d| d.as_secs().to_string()),
         None => "unknown".to_string(),
     }
 }
@@ -72,5 +69,14 @@ mod tests {
     fn format_system_time_handles_none() {
         let result = format_system_time(None);
         assert_eq!(result, "unknown");
+    }
+
+    #[test]
+    fn format_system_time_returns_unix_epoch_seconds() {
+        use std::time::{Duration, UNIX_EPOCH};
+
+        let t = UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        let result = format_system_time(Some(t));
+        assert_eq!(result, "1700000000");
     }
 }

--- a/crates/agent/src/tools/list_scripts.rs
+++ b/crates/agent/src/tools/list_scripts.rs
@@ -1,0 +1,76 @@
+use serde_json::{json, Value};
+use std::fs;
+use std::time::SystemTime;
+
+use crate::{ToolEffect, ToolExecutionError};
+use acrawl_core::config_home_dir;
+
+pub fn execute(_input: &Value) -> Result<ToolEffect, ToolExecutionError> {
+    let scripts_dir = config_home_dir().join("scripts");
+
+    let mut scripts = Vec::new();
+
+    if scripts_dir.exists() {
+        let entries = fs::read_dir(&scripts_dir).map_err(|e| {
+            ToolExecutionError::new(format!("failed to read scripts directory: {}", e))
+        })?;
+
+        for entry in entries {
+            let entry = entry.map_err(|e| {
+                ToolExecutionError::new(format!("failed to read directory entry: {}", e))
+            })?;
+            let path = entry.path();
+
+            if path.extension().and_then(|ext| ext.to_str()) == Some("json") {
+                if let Some(name) = path.file_stem().and_then(|stem| stem.to_str()) {
+                    let metadata = fs::metadata(&path).map_err(|e| {
+                        ToolExecutionError::new(format!("failed to get file metadata: {}", e))
+                    })?;
+
+                    let size_bytes = metadata.len();
+                    let modified_at = format_system_time(metadata.modified().ok());
+
+                    scripts.push(json!({
+                        "name": name,
+                        "size_bytes": size_bytes,
+                        "modified_at": modified_at
+                    }));
+                }
+            }
+        }
+    }
+
+    scripts.sort_by(|a, b| {
+        let a_name = a.get("name").and_then(|v| v.as_str()).unwrap_or("");
+        let b_name = b.get("name").and_then(|v| v.as_str()).unwrap_or("");
+        a_name.cmp(b_name)
+    });
+
+    let json_array = serde_json::to_string(&scripts)
+        .map_err(|e| ToolExecutionError::new(format!("failed to serialize scripts list: {}", e)))?;
+
+    Ok(ToolEffect::Reply(json_array))
+}
+
+fn format_system_time(time: Option<SystemTime>) -> String {
+    match time {
+        Some(t) => match t.duration_since(SystemTime::UNIX_EPOCH) {
+            Ok(_duration) => {
+                format!("{:?}", t)
+            }
+            Err(_) => "unknown".to_string(),
+        },
+        None => "unknown".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_system_time_handles_none() {
+        let result = format_system_time(None);
+        assert_eq!(result, "unknown");
+    }
+}

--- a/crates/agent/src/tools/mod.rs
+++ b/crates/agent/src/tools/mod.rs
@@ -22,3 +22,11 @@ pub mod subagent_status;
 pub mod switch_tab;
 pub mod wait;
 pub mod wait_for_subagents;
+
+pub mod cancel_script;
+pub mod list_scripts;
+pub mod read_script;
+pub mod run_script;
+pub mod save_script;
+pub mod script_status;
+pub mod wait_for_scripts;

--- a/crates/agent/src/tools/read_script.rs
+++ b/crates/agent/src/tools/read_script.rs
@@ -1,0 +1,116 @@
+use serde_json::Value;
+use std::fs;
+use std::path::Component;
+
+use crate::{CrawlError, ToolEffect, ToolExecutionError};
+use acrawl_core::config_home_dir;
+
+pub fn parse_input(input: &Value) -> Result<String, CrawlError> {
+    let name = input
+        .get("name")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| CrawlError::new("read_script requires 'name' field"))?
+        .to_string();
+
+    validate_script_name(&name)?;
+
+    Ok(name)
+}
+
+fn validate_script_name(name: &str) -> Result<(), CrawlError> {
+    if name.trim().is_empty() {
+        return Err(CrawlError::new("script name must not be empty"));
+    }
+
+    if name.starts_with('-') {
+        return Err(CrawlError::new("script name must not start with '-'"));
+    }
+
+    if name.contains('/') || name.contains('\\') || name.contains("..") || name.contains('.') {
+        return Err(CrawlError::new(
+            "script name must not contain '/', '\\', '.', or '..' (path traversal not allowed)",
+        ));
+    }
+
+    if name.contains('\0') {
+        return Err(CrawlError::new("script name must not contain null bytes"));
+    }
+
+    let path = std::path::Path::new(name);
+    for component in path.components() {
+        match component {
+            Component::Normal(_) => {}
+            Component::CurDir
+            | Component::ParentDir
+            | Component::RootDir
+            | Component::Prefix(_) => {
+                return Err(CrawlError::new(
+                    "script name must be a simple filename without path components",
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub fn execute(input: &Value) -> Result<ToolEffect, ToolExecutionError> {
+    let name = parse_input(input)?;
+
+    let script_path = config_home_dir()
+        .join("scripts")
+        .join(format!("{}.json", name));
+
+    if !script_path.exists() {
+        return Err(ToolExecutionError::new(format!(
+            "script '{}' not found",
+            name
+        )));
+    }
+
+    let content = fs::read_to_string(&script_path)
+        .map_err(|e| ToolExecutionError::new(format!("failed to read script file: {}", e)))?;
+
+    Ok(ToolEffect::Reply(content))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn validates_script_name_rejects_slashes() {
+        assert!(validate_script_name("my/script").is_err());
+        assert!(validate_script_name("my\\script").is_err());
+    }
+
+    #[test]
+    fn validates_script_name_rejects_dots() {
+        assert!(validate_script_name("my.script").is_err());
+        assert!(validate_script_name("..").is_err());
+    }
+
+    #[test]
+    fn validates_script_name_rejects_leading_dash() {
+        assert!(validate_script_name("-script").is_err());
+    }
+
+    #[test]
+    fn validates_script_name_rejects_null_bytes() {
+        assert!(validate_script_name("my\0script").is_err());
+    }
+
+    #[test]
+    fn validates_script_name_accepts_valid_names() {
+        assert!(validate_script_name("my_script").is_ok());
+        assert!(validate_script_name("my-script").is_ok());
+        assert!(validate_script_name("MyScript123").is_ok());
+    }
+
+    #[test]
+    fn parses_input_requires_name() {
+        let input = json!({});
+        assert!(parse_input(&input).is_err());
+    }
+}

--- a/crates/agent/src/tools/read_script.rs
+++ b/crates/agent/src/tools/read_script.rs
@@ -1,6 +1,5 @@
 use serde_json::Value;
 use std::fs;
-use std::path::Component;
 
 use crate::{CrawlError, ToolEffect, ToolExecutionError};
 use acrawl_core::config_home_dir;
@@ -12,46 +11,9 @@ pub fn parse_input(input: &Value) -> Result<String, CrawlError> {
         .ok_or_else(|| CrawlError::new("read_script requires 'name' field"))?
         .to_string();
 
-    validate_script_name(&name)?;
+    script::persistence::validate_script_name(&name).map_err(|e| CrawlError::new(e.to_string()))?;
 
     Ok(name)
-}
-
-fn validate_script_name(name: &str) -> Result<(), CrawlError> {
-    if name.trim().is_empty() {
-        return Err(CrawlError::new("script name must not be empty"));
-    }
-
-    if name.starts_with('-') {
-        return Err(CrawlError::new("script name must not start with '-'"));
-    }
-
-    if name.contains('/') || name.contains('\\') || name.contains("..") || name.contains('.') {
-        return Err(CrawlError::new(
-            "script name must not contain '/', '\\', '.', or '..' (path traversal not allowed)",
-        ));
-    }
-
-    if name.contains('\0') {
-        return Err(CrawlError::new("script name must not contain null bytes"));
-    }
-
-    let path = std::path::Path::new(name);
-    for component in path.components() {
-        match component {
-            Component::Normal(_) => {}
-            Component::CurDir
-            | Component::ParentDir
-            | Component::RootDir
-            | Component::Prefix(_) => {
-                return Err(CrawlError::new(
-                    "script name must be a simple filename without path components",
-                ));
-            }
-        }
-    }
-
-    Ok(())
 }
 
 pub fn execute(input: &Value) -> Result<ToolEffect, ToolExecutionError> {
@@ -80,31 +42,31 @@ mod tests {
 
     #[test]
     fn validates_script_name_rejects_slashes() {
-        assert!(validate_script_name("my/script").is_err());
-        assert!(validate_script_name("my\\script").is_err());
+        assert!(script::persistence::validate_script_name("my/script").is_err());
+        assert!(script::persistence::validate_script_name("my\\script").is_err());
     }
 
     #[test]
     fn validates_script_name_rejects_dots() {
-        assert!(validate_script_name("my.script").is_err());
-        assert!(validate_script_name("..").is_err());
+        assert!(script::persistence::validate_script_name("my.script").is_err());
+        assert!(script::persistence::validate_script_name("..").is_err());
     }
 
     #[test]
     fn validates_script_name_rejects_leading_dash() {
-        assert!(validate_script_name("-script").is_err());
+        assert!(script::persistence::validate_script_name("-script").is_err());
     }
 
     #[test]
     fn validates_script_name_rejects_null_bytes() {
-        assert!(validate_script_name("my\0script").is_err());
+        assert!(script::persistence::validate_script_name("my\0script").is_err());
     }
 
     #[test]
     fn validates_script_name_accepts_valid_names() {
-        assert!(validate_script_name("my_script").is_ok());
-        assert!(validate_script_name("my-script").is_ok());
-        assert!(validate_script_name("MyScript123").is_ok());
+        assert!(script::persistence::validate_script_name("my_script").is_ok());
+        assert!(script::persistence::validate_script_name("my-script").is_ok());
+        assert!(script::persistence::validate_script_name("MyScript123").is_ok());
     }
 
     #[test]

--- a/crates/agent/src/tools/read_script.rs
+++ b/crates/agent/src/tools/read_script.rs
@@ -59,17 +59,16 @@ pub fn execute(input: &Value) -> Result<ToolEffect, ToolExecutionError> {
 
     let script_path = config_home_dir()
         .join("scripts")
-        .join(format!("{}.json", name));
+        .join(format!("{name}.json"));
 
     if !script_path.exists() {
         return Err(ToolExecutionError::new(format!(
-            "script '{}' not found",
-            name
+            "script '{name}' not found",
         )));
     }
 
     let content = fs::read_to_string(&script_path)
-        .map_err(|e| ToolExecutionError::new(format!("failed to read script file: {}", e)))?;
+        .map_err(|e| ToolExecutionError::new(format!("failed to read script file: {e}")))?;
 
     Ok(ToolEffect::Reply(content))
 }

--- a/crates/agent/src/tools/run_script.rs
+++ b/crates/agent/src/tools/run_script.rs
@@ -1,0 +1,128 @@
+use serde_json::Value;
+
+use acrawl_core::script_types::{ScriptLimits, ScriptTask};
+
+use crate::{ToolEffect, ToolExecutionError};
+
+/// Parse the LLM's `run_script` tool input and return a `RunScript` effect.
+///
+/// Either `script` (inline JSON) or `name` (load from disk) must be present.
+/// If both are missing, an error is returned. The actual script loading from
+/// disk (when `name` is used) happens downstream in the effect dispatcher,
+/// not here.
+pub fn execute(input: &Value) -> Result<ToolEffect, ToolExecutionError> {
+    let script_value = input.get("script").cloned();
+    let name = input.get("name").and_then(Value::as_str).map(str::to_owned);
+    let save_as = input
+        .get("save_as")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+
+    let script = match (script_value, &name) {
+        (Some(s), _) => s,
+        (None, Some(n)) => {
+            serde_json::json!({ "__load_from_disk": n })
+        }
+        (None, None) => {
+            return Err(ToolExecutionError::new(
+                "run_script requires either `script` or `name`".to_string(),
+            ));
+        }
+    };
+
+    let limits = input
+        .get("limits")
+        .map(|v| {
+            serde_json::from_value::<ScriptLimits>(v.clone())
+                .map_err(|e| ToolExecutionError::new(format!("run_script: invalid limits: {e}")))
+        })
+        .transpose()?
+        .unwrap_or(ScriptLimits {
+            max_steps: 200,
+            max_timeout_secs: 300,
+            max_output_bytes: 10_485_760,
+            max_parallel_branches: 10,
+            per_step_timeout_secs: 30,
+            max_script_size_bytes: 1_048_576,
+            max_nesting_depth: 10,
+        });
+
+    Ok(ToolEffect::RunScript(ScriptTask {
+        script,
+        save_as,
+        limits,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn run_script_with_inline_script() {
+        let effect = execute(&json!({
+            "script": { "steps": [{"navigate": "https://example.com"}] }
+        }))
+        .expect("should parse inline script");
+        match effect {
+            ToolEffect::RunScript(task) => {
+                assert_eq!(
+                    task.script,
+                    json!({"steps": [{"navigate": "https://example.com"}]})
+                );
+                assert_eq!(task.save_as, None);
+                assert_eq!(task.limits.max_steps, 200);
+            }
+            _ => panic!("expected RunScript effect"),
+        }
+    }
+
+    #[test]
+    fn run_script_with_name() {
+        let effect = execute(&json!({
+            "name": "my-scraper"
+        }))
+        .expect("should parse name reference");
+        match effect {
+            ToolEffect::RunScript(task) => {
+                assert_eq!(task.script, json!({"__load_from_disk": "my-scraper"}));
+            }
+            _ => panic!("expected RunScript effect"),
+        }
+    }
+
+    #[test]
+    fn run_script_with_save_as_and_limits() {
+        let effect = execute(&json!({
+            "script": {"steps": []},
+            "save_as": "fast-script",
+            "limits": {
+                "max_steps": 50,
+                "max_timeout_secs": 60,
+                "max_output_bytes": 1024,
+                "max_parallel_branches": 2,
+                "per_step_timeout_secs": 10,
+                "max_script_size_bytes": 512,
+                "max_nesting_depth": 3
+            }
+        }))
+        .expect("should parse with limits");
+        match effect {
+            ToolEffect::RunScript(task) => {
+                assert_eq!(task.save_as, Some("fast-script".to_string()));
+                assert_eq!(task.limits.max_steps, 50);
+                assert_eq!(task.limits.max_timeout_secs, 60);
+                assert_eq!(task.limits.max_nesting_depth, 3);
+            }
+            _ => panic!("expected RunScript effect"),
+        }
+    }
+
+    #[test]
+    fn run_script_rejects_missing_script_and_name() {
+        let err = execute(&json!({})).expect_err("should fail without script or name");
+        assert!(err.to_string().contains("requires either"));
+    }
+}

--- a/crates/agent/src/tools/save_script.rs
+++ b/crates/agent/src/tools/save_script.rs
@@ -1,6 +1,5 @@
 use serde_json::Value;
 use std::fs;
-use std::path::Component;
 
 use crate::{CrawlError, ToolEffect, ToolExecutionError};
 use acrawl_core::config_home_dir;
@@ -17,49 +16,9 @@ pub fn parse_input(input: &Value) -> Result<(String, Value), CrawlError> {
         .ok_or_else(|| CrawlError::new("save_script requires 'script' field"))?
         .clone();
 
-    validate_script_name(&name)?;
+    script::persistence::validate_script_name(&name).map_err(|e| CrawlError::new(e.to_string()))?;
 
     Ok((name, script))
-}
-
-fn validate_script_name(name: &str) -> Result<(), CrawlError> {
-    if name.trim().is_empty() {
-        return Err(CrawlError::new("script name must not be empty"));
-    }
-
-    if name.starts_with('-') {
-        return Err(CrawlError::new("script name must not start with '-'"));
-    }
-
-    // Check for path traversal characters
-    if name.contains('/') || name.contains('\\') || name.contains("..") || name.contains('.') {
-        return Err(CrawlError::new(
-            "script name must not contain '/', '\\', '.', or '..' (path traversal not allowed)",
-        ));
-    }
-
-    // Check for null bytes
-    if name.contains('\0') {
-        return Err(CrawlError::new("script name must not contain null bytes"));
-    }
-
-    // Validate using Path components to catch edge cases
-    let path = std::path::Path::new(name);
-    for component in path.components() {
-        match component {
-            Component::Normal(_) => {}
-            Component::CurDir
-            | Component::ParentDir
-            | Component::RootDir
-            | Component::Prefix(_) => {
-                return Err(CrawlError::new(
-                    "script name must be a simple filename without path components",
-                ));
-            }
-        }
-    }
-
-    Ok(())
 }
 
 pub fn execute(input: &Value) -> Result<ToolEffect, ToolExecutionError> {
@@ -92,31 +51,31 @@ mod tests {
 
     #[test]
     fn validates_script_name_rejects_slashes() {
-        assert!(validate_script_name("my/script").is_err());
-        assert!(validate_script_name("my\\script").is_err());
+        assert!(script::persistence::validate_script_name("my/script").is_err());
+        assert!(script::persistence::validate_script_name("my\\script").is_err());
     }
 
     #[test]
     fn validates_script_name_rejects_dots() {
-        assert!(validate_script_name("my.script").is_err());
-        assert!(validate_script_name("..").is_err());
+        assert!(script::persistence::validate_script_name("my.script").is_err());
+        assert!(script::persistence::validate_script_name("..").is_err());
     }
 
     #[test]
     fn validates_script_name_rejects_leading_dash() {
-        assert!(validate_script_name("-script").is_err());
+        assert!(script::persistence::validate_script_name("-script").is_err());
     }
 
     #[test]
     fn validates_script_name_rejects_null_bytes() {
-        assert!(validate_script_name("my\0script").is_err());
+        assert!(script::persistence::validate_script_name("my\0script").is_err());
     }
 
     #[test]
     fn validates_script_name_accepts_valid_names() {
-        assert!(validate_script_name("my_script").is_ok());
-        assert!(validate_script_name("my-script").is_ok());
-        assert!(validate_script_name("MyScript123").is_ok());
+        assert!(script::persistence::validate_script_name("my_script").is_ok());
+        assert!(script::persistence::validate_script_name("my-script").is_ok());
+        assert!(script::persistence::validate_script_name("MyScript123").is_ok());
     }
 
     #[test]

--- a/crates/agent/src/tools/save_script.rs
+++ b/crates/agent/src/tools/save_script.rs
@@ -67,23 +67,22 @@ pub fn execute(input: &Value) -> Result<ToolEffect, ToolExecutionError> {
 
     // Validate script JSON via parser
     script::parser::parse_script(&script)
-        .map_err(|e| ToolExecutionError::new(format!("invalid script: {}", e)))?;
+        .map_err(|e| ToolExecutionError::new(format!("invalid script: {e}")))?;
 
     // Create scripts directory
     let scripts_dir = config_home_dir().join("scripts");
-    fs::create_dir_all(&scripts_dir).map_err(|e| {
-        ToolExecutionError::new(format!("failed to create scripts directory: {}", e))
-    })?;
+    fs::create_dir_all(&scripts_dir)
+        .map_err(|e| ToolExecutionError::new(format!("failed to create scripts directory: {e}")))?;
 
     // Write script file
-    let script_path = scripts_dir.join(format!("{}.json", name));
+    let script_path = scripts_dir.join(format!("{name}.json"));
     let script_json = serde_json::to_string_pretty(&script)
-        .map_err(|e| ToolExecutionError::new(format!("failed to serialize script: {}", e)))?;
+        .map_err(|e| ToolExecutionError::new(format!("failed to serialize script: {e}")))?;
 
     fs::write(&script_path, script_json)
-        .map_err(|e| ToolExecutionError::new(format!("failed to write script file: {}", e)))?;
+        .map_err(|e| ToolExecutionError::new(format!("failed to write script file: {e}")))?;
 
-    Ok(ToolEffect::Reply(format!("Script '{}' saved", name)))
+    Ok(ToolEffect::Reply(format!("Script '{name}' saved")))
 }
 
 #[cfg(test)]

--- a/crates/agent/src/tools/save_script.rs
+++ b/crates/agent/src/tools/save_script.rs
@@ -1,0 +1,134 @@
+use serde_json::Value;
+use std::fs;
+use std::path::Component;
+
+use crate::{CrawlError, ToolEffect, ToolExecutionError};
+use acrawl_core::config_home_dir;
+
+pub fn parse_input(input: &Value) -> Result<(String, Value), CrawlError> {
+    let name = input
+        .get("name")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| CrawlError::new("save_script requires 'name' field"))?
+        .to_string();
+
+    let script = input
+        .get("script")
+        .ok_or_else(|| CrawlError::new("save_script requires 'script' field"))?
+        .clone();
+
+    validate_script_name(&name)?;
+
+    Ok((name, script))
+}
+
+fn validate_script_name(name: &str) -> Result<(), CrawlError> {
+    if name.trim().is_empty() {
+        return Err(CrawlError::new("script name must not be empty"));
+    }
+
+    if name.starts_with('-') {
+        return Err(CrawlError::new("script name must not start with '-'"));
+    }
+
+    // Check for path traversal characters
+    if name.contains('/') || name.contains('\\') || name.contains("..") || name.contains('.') {
+        return Err(CrawlError::new(
+            "script name must not contain '/', '\\', '.', or '..' (path traversal not allowed)",
+        ));
+    }
+
+    // Check for null bytes
+    if name.contains('\0') {
+        return Err(CrawlError::new("script name must not contain null bytes"));
+    }
+
+    // Validate using Path components to catch edge cases
+    let path = std::path::Path::new(name);
+    for component in path.components() {
+        match component {
+            Component::Normal(_) => {}
+            Component::CurDir
+            | Component::ParentDir
+            | Component::RootDir
+            | Component::Prefix(_) => {
+                return Err(CrawlError::new(
+                    "script name must be a simple filename without path components",
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub fn execute(input: &Value) -> Result<ToolEffect, ToolExecutionError> {
+    let (name, script) = parse_input(input)?;
+
+    // Validate script JSON via parser
+    script::parser::parse_script(&script)
+        .map_err(|e| ToolExecutionError::new(format!("invalid script: {}", e)))?;
+
+    // Create scripts directory
+    let scripts_dir = config_home_dir().join("scripts");
+    fs::create_dir_all(&scripts_dir).map_err(|e| {
+        ToolExecutionError::new(format!("failed to create scripts directory: {}", e))
+    })?;
+
+    // Write script file
+    let script_path = scripts_dir.join(format!("{}.json", name));
+    let script_json = serde_json::to_string_pretty(&script)
+        .map_err(|e| ToolExecutionError::new(format!("failed to serialize script: {}", e)))?;
+
+    fs::write(&script_path, script_json)
+        .map_err(|e| ToolExecutionError::new(format!("failed to write script file: {}", e)))?;
+
+    Ok(ToolEffect::Reply(format!("Script '{}' saved", name)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn validates_script_name_rejects_slashes() {
+        assert!(validate_script_name("my/script").is_err());
+        assert!(validate_script_name("my\\script").is_err());
+    }
+
+    #[test]
+    fn validates_script_name_rejects_dots() {
+        assert!(validate_script_name("my.script").is_err());
+        assert!(validate_script_name("..").is_err());
+    }
+
+    #[test]
+    fn validates_script_name_rejects_leading_dash() {
+        assert!(validate_script_name("-script").is_err());
+    }
+
+    #[test]
+    fn validates_script_name_rejects_null_bytes() {
+        assert!(validate_script_name("my\0script").is_err());
+    }
+
+    #[test]
+    fn validates_script_name_accepts_valid_names() {
+        assert!(validate_script_name("my_script").is_ok());
+        assert!(validate_script_name("my-script").is_ok());
+        assert!(validate_script_name("MyScript123").is_ok());
+    }
+
+    #[test]
+    fn parses_input_requires_name() {
+        let input = json!({"script": {}});
+        assert!(parse_input(&input).is_err());
+    }
+
+    #[test]
+    fn parses_input_requires_script() {
+        let input = json!({"name": "test"});
+        assert!(parse_input(&input).is_err());
+    }
+}

--- a/crates/agent/src/tools/script_status.rs
+++ b/crates/agent/src/tools/script_status.rs
@@ -1,0 +1,53 @@
+use serde_json::Value;
+
+use acrawl_core::script_types::ScriptStatusSpec;
+
+use crate::{ToolEffect, ToolExecutionError};
+
+/// Parse the LLM's `script_status` tool input and return a `ScriptStatus` effect.
+///
+/// Input: `{ "script_id": "<id>" }`
+pub fn execute(input: &Value) -> Result<ToolEffect, ToolExecutionError> {
+    let script_id = input
+        .get("script_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            ToolExecutionError::new("script_status requires non-empty `script_id`".to_string())
+        })?
+        .to_string();
+
+    Ok(ToolEffect::ScriptStatus(ScriptStatusSpec { script_id }))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn script_status_returns_effect() {
+        let effect = execute(&json!({"script_id": "abc-123"})).expect("should parse script_id");
+        match effect {
+            ToolEffect::ScriptStatus(spec) => {
+                assert_eq!(spec.script_id, "abc-123");
+            }
+            _ => panic!("expected ScriptStatus effect"),
+        }
+    }
+
+    #[test]
+    fn script_status_rejects_missing_id() {
+        let err = execute(&json!({})).expect_err("should fail without script_id");
+        assert!(err.to_string().contains("script_id"));
+    }
+
+    #[test]
+    fn script_status_rejects_empty_id() {
+        let err =
+            execute(&json!({"script_id": "  "})).expect_err("should fail with empty script_id");
+        assert!(err.to_string().contains("script_id"));
+    }
+}

--- a/crates/agent/src/tools/wait_for_scripts.rs
+++ b/crates/agent/src/tools/wait_for_scripts.rs
@@ -1,0 +1,83 @@
+use serde_json::Value;
+
+use acrawl_core::script_types::ScriptWaitSpec;
+
+use crate::{ToolEffect, ToolExecutionError};
+
+/// Parse the LLM's `wait_for_scripts` tool input and return a `ScriptWait` effect.
+///
+/// Input: `{ "script_ids": ["id1", "id2"] }` or `{}` (wait for all).
+pub fn execute(input: &Value) -> Result<ToolEffect, ToolExecutionError> {
+    let script_ids = input
+        .get("script_ids")
+        .map(|value| {
+            value
+                .as_array()
+                .ok_or_else(|| {
+                    ToolExecutionError::new(
+                        "wait_for_scripts script_ids must be an array".to_string(),
+                    )
+                })
+                .and_then(|values| {
+                    values
+                        .iter()
+                        .map(|v| {
+                            v.as_str().map(str::to_owned).ok_or_else(|| {
+                                ToolExecutionError::new(
+                                    "wait_for_scripts script_ids entries must be strings"
+                                        .to_string(),
+                                )
+                            })
+                        })
+                        .collect::<Result<Vec<_>, _>>()
+                })
+        })
+        .transpose()?;
+
+    Ok(ToolEffect::ScriptWait(ScriptWaitSpec { script_ids }))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn wait_for_scripts_with_ids() {
+        let effect =
+            execute(&json!({"script_ids": ["s1", "s2"]})).expect("should parse script_ids");
+        match effect {
+            ToolEffect::ScriptWait(spec) => {
+                assert_eq!(
+                    spec.script_ids,
+                    Some(vec!["s1".to_string(), "s2".to_string()])
+                );
+            }
+            _ => panic!("expected ScriptWait effect"),
+        }
+    }
+
+    #[test]
+    fn wait_for_scripts_defaults_to_all() {
+        let effect = execute(&json!({})).expect("should default to all scripts");
+        match effect {
+            ToolEffect::ScriptWait(spec) => assert_eq!(spec.script_ids, None),
+            _ => panic!("expected ScriptWait effect"),
+        }
+    }
+
+    #[test]
+    fn wait_for_scripts_rejects_non_array() {
+        let err = execute(&json!({"script_ids": "not-an-array"}))
+            .expect_err("should fail with non-array");
+        assert!(err.to_string().contains("must be an array"));
+    }
+
+    #[test]
+    fn wait_for_scripts_rejects_non_string_entries() {
+        let err = execute(&json!({"script_ids": [123]}))
+            .expect_err("should fail with non-string entries");
+        assert!(err.to_string().contains("must be strings"));
+    }
+}

--- a/crates/agent/tests/script_integration.rs
+++ b/crates/agent/tests/script_integration.rs
@@ -1,0 +1,300 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+use acrawl_core::{script_types::ScriptLimits, ToolEffect};
+use agent::{mvp_tool_specs, tools};
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+fn script_fixture() -> Value {
+    json!({
+        "schema_version": 1,
+        "steps": []
+    })
+}
+
+fn script_limits_fixture() -> Value {
+    json!({
+        "max_steps": 50,
+        "max_timeout_secs": 60,
+        "max_output_bytes": 1024,
+        "max_parallel_branches": 2,
+        "per_step_timeout_secs": 10,
+        "max_script_size_bytes": 2048,
+        "max_nesting_depth": 3
+    })
+}
+
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn with_temp_config_home(test: impl FnOnce(&Path)) {
+    let _guard = env_lock().lock().expect("env lock poisoned");
+    let temp_dir = TempDir::new().expect("temp dir should be created");
+    let original = std::env::var_os("ACRAWL_CONFIG_HOME");
+    std::env::set_var("ACRAWL_CONFIG_HOME", temp_dir.path());
+    test(temp_dir.path());
+    match original {
+        Some(value) => std::env::set_var("ACRAWL_CONFIG_HOME", value),
+        None => std::env::remove_var("ACRAWL_CONFIG_HOME"),
+    }
+}
+
+fn unwrap_reply(effect: ToolEffect) -> String {
+    match effect {
+        ToolEffect::Reply(reply) => reply,
+        other => panic!("expected Reply effect, got {other:?}"),
+    }
+}
+
+fn saved_script_path(config_home: &Path, name: &str) -> PathBuf {
+    config_home.join("scripts").join(format!("{name}.json"))
+}
+
+#[test]
+fn script_integration_test_run_script_spawns_and_returns_id() {
+    let effect = tools::run_script::execute(&json!({
+        "script": script_fixture(),
+        "save_as": "saved-script",
+        "limits": script_limits_fixture()
+    }))
+    .expect("run_script should parse valid input");
+
+    match effect {
+        ToolEffect::RunScript(task) => {
+            assert_eq!(task.script, script_fixture());
+            assert_eq!(task.save_as.as_deref(), Some("saved-script"));
+            assert_eq!(task.limits.max_steps, 50);
+            assert_eq!(task.limits.max_timeout_secs, 60);
+            assert_eq!(task.limits.max_output_bytes, 1024);
+            assert_eq!(task.limits.max_parallel_branches, 2);
+            assert_eq!(task.limits.per_step_timeout_secs, 10);
+            assert_eq!(task.limits.max_script_size_bytes, 2048);
+            assert_eq!(task.limits.max_nesting_depth, 3);
+        }
+        other => panic!("expected RunScript effect, got {other:?}"),
+    }
+}
+
+#[test]
+fn script_integration_test_script_status_tool_returns_effect() {
+    let effect = tools::script_status::execute(&json!({ "script_id": "scr_deadbeef" }))
+        .expect("script_status should parse valid input");
+
+    match effect {
+        ToolEffect::ScriptStatus(spec) => assert_eq!(spec.script_id, "scr_deadbeef"),
+        other => panic!("expected ScriptStatus effect, got {other:?}"),
+    }
+}
+
+#[test]
+fn script_integration_test_wait_for_scripts_tool_returns_effect() {
+    let effect = tools::wait_for_scripts::execute(&json!({
+        "script_ids": ["scr_one", "scr_two"]
+    }))
+    .expect("wait_for_scripts should parse valid input");
+
+    match effect {
+        ToolEffect::ScriptWait(spec) => {
+            assert_eq!(
+                spec.script_ids,
+                Some(vec!["scr_one".to_string(), "scr_two".to_string()])
+            );
+        }
+        other => panic!("expected ScriptWait effect, got {other:?}"),
+    }
+}
+
+#[test]
+fn script_integration_test_cancel_script_tool_returns_effect() {
+    let effect = tools::cancel_script::execute(&json!({ "script_id": "scr_cancelme" }))
+        .expect("cancel_script should parse valid input");
+
+    match effect {
+        ToolEffect::ScriptCancel(spec) => assert_eq!(spec.script_id, "scr_cancelme"),
+        other => panic!("expected ScriptCancel effect, got {other:?}"),
+    }
+}
+
+#[test]
+fn script_integration_test_save_script_writes_to_disk() {
+    with_temp_config_home(|config_home| {
+        let effect = tools::save_script::execute(&json!({
+            "name": "saved_script",
+            "script": script_fixture()
+        }))
+        .expect("save_script should write a valid script");
+
+        assert_eq!(unwrap_reply(effect), "Script 'saved_script' saved");
+
+        let script_path = saved_script_path(config_home, "saved_script");
+        assert!(script_path.exists(), "saved script file should exist");
+
+        let content = fs::read_to_string(script_path).expect("saved script should be readable");
+        let parsed: Value = serde_json::from_str(&content).expect("saved script should be JSON");
+        assert_eq!(parsed, script_fixture());
+    });
+}
+
+#[test]
+fn script_integration_test_list_scripts_returns_empty_for_new_dir() {
+    with_temp_config_home(|_config_home| {
+        let effect = tools::list_scripts::execute(&json!({}))
+            .expect("list_scripts should handle missing scripts dir");
+
+        let parsed: Value = serde_json::from_str(&unwrap_reply(effect))
+            .expect("list_scripts reply should be valid JSON");
+        assert_eq!(parsed, json!([]));
+    });
+}
+
+#[test]
+fn script_integration_test_read_script_reads_saved_file() {
+    with_temp_config_home(|config_home| {
+        let scripts_dir = config_home.join("scripts");
+        fs::create_dir_all(&scripts_dir).expect("scripts dir should be created");
+        let script_json =
+            serde_json::to_string_pretty(&script_fixture()).expect("fixture should serialize");
+        fs::write(saved_script_path(config_home, "reader"), &script_json)
+            .expect("script fixture should be written");
+
+        let effect = tools::read_script::execute(&json!({ "name": "reader" }))
+            .expect("read_script should read saved file");
+
+        let parsed: Value = serde_json::from_str(&unwrap_reply(effect))
+            .expect("read_script reply should be valid JSON");
+        assert_eq!(parsed, script_fixture());
+    });
+}
+
+#[test]
+fn script_integration_test_tool_handlers_reject_missing_required_fields() {
+    let run_script_err = tools::run_script::execute(&json!({}))
+        .expect_err("run_script should require script or name");
+    assert!(run_script_err
+        .to_string()
+        .contains("requires either `script` or `name`"));
+
+    let script_status_err = tools::script_status::execute(&json!({}))
+        .expect_err("script_status should require script_id");
+    assert!(script_status_err.to_string().contains("script_id"));
+
+    let cancel_script_err = tools::cancel_script::execute(&json!({}))
+        .expect_err("cancel_script should require script_id");
+    assert!(cancel_script_err.to_string().contains("script_id"));
+
+    let read_script_err =
+        tools::read_script::execute(&json!({})).expect_err("read_script should require name");
+    assert!(read_script_err.to_string().contains("name"));
+}
+
+#[test]
+fn script_integration_test_save_script_rejects_path_traversal() {
+    let err = tools::save_script::execute(&json!({
+        "name": "nested/script",
+        "script": script_fixture()
+    }))
+    .expect_err("save_script should reject path traversal");
+
+    assert!(err.to_string().contains("path traversal"));
+}
+
+#[test]
+fn script_integration_test_script_tool_schemas_are_valid() {
+    let specs = mvp_tool_specs();
+    let tool_names = [
+        "run_script",
+        "script_status",
+        "wait_for_scripts",
+        "cancel_script",
+        "save_script",
+        "list_scripts",
+        "read_script",
+    ];
+
+    for tool_name in tool_names {
+        let spec = specs
+            .iter()
+            .find(|spec| spec.name == tool_name)
+            .unwrap_or_else(|| panic!("missing tool spec for {tool_name}"));
+
+        assert_eq!(
+            spec.input_schema["type"],
+            json!("object"),
+            "tool: {tool_name}"
+        );
+        assert!(
+            spec.input_schema["properties"].is_object(),
+            "tool: {tool_name}"
+        );
+        assert_eq!(
+            spec.input_schema["additionalProperties"],
+            json!(false),
+            "tool: {tool_name}"
+        );
+    }
+
+    let required_fields = [
+        ("script_status", "script_id"),
+        ("cancel_script", "script_id"),
+        ("save_script", "name"),
+        ("save_script", "script"),
+        ("read_script", "name"),
+    ];
+
+    for (tool_name, required_field) in required_fields {
+        let spec = specs
+            .iter()
+            .find(|spec| spec.name == tool_name)
+            .unwrap_or_else(|| panic!("missing tool spec for {tool_name}"));
+        let required = spec.input_schema["required"]
+            .as_array()
+            .unwrap_or_else(|| panic!("tool {tool_name} should declare required fields"));
+        assert!(
+            required.iter().any(|field| field == required_field),
+            "tool {tool_name} should require {required_field}"
+        );
+    }
+}
+
+#[test]
+fn script_integration_test_run_script_uses_default_limits_without_override() {
+    let effect = tools::run_script::execute(&json!({
+        "script": script_fixture()
+    }))
+    .expect("run_script should use default limits");
+
+    match effect {
+        ToolEffect::RunScript(task) => {
+            let expected = ScriptLimits {
+                max_steps: 200,
+                max_timeout_secs: 300,
+                max_output_bytes: 10_485_760,
+                max_parallel_branches: 10,
+                per_step_timeout_secs: 30,
+                max_script_size_bytes: 1_048_576,
+                max_nesting_depth: 10,
+            };
+            assert_eq!(task.limits.max_steps, expected.max_steps);
+            assert_eq!(task.limits.max_timeout_secs, expected.max_timeout_secs);
+            assert_eq!(task.limits.max_output_bytes, expected.max_output_bytes);
+            assert_eq!(
+                task.limits.max_parallel_branches,
+                expected.max_parallel_branches
+            );
+            assert_eq!(
+                task.limits.per_step_timeout_secs,
+                expected.per_step_timeout_secs
+            );
+            assert_eq!(
+                task.limits.max_script_size_bytes,
+                expected.max_script_size_bytes
+            );
+            assert_eq!(task.limits.max_nesting_depth, expected.max_nesting_depth);
+        }
+        other => panic!("expected RunScript effect, got {other:?}"),
+    }
+}

--- a/crates/cli/tests/mcp_stdio.rs
+++ b/crates/cli/tests/mcp_stdio.rs
@@ -233,6 +233,101 @@ fn stdio_server_returns_jsonrpc_error_when_run_goal_is_missing_goal() {
 }
 
 #[test]
+fn stdio_server_run_script_returns_script_id_and_survives() {
+    let mut server = TestServer::spawn();
+
+    server.send(&json!({
+        "jsonrpc": "2.0", "id": 1,
+        "method": "initialize",
+        "params": { "protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": { "name": "e2e", "version": "1" } }
+    }));
+    server.read_response();
+
+    server.send(&json!({ "jsonrpc": "2.0", "method": "notifications/initialized", "params": {} }));
+
+    server.send(&json!({
+        "jsonrpc": "2.0", "id": 2,
+        "method": "tools/call",
+        "params": {
+            "name": "run_script",
+            "arguments": {
+                "script": {
+                    "schema_version": 1,
+                    "steps": [
+                        { "type": "assign", "variable": "n", "value": { "kind": "literal", "value": 7 } },
+                        { "type": "collect", "value": { "kind": "variable", "value": "n" } },
+                        { "type": "yield",   "value": { "kind": "literal",  "value": "ok" } }
+                    ]
+                },
+                "limits": {
+                    "max_steps": 10, "max_timeout_secs": 30,
+                    "max_output_bytes": 1048576, "max_parallel_branches": 2,
+                    "max_script_size_bytes": 65536, "max_nesting_depth": 5,
+                    "per_step_timeout_secs": 10
+                }
+            }
+        }
+    }));
+    let run_response = server.read_response();
+    assert_eq!(run_response["jsonrpc"], "2.0");
+    assert_eq!(run_response["id"], 2);
+
+    let content_text = run_response["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or("");
+
+    if run_response["result"]["isError"] == true
+        && content_text.contains("failed to launch browser")
+    {
+        return;
+    }
+
+    assert_eq!(
+        run_response["result"]["isError"], false,
+        "run_script failed: {content_text}"
+    );
+    let spawned: Value = serde_json::from_str(content_text).expect("parse script_id response");
+    let script_id = spawned["script_id"].as_str().expect("script_id present");
+    assert!(
+        script_id.starts_with("scr_"),
+        "script_id should have scr_ prefix: {script_id}"
+    );
+
+    server.send(&json!({
+        "jsonrpc": "2.0", "id": 3,
+        "method": "tools/call",
+        "params": { "name": "wait_for_scripts", "arguments": {} }
+    }));
+    let wait_response = server.read_response();
+    assert_eq!(wait_response["result"]["isError"], false);
+
+    let results: Vec<Value> = serde_json::from_str(
+        wait_response["result"]["content"][0]["text"]
+            .as_str()
+            .expect("result text"),
+    )
+    .expect("parse results");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0]["script_id"], script_id);
+    assert_eq!(results[0]["status"], "Completed");
+    assert_eq!(results[0]["extracted_data"][0], 7);
+    assert_eq!(results[0]["yielded_data"][0], "ok");
+
+    server.send(&json!({
+        "jsonrpc": "2.0", "id": 4,
+        "method": "tools/call",
+        "params": { "name": "list_scripts", "arguments": {} }
+    }));
+    let alive = server.read_response();
+    assert_eq!(
+        alive["id"], 4,
+        "server must still be alive after run_script"
+    );
+
+    server.shutdown();
+}
+
+#[test]
 fn stdio_server_supports_line_delimited_jsonrpc() {
     let mut server = TestServer::spawn();
 

--- a/crates/cli/tests/mcp_stdio.rs
+++ b/crates/cli/tests/mcp_stdio.rs
@@ -261,8 +261,8 @@ fn stdio_server_run_script_returns_script_id_and_survives() {
                 },
                 "limits": {
                     "max_steps": 10, "max_timeout_secs": 30,
-                    "max_output_bytes": 1048576, "max_parallel_branches": 2,
-                    "max_script_size_bytes": 65536, "max_nesting_depth": 5,
+                    "max_output_bytes": 1_048_576, "max_parallel_branches": 2,
+                    "max_script_size_bytes": 65_536, "max_nesting_depth": 5,
                     "per_step_timeout_secs": 10
                 }
             }

--- a/crates/cli/tests/mcp_stdio.rs
+++ b/crates/cli/tests/mcp_stdio.rs
@@ -160,7 +160,7 @@ fn stdio_server_handles_initialize_list_and_tool_call() {
     assert!(names.contains(&"run_goal"));
     assert!(!names.contains(&"fork"));
     assert!(!names.contains(&"list_builtin_tools"));
-    assert_eq!(names.len(), 18);
+    assert_eq!(names.len(), 25);
 
     server.send(&json!({
         "jsonrpc": "2.0",
@@ -259,7 +259,7 @@ fn stdio_server_supports_line_delimited_jsonrpc() {
     assert_eq!(response["id"], 21);
     assert!(names.contains(&"navigate"));
     assert!(names.contains(&"run_goal"));
-    assert_eq!(names.len(), 18);
+    assert_eq!(names.len(), 25);
 
     server.shutdown();
 }

--- a/crates/core/src/effect.rs
+++ b/crates/core/src/effect.rs
@@ -1,5 +1,7 @@
 use serde_json::Value;
 
+use crate::script_types::{ScriptCancelSpec, ScriptStatusSpec, ScriptTask, ScriptWaitSpec};
+
 /// Control-flow instruction returned by a tool handler.
 #[derive(Debug, Clone)]
 pub enum ToolEffect {
@@ -16,6 +18,14 @@ pub enum ToolEffect {
     /// Tool requests a read-only snapshot of running sub-agents. Never joins
     /// or cancels — safe to call between steps.
     Status(StatusSpec),
+    /// Tool requests running a script with the given task specification.
+    RunScript(ScriptTask),
+    /// Tool requests waiting for scripts to finish.
+    ScriptWait(ScriptWaitSpec),
+    /// Tool requests cancelling a running script.
+    ScriptCancel(ScriptCancelSpec),
+    /// Tool requests a read-only snapshot of script status.
+    ScriptStatus(ScriptStatusSpec),
 }
 
 impl ToolEffect {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod event;
 pub mod message;
 pub mod observer;
 pub mod outcome;
+pub mod script_types;
 pub mod tool_spec;
 pub mod traits;
 
@@ -19,5 +20,9 @@ pub use event::AssistantEvent;
 pub use message::{ContentBlock, ConversationMessage, MessageRole, TokenUsage};
 pub use observer::RuntimeObserver;
 pub use outcome::ToolOutcome;
+pub use script_types::{
+    ScriptCancelSpec, ScriptLimits, ScriptResult, ScriptState, ScriptStatus, ScriptStatusSpec,
+    ScriptTask, ScriptWaitSpec,
+};
 pub use tool_spec::ToolSpec;
 pub use traits::ToolExecutor;

--- a/crates/core/src/script_types.rs
+++ b/crates/core/src/script_types.rs
@@ -1,0 +1,76 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// A script task to be executed. The `script` field contains the raw JSON
+/// representation of the script (not the parsed AST) to avoid circular
+/// dependencies between core and the script crate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScriptTask {
+    pub script: Value,
+    pub save_as: Option<String>,
+    pub limits: ScriptLimits,
+}
+
+/// Runtime state of an executing script.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScriptState {
+    pub script_id: String,
+    pub status: ScriptStatus,
+    pub step: usize,
+    pub total_steps: Option<usize>,
+    pub current_url: Option<String>,
+    pub items_collected: usize,
+    pub elapsed_secs: f64,
+    pub errors_caught: usize,
+    pub yielded_data: Vec<Value>,
+}
+
+/// Status of a script execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ScriptStatus {
+    Pending,
+    Running,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+/// Final result of a script execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScriptResult {
+    pub script_id: String,
+    pub status: ScriptStatus,
+    pub extracted_data: Vec<Value>,
+    pub yielded_data: Vec<Value>,
+    pub steps_executed: usize,
+    pub elapsed_secs: f64,
+    pub error: Option<String>,
+}
+
+/// Execution limits for a script.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScriptLimits {
+    pub max_steps: usize,
+    pub max_timeout_secs: u64,
+    pub max_output_bytes: usize,
+    pub max_parallel_branches: usize,
+    pub per_step_timeout_secs: u64,
+}
+
+/// Parameters for waiting on script execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScriptWaitSpec {
+    pub script_ids: Option<Vec<String>>,
+}
+
+/// Parameters for cancelling a script.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScriptCancelSpec {
+    pub script_id: String,
+}
+
+/// Parameters for querying script status.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScriptStatusSpec {
+    pub script_id: String,
+}

--- a/crates/core/src/script_types.rs
+++ b/crates/core/src/script_types.rs
@@ -53,8 +53,20 @@ pub struct ScriptLimits {
     pub max_steps: usize,
     pub max_timeout_secs: u64,
     pub max_output_bytes: usize,
+    #[serde(default = "default_max_script_size_bytes")]
+    pub max_script_size_bytes: usize,
     pub max_parallel_branches: usize,
+    #[serde(default = "default_max_nesting_depth")]
+    pub max_nesting_depth: usize,
     pub per_step_timeout_secs: u64,
+}
+
+const fn default_max_script_size_bytes() -> usize {
+    1_048_576
+}
+
+const fn default_max_nesting_depth() -> usize {
+    10
 }
 
 /// Parameters for waiting on script execution.

--- a/crates/mcp-server/src/server.rs
+++ b/crates/mcp-server/src/server.rs
@@ -7,6 +7,7 @@ use acrawl_core::{
     ApiClient, ApiRequest, AssistantEvent, ContentBlock, ConversationMessage, MessageRole,
     RuntimeError, TokenUsage, ToolEffect, ToolSpec,
 };
+use agent::script_manager::ScriptManager;
 use agent::{mvp_tool_specs, ToolRegistry};
 use agent::{CrawlResult, CrawlerAgent};
 use api::provider::{model_api_id, ProviderClient, ProviderRegistry};
@@ -32,6 +33,16 @@ const EXCLUDED_TOOLS: &[&str] = &[
     "wait_for_subagents",
     "cancel_subagent",
     "subagent_status",
+];
+
+const SCRIPT_TOOLS: &[&str] = &[
+    "run_script",
+    "script_status",
+    "wait_for_scripts",
+    "cancel_script",
+    "save_script",
+    "list_scripts",
+    "read_script",
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -244,6 +255,98 @@ fn execute_browser_tool(
             Err(e) => Err(e.to_string()),
         }
     })
+}
+
+fn execute_script_tool(
+    name: &str,
+    input: &Value,
+    script_manager: &mut ScriptManager,
+    browser: &mut Option<BrowserContext>,
+    rt: &tokio::runtime::Runtime,
+) -> Result<String, String> {
+    match name {
+        "save_script" => match agent::tools::save_script::execute(input) {
+            Ok(ToolEffect::Reply(output)) => Ok(output),
+            Ok(_) => Err("save_script returned unexpected effect".to_string()),
+            Err(e) => Err(e.to_string()),
+        },
+        "list_scripts" => match agent::tools::list_scripts::execute(input) {
+            Ok(ToolEffect::Reply(output)) => Ok(output),
+            Ok(_) => Err("list_scripts returned unexpected effect".to_string()),
+            Err(e) => Err(e.to_string()),
+        },
+        "read_script" => match agent::tools::read_script::execute(input) {
+            Ok(ToolEffect::Reply(output)) => Ok(output),
+            Ok(_) => Err("read_script returned unexpected effect".to_string()),
+            Err(e) => Err(e.to_string()),
+        },
+        "run_script" => {
+            let task = match agent::tools::run_script::execute(input) {
+                Ok(ToolEffect::RunScript(task)) => task,
+                Ok(_) => return Err("run_script returned unexpected effect".to_string()),
+                Err(e) => return Err(e.to_string()),
+            };
+
+            // Ensure browser is initialized for script execution
+            if browser.is_none() {
+                match rt.block_on(PlaywrightBridge::new()) {
+                    Ok(bridge) => {
+                        let shared = std::sync::Arc::new(tokio::sync::Mutex::new(
+                            Box::new(bridge) as Box<dyn BrowserBackend + Send>
+                        ));
+                        *browser = Some(BrowserContext::new(shared));
+                    }
+                    Err(e) => {
+                        return Err(format!("failed to launch browser for script: {e}"));
+                    }
+                }
+            }
+
+            let browser_ctx = browser.as_ref().unwrap().clone();
+            match script_manager.spawn_script(task, browser_ctx) {
+                Ok(script_id) => Ok(json!({"script_id": script_id}).to_string()),
+                Err(e) => Err(e.to_string()),
+            }
+        }
+        "script_status" => {
+            let spec = match agent::tools::script_status::execute(input) {
+                Ok(ToolEffect::ScriptStatus(spec)) => spec,
+                Ok(_) => return Err("script_status returned unexpected effect".to_string()),
+                Err(e) => return Err(e.to_string()),
+            };
+            match script_manager.get_status(&spec.script_id) {
+                Ok(state) => serde_json::to_string(&state)
+                    .map_err(|e| format!("failed to serialize script state: {e}")),
+                Err(e) => Err(e.to_string()),
+            }
+        }
+        "wait_for_scripts" => {
+            let spec = match agent::tools::wait_for_scripts::execute(input) {
+                Ok(ToolEffect::ScriptWait(spec)) => spec,
+                Ok(_) => return Err("wait_for_scripts returned unexpected effect".to_string()),
+                Err(e) => return Err(e.to_string()),
+            };
+            rt.block_on(async {
+                match script_manager.wait_for_scripts(spec.script_ids).await {
+                    Ok(results) => serde_json::to_string(&results)
+                        .map_err(|e| format!("failed to serialize script results: {e}")),
+                    Err(e) => Err(e.to_string()),
+                }
+            })
+        }
+        "cancel_script" => {
+            let spec = match agent::tools::cancel_script::execute(input) {
+                Ok(ToolEffect::ScriptCancel(spec)) => spec,
+                Ok(_) => return Err("cancel_script returned unexpected effect".to_string()),
+                Err(e) => return Err(e.to_string()),
+            };
+            match script_manager.cancel_script(&spec.script_id) {
+                Ok(()) => Ok(format!("Script '{}' cancelled", spec.script_id)),
+                Err(e) => Err(e.to_string()),
+            }
+        }
+        _ => Err(format!("unknown script tool: {name}")),
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -802,6 +905,7 @@ fn handle_tools_call(
     params: Option<Value>,
     registry: &ToolRegistry,
     browser: &mut Option<BrowserContext>,
+    script_manager: &mut ScriptManager,
     rt: &tokio::runtime::Runtime,
 ) {
     let Some(params) = params else {
@@ -837,6 +941,36 @@ fn handle_tools_call(
         .collect();
     if !valid_browser_tools.contains(name) {
         send_error(id, -32601, format!("unknown tool: {name}"));
+        return;
+    }
+
+    if SCRIPT_TOOLS.contains(&name) {
+        match execute_script_tool(name, &arguments, script_manager, browser, rt) {
+            Ok(output) => {
+                let result = json!({
+                    "content": [{ "type": "text", "text": output }],
+                    "isError": false,
+                });
+                send_response(&JsonRpcResponse {
+                    jsonrpc: "2.0".to_string(),
+                    id,
+                    result: Some(result),
+                    error: None,
+                });
+            }
+            Err(message) => {
+                let result = json!({
+                    "content": [{ "type": "text", "text": format!("Error: {message}") }],
+                    "isError": true,
+                });
+                send_response(&JsonRpcResponse {
+                    jsonrpc: "2.0".to_string(),
+                    id,
+                    result: Some(result),
+                    error: None,
+                });
+            }
+        }
         return;
     }
 
@@ -902,6 +1036,9 @@ pub fn run_mcp_server() {
 
     let mut browser: Option<BrowserContext> = None;
     let registry = ToolRegistry::new_with_core_tools();
+    let settings = runtime::load_settings();
+    let script_settings = settings.script.unwrap_or_default();
+    let mut script_manager = ScriptManager::new(script_settings);
 
     let stdin = io::stdin().lock();
     let mut reader = BufReader::new(stdin);
@@ -940,7 +1077,14 @@ pub fn run_mcp_server() {
             "notifications/initialized" => {}
             "tools/list" => tools_list_response(request.id),
             "tools/call" => {
-                handle_tools_call(request.id, request.params, &registry, &mut browser, &rt);
+                handle_tools_call(
+                    request.id,
+                    request.params,
+                    &registry,
+                    &mut browser,
+                    &mut script_manager,
+                    &rt,
+                );
             }
             method => {
                 send_error(request.id, -32601, format!("method not found: {method}"));
@@ -1023,16 +1167,23 @@ mod tests {
     }
 
     #[test]
-    fn tools_list_has_17_browser_tools_plus_run_goal() {
+    fn tools_list_has_24_nonexcluded_tools_plus_run_goal() {
         let browser_specs: Vec<_> = mvp_tool_specs()
             .into_iter()
             .filter(|spec| !EXCLUDED_TOOLS.contains(&spec.name))
             .collect();
-        assert_eq!(browser_specs.len(), 17);
+        assert_eq!(browser_specs.len(), 24);
         let names: BTreeSet<&str> = browser_specs.iter().map(|s| s.name).collect();
         assert!(names.contains("navigate"));
         assert!(names.contains("click"));
         assert!(names.contains("screenshot"));
+        assert!(names.contains("run_script"));
+        assert!(names.contains("script_status"));
+        assert!(names.contains("wait_for_scripts"));
+        assert!(names.contains("cancel_script"));
+        assert!(names.contains("save_script"));
+        assert!(names.contains("list_scripts"));
+        assert!(names.contains("read_script"));
         assert!(!names.contains("fork"));
         assert!(!names.contains("wait_for_subagents"));
     }

--- a/crates/mcp-server/src/server.rs
+++ b/crates/mcp-server/src/server.rs
@@ -303,7 +303,7 @@ fn execute_script_tool(
             }
 
             let browser_ctx = browser.as_ref().unwrap().clone();
-            match script_manager.spawn_script(task, browser_ctx) {
+            match rt.block_on(async { script_manager.spawn_script(task, browser_ctx) }) {
                 Ok(script_id) => Ok(json!({"script_id": script_id}).to_string()),
                 Err(e) => Err(e.to_string()),
             }

--- a/crates/mcp-server/src/server.rs
+++ b/crates/mcp-server/src/server.rs
@@ -900,6 +900,7 @@ fn handle_run_goal(id: Option<Value>, arguments: Value) {
     }
 }
 
+#[allow(clippy::too_many_lines)]
 fn handle_tools_call(
     id: Option<Value>,
     params: Option<Value>,

--- a/crates/runtime/src/settings.rs
+++ b/crates/runtime/src/settings.rs
@@ -16,7 +16,7 @@ pub struct ScriptSettings {
     #[serde(default)]
     pub max_timeout_secs: Option<u64>,
 
-    /// Maximum output size in bytes (default: 10_485_760 = 10MB)
+    /// Maximum output size in bytes (default: `10_485_760` = 10MB)
     #[serde(default)]
     pub max_output_bytes: Option<usize>,
 
@@ -32,7 +32,7 @@ pub struct ScriptSettings {
     #[serde(default)]
     pub per_step_timeout_secs: Option<u64>,
 
-    /// Maximum script size in bytes (default: 1_048_576 = 1MB)
+    /// Maximum script size in bytes (default: `1_048_576` = 1MB)
     #[serde(default)]
     pub max_script_size_bytes: Option<usize>,
 

--- a/crates/runtime/src/settings.rs
+++ b/crates/runtime/src/settings.rs
@@ -5,6 +5,62 @@ use std::path::PathBuf;
 
 use acrawl_core::config_home_dir as core_config_home_dir;
 
+/// Script resource limits and configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ScriptSettings {
+    /// Maximum number of script execution steps (default: 200)
+    #[serde(default)]
+    pub max_steps: Option<usize>,
+
+    /// Maximum timeout in seconds for script execution (default: 300)
+    #[serde(default)]
+    pub max_timeout_secs: Option<u64>,
+
+    /// Maximum output size in bytes (default: 10_485_760 = 10MB)
+    #[serde(default)]
+    pub max_output_bytes: Option<usize>,
+
+    /// Maximum number of parallel branches (default: 10)
+    #[serde(default)]
+    pub max_parallel_branches: Option<usize>,
+
+    /// Maximum number of concurrent scripts (default: 5)
+    #[serde(default)]
+    pub max_concurrent_scripts: Option<usize>,
+
+    /// Timeout in seconds per individual step (default: 30)
+    #[serde(default)]
+    pub per_step_timeout_secs: Option<u64>,
+
+    /// Maximum script size in bytes (default: 1_048_576 = 1MB)
+    #[serde(default)]
+    pub max_script_size_bytes: Option<usize>,
+
+    /// Maximum nesting depth for script calls (default: 10)
+    #[serde(default)]
+    pub max_nesting_depth: Option<usize>,
+
+    /// Directory for storing scripts (default: ~/.acrawl/scripts/)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scripts_dir: Option<PathBuf>,
+}
+
+impl Default for ScriptSettings {
+    fn default() -> Self {
+        Self {
+            max_steps: Some(200),
+            max_timeout_secs: Some(300),
+            max_output_bytes: Some(10_485_760),
+            max_parallel_branches: Some(10),
+            max_concurrent_scripts: Some(5),
+            per_step_timeout_secs: Some(30),
+            max_script_size_bytes: Some(1_048_576),
+            max_nesting_depth: Some(10),
+            scripts_dir: Some(core_config_home_dir().join("scripts")),
+        }
+    }
+}
+
 /// Settings loaded from settings.json configuration file.
 /// All fields are optional with serde defaults to support partial JSON files.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -88,6 +144,10 @@ pub struct Settings {
     /// Compaction: enable LLM-powered summarization (default: false)
     #[serde(default)]
     pub compaction_llm_summarization: Option<bool>,
+
+    /// Script resource limits and configuration
+    #[serde(default)]
+    pub script: Option<ScriptSettings>,
 }
 
 impl Default for Settings {
@@ -113,6 +173,7 @@ impl Default for Settings {
             compaction_preserve_recent_messages_floor: None,
             compaction_max_summary_chars: None,
             compaction_llm_summarization: None,
+            script: Some(ScriptSettings::default()),
         }
     }
 }
@@ -389,6 +450,7 @@ mod tests {
             compaction_preserve_recent_messages_floor: None,
             compaction_max_summary_chars: None,
             compaction_llm_summarization: None,
+            script: Some(ScriptSettings::default()),
         };
 
         save_settings(&original).expect("Failed to save settings");
@@ -594,6 +656,7 @@ mod tests {
             compaction_preserve_recent_messages_floor: None,
             compaction_max_summary_chars: None,
             compaction_llm_summarization: None,
+            script: Some(ScriptSettings::default()),
         })
         .expect("save settings");
 
@@ -656,6 +719,7 @@ mod tests {
             compaction_preserve_recent_messages_floor: None,
             compaction_max_summary_chars: None,
             compaction_llm_summarization: None,
+            script: Some(ScriptSettings::default()),
         };
 
         save_settings(&original).expect("Failed to save settings");
@@ -718,6 +782,7 @@ mod tests {
             compaction_preserve_recent_messages_floor: None,
             compaction_max_summary_chars: None,
             compaction_llm_summarization: None,
+            script: None,
         };
 
         assert_eq!(settings_get_max_concurrent_per_parent(&settings), 5);

--- a/crates/script/Cargo.toml
+++ b/crates/script/Cargo.toml
@@ -12,5 +12,8 @@ serde_json = "1"
 thiserror = "1"
 tracing = "0.1"
 
+[dev-dependencies]
+tempfile = "3"
+
 [lints]
 workspace = true

--- a/crates/script/Cargo.toml
+++ b/crates/script/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "script"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[dependencies]
+acrawl-core = { path = "../core" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "1"
+tracing = "0.1"
+
+[lints]
+workspace = true

--- a/crates/script/src/error.rs
+++ b/crates/script/src/error.rs
@@ -1,2 +1,31 @@
 //! Error types for the script crate.
-//! TODO: implement
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ScriptParseError {
+    #[error("failed to deserialize script JSON: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("unsupported schema_version {found}; expected {expected}")]
+    WrongSchemaVersion { found: u32, expected: u32 },
+    #[error("invalid script structure: {0}")]
+    Structural(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ValidationError {
+    #[error("unsupported schema_version {found}; expected {expected}")]
+    WrongSchemaVersion { found: u32, expected: u32 },
+    #[error("unknown tool `{tool}`")]
+    UnknownTool { tool: String },
+    #[error("nesting depth {depth} exceeds maximum {max}")]
+    ExcessiveNesting { depth: usize, max: usize },
+    #[error("script size {size_bytes} bytes exceeds maximum {max_bytes} bytes")]
+    ScriptTooLarge { size_bytes: usize, max_bytes: usize },
+    #[error("parallel branch count {branch_count} exceeds maximum {max}")]
+    TooManyParallelBranches { branch_count: usize, max: usize },
+    #[error("empty steps in {context}")]
+    EmptySteps { context: String },
+    #[error("undefined variable `{name}` in {context}")]
+    UndefinedVariable { name: String, context: String },
+}

--- a/crates/script/src/error.rs
+++ b/crates/script/src/error.rs
@@ -1,0 +1,2 @@
+//! Error types for the script crate.
+//! TODO: implement

--- a/crates/script/src/grammar.rs
+++ b/crates/script/src/grammar.rs
@@ -1,0 +1,97 @@
+//! Grammar definitions for the Autonomous Script Protocol.
+
+use serde::{Deserialize, Serialize};
+
+pub const SCHEMA_VERSION: u32 = 1;
+
+pub const ALLOWED_TOOLS: &[&str] = &[
+    "navigate",
+    "click",
+    "click_at",
+    "fill_form",
+    "page_map",
+    "read_content",
+    "screenshot",
+    "go_back",
+    "scroll",
+    "wait",
+    "select_option",
+    "execute_js",
+    "hover",
+    "press_key",
+    "switch_tab",
+    "list_resources",
+    "save_file",
+];
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScriptDefinition {
+    pub schema_version: u32,
+    pub name: Option<String>,
+    pub steps: Vec<ScriptNode>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ScriptNode {
+    ToolCall {
+        tool: String,
+        input: serde_json::Value,
+        output: Option<String>,
+    },
+    Assign {
+        variable: String,
+        value: Expression,
+    },
+    Collect {
+        value: Expression,
+    },
+    Yield {
+        value: Expression,
+    },
+    ForLoop {
+        variable: String,
+        from: Expression,
+        to: Expression,
+        steps: Vec<ScriptNode>,
+    },
+    ForEach {
+        variable: String,
+        iterable: Expression,
+        steps: Vec<ScriptNode>,
+    },
+    WhileLoop {
+        condition: Expression,
+        steps: Vec<ScriptNode>,
+    },
+    IfElse {
+        condition: Expression,
+        then_steps: Vec<ScriptNode>,
+        else_steps: Option<Vec<ScriptNode>>,
+    },
+    TryCatch {
+        try_steps: Vec<ScriptNode>,
+        catch_steps: Option<Vec<ScriptNode>>,
+        finally_steps: Option<Vec<ScriptNode>>,
+        error_var: Option<String>,
+    },
+    Parallel {
+        branches: Vec<Vec<ScriptNode>>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Expression {
+    Literal(serde_json::Value),
+    Variable(String),
+    JsEval(String),
+    FieldAccess {
+        object: Box<Expression>,
+        field: String,
+    },
+    ArrayIndex {
+        array: Box<Expression>,
+        index: Box<Expression>,
+    },
+}

--- a/crates/script/src/grammar.rs
+++ b/crates/script/src/grammar.rs
@@ -81,7 +81,7 @@ pub enum ScriptNode {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind", content = "value", rename_all = "snake_case")]
 pub enum Expression {
     Literal(serde_json::Value),
     Variable(String),

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -1,0 +1,10 @@
+//! Autonomous Script Protocol — parser and AST for acrawl scripts.
+//!
+//! This crate provides parsing and AST representation for acrawl's script language.
+//! It is parser/AST-only with no runtime, browser, or tokio dependencies.
+//! The executor lives in `crates/agent/src/script_executor/`.
+
+pub mod error;
+pub mod grammar;
+pub mod parser;
+pub mod persistence;

--- a/crates/script/src/parser.rs
+++ b/crates/script/src/parser.rs
@@ -1,0 +1,2 @@
+//! Parser for the Autonomous Script Protocol.
+//! TODO: implement

--- a/crates/script/src/parser.rs
+++ b/crates/script/src/parser.rs
@@ -185,13 +185,17 @@ fn expression_to_value(expression: &Expression) -> serde_json::Value {
         }),
         Expression::FieldAccess { object, field } => serde_json::json!({
             "kind": "field_access",
-            "object": expression_to_value(object),
-            "field": field,
+            "value": {
+                "object": expression_to_value(object),
+                "field": field,
+            },
         }),
         Expression::ArrayIndex { array, index } => serde_json::json!({
             "kind": "array_index",
-            "array": expression_to_value(array),
-            "index": expression_to_value(index),
+            "value": {
+                "array": expression_to_value(array),
+                "index": expression_to_value(index),
+            },
         }),
     }
 }
@@ -1055,5 +1059,84 @@ mod tests {
         };
 
         assert_eq!(validate_script(&script, &limits()), Ok(()));
+    }
+
+    #[test]
+    fn parse_script_expression_round_trip() {
+        let script = ScriptDefinition {
+            schema_version: SCHEMA_VERSION,
+            name: Some("round-trip".to_string()),
+            steps: vec![
+                ScriptNode::ToolCall {
+                    tool: "navigate".to_string(),
+                    input: json!({"url": "https://example.com"}),
+                    output: Some("nav_result".to_string()),
+                },
+                ScriptNode::Assign {
+                    variable: "copied".to_string(),
+                    value: Expression::Variable("nav_result".to_string()),
+                },
+                ScriptNode::Assign {
+                    variable: "literal_value".to_string(),
+                    value: Expression::Literal(json!(42)),
+                },
+                ScriptNode::Assign {
+                    variable: "evaluated".to_string(),
+                    value: Expression::JsEval("2+2".to_string()),
+                },
+                ScriptNode::Assign {
+                    variable: "title".to_string(),
+                    value: Expression::FieldAccess {
+                        object: Box::new(Expression::Variable("nav_result".to_string())),
+                        field: "title".to_string(),
+                    },
+                },
+                ScriptNode::Collect {
+                    value: Expression::ArrayIndex {
+                        array: Box::new(Expression::Variable("nav_result".to_string())),
+                        index: Box::new(Expression::Literal(json!(0))),
+                    },
+                },
+            ],
+        };
+
+        let json = serde_json::to_value(&script).unwrap();
+        let parsed = parse_script(&json).unwrap();
+
+        assert!(matches!(
+            &parsed.steps[1],
+            ScriptNode::Assign {
+                value: Expression::Variable(name),
+                ..
+            } if name == "nav_result"
+        ));
+        assert!(matches!(
+            &parsed.steps[2],
+            ScriptNode::Assign {
+                value: Expression::Literal(value),
+                ..
+            } if value == &json!(42)
+        ));
+        assert!(matches!(
+            &parsed.steps[3],
+            ScriptNode::Assign {
+                value: Expression::JsEval(code),
+                ..
+            } if code == "2+2"
+        ));
+        assert!(matches!(
+            &parsed.steps[4],
+            ScriptNode::Assign {
+                value: Expression::FieldAccess { object, field },
+                ..
+            } if matches!(object.as_ref(), Expression::Variable(name) if name == "nav_result") && field == "title"
+        ));
+        assert!(matches!(
+            &parsed.steps[5],
+            ScriptNode::Collect {
+                value: Expression::ArrayIndex { array, index },
+            } if matches!(array.as_ref(), Expression::Variable(name) if name == "nav_result")
+                && matches!(index.as_ref(), Expression::Literal(value) if value == &json!(0))
+        ));
     }
 }

--- a/crates/script/src/parser.rs
+++ b/crates/script/src/parser.rs
@@ -216,6 +216,7 @@ fn validate_steps(
     }
 }
 
+#[allow(clippy::too_many_lines)]
 fn validate_node(
     node: &ScriptNode,
     depth: usize,

--- a/crates/script/src/parser.rs
+++ b/crates/script/src/parser.rs
@@ -1,2 +1,649 @@
 //! Parser for the Autonomous Script Protocol.
-//! TODO: implement
+
+use std::collections::HashSet;
+
+use acrawl_core::ScriptLimits;
+
+use crate::{
+    error::{ScriptParseError, ValidationError},
+    grammar::{Expression, ScriptDefinition, ScriptNode, ALLOWED_TOOLS, SCHEMA_VERSION},
+};
+
+pub fn parse_script(json: &serde_json::Value) -> Result<ScriptDefinition, ScriptParseError> {
+    let script = serde_json::from_value::<ScriptDefinition>(json.clone())?;
+
+    if script.schema_version != SCHEMA_VERSION {
+        return Err(ScriptParseError::WrongSchemaVersion {
+            found: script.schema_version,
+            expected: SCHEMA_VERSION,
+        });
+    }
+
+    if !json.is_object() {
+        return Err(ScriptParseError::Structural(
+            "script root must be a JSON object".to_string(),
+        ));
+    }
+
+    Ok(script)
+}
+
+pub fn validate_script(
+    script: &ScriptDefinition,
+    limits: &ScriptLimits,
+) -> Result<(), Vec<ValidationError>> {
+    let mut errors = Vec::new();
+
+    if script.schema_version != SCHEMA_VERSION {
+        errors.push(ValidationError::WrongSchemaVersion {
+            found: script.schema_version,
+            expected: SCHEMA_VERSION,
+        });
+    }
+
+    match serde_json::to_vec(&script_to_value(script)) {
+        Ok(bytes) if bytes.len() > limits.max_script_size_bytes => {
+            errors.push(ValidationError::ScriptTooLarge {
+                size_bytes: bytes.len(),
+                max_bytes: limits.max_script_size_bytes,
+            });
+        }
+        Ok(_) => {}
+        Err(error) => errors.push(ValidationError::EmptySteps {
+            context: format!("failed to serialize script for size validation: {error}"),
+        }),
+    }
+
+    if script.steps.is_empty() {
+        errors.push(ValidationError::EmptySteps {
+            context: "top-level script steps".to_string(),
+        });
+    }
+
+    let mut scope = HashSet::new();
+    validate_steps(
+        &script.steps,
+        0,
+        limits,
+        &mut scope,
+        "top-level script steps",
+        &mut errors,
+    );
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
+}
+
+fn script_to_value(script: &ScriptDefinition) -> serde_json::Value {
+    serde_json::json!({
+        "schema_version": script.schema_version,
+        "name": script.name,
+        "steps": script.steps.iter().map(node_to_value).collect::<Vec<_>>(),
+    })
+}
+
+fn node_to_value(node: &ScriptNode) -> serde_json::Value {
+    match node {
+        ScriptNode::ToolCall {
+            tool,
+            input,
+            output,
+        } => serde_json::json!({
+            "type": "tool_call",
+            "tool": tool,
+            "input": input,
+            "output": output,
+        }),
+        ScriptNode::Assign { variable, value } => serde_json::json!({
+            "type": "assign",
+            "variable": variable,
+            "value": expression_to_value(value),
+        }),
+        ScriptNode::Collect { value } => serde_json::json!({
+            "type": "collect",
+            "value": expression_to_value(value),
+        }),
+        ScriptNode::Yield { value } => serde_json::json!({
+            "type": "yield",
+            "value": expression_to_value(value),
+        }),
+        ScriptNode::ForLoop {
+            variable,
+            from,
+            to,
+            steps,
+        } => serde_json::json!({
+            "type": "for_loop",
+            "variable": variable,
+            "from": expression_to_value(from),
+            "to": expression_to_value(to),
+            "steps": steps.iter().map(node_to_value).collect::<Vec<_>>(),
+        }),
+        ScriptNode::ForEach {
+            variable,
+            iterable,
+            steps,
+        } => serde_json::json!({
+            "type": "for_each",
+            "variable": variable,
+            "iterable": expression_to_value(iterable),
+            "steps": steps.iter().map(node_to_value).collect::<Vec<_>>(),
+        }),
+        ScriptNode::WhileLoop { condition, steps } => serde_json::json!({
+            "type": "while_loop",
+            "condition": expression_to_value(condition),
+            "steps": steps.iter().map(node_to_value).collect::<Vec<_>>(),
+        }),
+        ScriptNode::IfElse {
+            condition,
+            then_steps,
+            else_steps,
+        } => serde_json::json!({
+            "type": "if_else",
+            "condition": expression_to_value(condition),
+            "then_steps": then_steps.iter().map(node_to_value).collect::<Vec<_>>(),
+            "else_steps": else_steps.as_ref().map(|steps| steps.iter().map(node_to_value).collect::<Vec<_>>()),
+        }),
+        ScriptNode::TryCatch {
+            try_steps,
+            catch_steps,
+            finally_steps,
+            error_var,
+        } => serde_json::json!({
+            "type": "try_catch",
+            "try_steps": try_steps.iter().map(node_to_value).collect::<Vec<_>>(),
+            "catch_steps": catch_steps.as_ref().map(|steps| steps.iter().map(node_to_value).collect::<Vec<_>>()),
+            "finally_steps": finally_steps.as_ref().map(|steps| steps.iter().map(node_to_value).collect::<Vec<_>>()),
+            "error_var": error_var,
+        }),
+        ScriptNode::Parallel { branches } => serde_json::json!({
+            "type": "parallel",
+            "branches": branches
+                .iter()
+                .map(|branch| branch.iter().map(node_to_value).collect::<Vec<_>>())
+                .collect::<Vec<_>>(),
+        }),
+    }
+}
+
+fn expression_to_value(expression: &Expression) -> serde_json::Value {
+    match expression {
+        Expression::Literal(value) => serde_json::json!({
+            "kind": "literal",
+            "value": value,
+        }),
+        Expression::Variable(name) => serde_json::json!({
+            "kind": "variable",
+            "value": name,
+        }),
+        Expression::JsEval(code) => serde_json::json!({
+            "kind": "js_eval",
+            "value": code,
+        }),
+        Expression::FieldAccess { object, field } => serde_json::json!({
+            "kind": "field_access",
+            "object": expression_to_value(object),
+            "field": field,
+        }),
+        Expression::ArrayIndex { array, index } => serde_json::json!({
+            "kind": "array_index",
+            "array": expression_to_value(array),
+            "index": expression_to_value(index),
+        }),
+    }
+}
+
+fn validate_steps(
+    steps: &[ScriptNode],
+    depth: usize,
+    limits: &ScriptLimits,
+    scope: &mut HashSet<String>,
+    context: &str,
+    errors: &mut Vec<ValidationError>,
+) {
+    if steps.is_empty() {
+        errors.push(ValidationError::EmptySteps {
+            context: context.to_string(),
+        });
+        return;
+    }
+
+    for step in steps {
+        validate_node(step, depth, limits, scope, errors);
+    }
+}
+
+fn validate_node(
+    node: &ScriptNode,
+    depth: usize,
+    limits: &ScriptLimits,
+    scope: &mut HashSet<String>,
+    errors: &mut Vec<ValidationError>,
+) {
+    match node {
+        ScriptNode::ToolCall { tool, output, .. } => {
+            if !ALLOWED_TOOLS.contains(&tool.as_str()) {
+                errors.push(ValidationError::UnknownTool { tool: tool.clone() });
+            }
+            if let Some(output) = output {
+                scope.insert(output.clone());
+            }
+        }
+        ScriptNode::Assign { variable, value } => {
+            validate_expression(value, scope, &format!("assignment to `{variable}`"), errors);
+            scope.insert(variable.clone());
+        }
+        ScriptNode::Collect { value } => {
+            validate_expression(value, scope, "collect expression", errors);
+        }
+        ScriptNode::Yield { value } => {
+            validate_expression(value, scope, "yield expression", errors);
+        }
+        ScriptNode::ForLoop {
+            variable,
+            from,
+            to,
+            steps,
+        } => {
+            validate_expression(from, scope, &format!("for_loop `{variable}` from"), errors);
+            validate_expression(to, scope, &format!("for_loop `{variable}` to"), errors);
+            validate_nested_steps(
+                steps,
+                depth + 1,
+                limits,
+                scope,
+                variable,
+                &format!("for_loop `{variable}` body"),
+                errors,
+            );
+        }
+        ScriptNode::ForEach {
+            variable,
+            iterable,
+            steps,
+        } => {
+            validate_expression(
+                iterable,
+                scope,
+                &format!("for_each `{variable}` iterable"),
+                errors,
+            );
+            validate_nested_steps(
+                steps,
+                depth + 1,
+                limits,
+                scope,
+                variable,
+                &format!("for_each `{variable}` body"),
+                errors,
+            );
+        }
+        ScriptNode::WhileLoop { condition, steps } => {
+            validate_expression(condition, scope, "while_loop condition", errors);
+            validate_nested_steps(
+                steps,
+                depth + 1,
+                limits,
+                scope,
+                "",
+                "while_loop body",
+                errors,
+            );
+        }
+        ScriptNode::IfElse {
+            condition,
+            then_steps,
+            else_steps,
+        } => {
+            validate_expression(condition, scope, "if_else condition", errors);
+            validate_nested_steps(
+                then_steps,
+                depth + 1,
+                limits,
+                scope,
+                "",
+                "if_else then_steps",
+                errors,
+            );
+            if let Some(else_steps) = else_steps {
+                validate_nested_steps(
+                    else_steps,
+                    depth + 1,
+                    limits,
+                    scope,
+                    "",
+                    "if_else else_steps",
+                    errors,
+                );
+            }
+        }
+        ScriptNode::TryCatch {
+            try_steps,
+            catch_steps,
+            finally_steps,
+            error_var,
+        } => {
+            validate_nested_steps(
+                try_steps,
+                depth + 1,
+                limits,
+                scope,
+                "",
+                "try_catch try_steps",
+                errors,
+            );
+
+            if let Some(catch_steps) = catch_steps {
+                validate_nested_steps(
+                    catch_steps,
+                    depth + 1,
+                    limits,
+                    scope,
+                    error_var.as_deref().unwrap_or(""),
+                    "try_catch catch_steps",
+                    errors,
+                );
+            }
+
+            if let Some(finally_steps) = finally_steps {
+                validate_nested_steps(
+                    finally_steps,
+                    depth + 1,
+                    limits,
+                    scope,
+                    "",
+                    "try_catch finally_steps",
+                    errors,
+                );
+            }
+        }
+        ScriptNode::Parallel { branches } => {
+            if branches.len() > limits.max_parallel_branches {
+                errors.push(ValidationError::TooManyParallelBranches {
+                    branch_count: branches.len(),
+                    max: limits.max_parallel_branches,
+                });
+            }
+            if branches.is_empty() {
+                errors.push(ValidationError::EmptySteps {
+                    context: "parallel branches".to_string(),
+                });
+            }
+
+            let next_depth = depth + 1;
+            if next_depth > limits.max_nesting_depth {
+                errors.push(ValidationError::ExcessiveNesting {
+                    depth: next_depth,
+                    max: limits.max_nesting_depth,
+                });
+            }
+
+            for (index, branch) in branches.iter().enumerate() {
+                let mut branch_scope = scope.clone();
+                validate_steps(
+                    branch,
+                    next_depth,
+                    limits,
+                    &mut branch_scope,
+                    &format!("parallel branch {index}"),
+                    errors,
+                );
+            }
+        }
+    }
+}
+
+fn validate_nested_steps(
+    steps: &[ScriptNode],
+    next_depth: usize,
+    limits: &ScriptLimits,
+    scope: &HashSet<String>,
+    bound_variable: &str,
+    context: &str,
+    errors: &mut Vec<ValidationError>,
+) {
+    if next_depth > limits.max_nesting_depth {
+        errors.push(ValidationError::ExcessiveNesting {
+            depth: next_depth,
+            max: limits.max_nesting_depth,
+        });
+    }
+
+    let mut nested_scope = scope.clone();
+    if !bound_variable.is_empty() {
+        nested_scope.insert(bound_variable.to_string());
+    }
+    validate_steps(
+        steps,
+        next_depth,
+        limits,
+        &mut nested_scope,
+        context,
+        errors,
+    );
+}
+
+fn validate_expression(
+    expression: &Expression,
+    scope: &HashSet<String>,
+    context: &str,
+    errors: &mut Vec<ValidationError>,
+) {
+    match expression {
+        Expression::Literal(_) | Expression::JsEval(_) => {}
+        Expression::Variable(name) => {
+            if !scope.contains(name) {
+                errors.push(ValidationError::UndefinedVariable {
+                    name: name.clone(),
+                    context: context.to_string(),
+                });
+            }
+        }
+        Expression::FieldAccess { object, field } => {
+            validate_expression(
+                object,
+                scope,
+                &format!("{context} field access `{field}`"),
+                errors,
+            );
+        }
+        Expression::ArrayIndex { array, index } => {
+            validate_expression(array, scope, &format!("{context} array access"), errors);
+            validate_expression(index, scope, &format!("{context} array index"), errors);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use acrawl_core::ScriptLimits;
+    use serde_json::json;
+
+    use super::{parse_script, validate_script};
+    use crate::{
+        error::{ScriptParseError, ValidationError},
+        grammar::{Expression, ScriptDefinition, ScriptNode, SCHEMA_VERSION},
+    };
+
+    fn limits() -> ScriptLimits {
+        ScriptLimits {
+            max_steps: 100,
+            max_timeout_secs: 60,
+            max_output_bytes: 1024,
+            max_script_size_bytes: 10_000,
+            max_parallel_branches: 4,
+            max_nesting_depth: 3,
+            per_step_timeout_secs: 10,
+        }
+    }
+
+    #[test]
+    fn parse_script_accepts_valid_minimal_script() {
+        let json = json!({
+            "schema_version": SCHEMA_VERSION,
+            "name": "minimal",
+            "steps": [
+                {
+                    "type": "tool_call",
+                    "tool": "navigate",
+                    "input": {"url": "https://example.com"},
+                    "output": "page"
+                }
+            ]
+        });
+
+        let script = parse_script(&json).expect("script should parse");
+        assert_eq!(script.schema_version, SCHEMA_VERSION);
+        assert_eq!(script.steps.len(), 1);
+    }
+
+    #[test]
+    fn parse_script_rejects_wrong_schema_version() {
+        let json = json!({
+            "schema_version": 99,
+            "steps": []
+        });
+
+        let error = parse_script(&json).expect_err("schema version should fail");
+        assert!(matches!(
+            error,
+            ScriptParseError::WrongSchemaVersion {
+                found: 99,
+                expected: SCHEMA_VERSION,
+            }
+        ));
+    }
+
+    #[test]
+    fn validate_script_accepts_full_featured_script() {
+        let script = ScriptDefinition {
+            schema_version: SCHEMA_VERSION,
+            name: Some("full".to_string()),
+            steps: vec![
+                ScriptNode::ToolCall {
+                    tool: "navigate".to_string(),
+                    input: json!({"url": "https://example.com"}),
+                    output: Some("page".to_string()),
+                },
+                ScriptNode::Assign {
+                    variable: "items".to_string(),
+                    value: Expression::FieldAccess {
+                        object: Box::new(Expression::Variable("page".to_string())),
+                        field: "results".to_string(),
+                    },
+                },
+                ScriptNode::ForEach {
+                    variable: "item".to_string(),
+                    iterable: Expression::Variable("items".to_string()),
+                    steps: vec![ScriptNode::TryCatch {
+                        try_steps: vec![ScriptNode::IfElse {
+                            condition: Expression::JsEval("true".to_string()),
+                            then_steps: vec![ScriptNode::Collect {
+                                value: Expression::FieldAccess {
+                                    object: Box::new(Expression::Variable("item".to_string())),
+                                    field: "title".to_string(),
+                                },
+                            }],
+                            else_steps: Some(vec![ScriptNode::Yield {
+                                value: Expression::Variable("item".to_string()),
+                            }]),
+                        }],
+                        catch_steps: Some(vec![ScriptNode::Yield {
+                            value: Expression::Variable("err".to_string()),
+                        }]),
+                        finally_steps: Some(vec![ScriptNode::Parallel {
+                            branches: vec![
+                                vec![ScriptNode::ToolCall {
+                                    tool: "scroll".to_string(),
+                                    input: json!({"direction": "down", "pixels": 100}),
+                                    output: None,
+                                }],
+                                vec![ScriptNode::ToolCall {
+                                    tool: "wait".to_string(),
+                                    input: json!({"seconds": 1, "selector": "", "state": "attached"}),
+                                    output: None,
+                                }],
+                            ],
+                        }]),
+                        error_var: Some("err".to_string()),
+                    }],
+                },
+            ],
+        };
+
+        assert_eq!(validate_script(&script, &limits()), Ok(()));
+    }
+
+    #[test]
+    fn validate_script_rejects_unknown_tool() {
+        let script = ScriptDefinition {
+            schema_version: SCHEMA_VERSION,
+            name: None,
+            steps: vec![ScriptNode::ToolCall {
+                tool: "fork".to_string(),
+                input: json!({}),
+                output: None,
+            }],
+        };
+
+        let errors = validate_script(&script, &limits()).expect_err("unknown tool should fail");
+        assert!(errors.contains(&ValidationError::UnknownTool {
+            tool: "fork".to_string(),
+        }));
+    }
+
+    #[test]
+    fn validate_script_rejects_excessive_nesting() {
+        let script = ScriptDefinition {
+            schema_version: SCHEMA_VERSION,
+            name: None,
+            steps: vec![ScriptNode::ForLoop {
+                variable: "i".to_string(),
+                from: Expression::Literal(json!(0)),
+                to: Expression::Literal(json!(1)),
+                steps: vec![ScriptNode::WhileLoop {
+                    condition: Expression::JsEval("true".to_string()),
+                    steps: vec![ScriptNode::IfElse {
+                        condition: Expression::JsEval("true".to_string()),
+                        then_steps: vec![ScriptNode::Parallel {
+                            branches: vec![vec![ScriptNode::ToolCall {
+                                tool: "scroll".to_string(),
+                                input: json!({"direction": "down", "pixels": 10}),
+                                output: None,
+                            }]],
+                        }],
+                        else_steps: None,
+                    }],
+                }],
+            }],
+        };
+
+        let errors = validate_script(&script, &limits()).expect_err("nesting should fail");
+        assert!(errors.iter().any(|error| matches!(
+            error,
+            ValidationError::ExcessiveNesting { depth: 4, max: 3 }
+        )));
+    }
+
+    #[test]
+    fn validate_script_rejects_undefined_variable() {
+        let script = ScriptDefinition {
+            schema_version: SCHEMA_VERSION,
+            name: None,
+            steps: vec![ScriptNode::Assign {
+                variable: "value".to_string(),
+                value: Expression::Variable("missing".to_string()),
+            }],
+        };
+
+        let errors =
+            validate_script(&script, &limits()).expect_err("undefined variable should fail");
+        assert!(errors.contains(&ValidationError::UndefinedVariable {
+            name: "missing".to_string(),
+            context: "assignment to `value`".to_string(),
+        }));
+    }
+}

--- a/crates/script/src/parser.rs
+++ b/crates/script/src/parser.rs
@@ -646,4 +646,413 @@ mod tests {
             context: "assignment to `value`".to_string(),
         }));
     }
+
+    #[test]
+    fn validate_all_17_browser_tools_accepted() {
+        use crate::grammar::ALLOWED_TOOLS;
+
+        let steps: Vec<ScriptNode> = ALLOWED_TOOLS
+            .iter()
+            .map(|tool| ScriptNode::ToolCall {
+                tool: (*tool).to_string(),
+                input: json!({}),
+                output: None,
+            })
+            .collect();
+        assert_eq!(steps.len(), 17);
+
+        let script = ScriptDefinition {
+            schema_version: SCHEMA_VERSION,
+            name: Some("all_tools".to_string()),
+            steps,
+        };
+
+        assert_eq!(validate_script(&script, &limits()), Ok(()));
+    }
+
+    #[test]
+    fn validate_rejects_agent_control_tools() {
+        let agent_tools = [
+            "fork",
+            "wait_for_subagents",
+            "cancel_subagent",
+            "subagent_status",
+        ];
+
+        for tool_name in &agent_tools {
+            let script = ScriptDefinition {
+                schema_version: SCHEMA_VERSION,
+                name: None,
+                steps: vec![ScriptNode::ToolCall {
+                    tool: tool_name.to_string(),
+                    input: json!({}),
+                    output: None,
+                }],
+            };
+
+            let errors = validate_script(&script, &limits())
+                .expect_err(&format!("agent tool `{tool_name}` should be rejected"));
+            assert!(
+                errors.contains(&ValidationError::UnknownTool {
+                    tool: tool_name.to_string(),
+                }),
+                "expected UnknownTool for `{tool_name}`"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_rejects_script_tools() {
+        let script_tools = [
+            "run_script",
+            "script_status",
+            "cancel_script",
+            "wait_for_scripts",
+        ];
+
+        for tool_name in &script_tools {
+            let script = ScriptDefinition {
+                schema_version: SCHEMA_VERSION,
+                name: None,
+                steps: vec![ScriptNode::ToolCall {
+                    tool: tool_name.to_string(),
+                    input: json!({}),
+                    output: None,
+                }],
+            };
+
+            let errors = validate_script(&script, &limits())
+                .expect_err(&format!("script tool `{tool_name}` should be rejected"));
+            assert!(
+                errors.contains(&ValidationError::UnknownTool {
+                    tool: tool_name.to_string(),
+                }),
+                "expected UnknownTool for `{tool_name}`"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_script_rejects_version_2() {
+        let json = json!({
+            "schema_version": 2,
+            "steps": []
+        });
+
+        let error = parse_script(&json).expect_err("version 2 should be rejected");
+        assert!(matches!(
+            error,
+            ScriptParseError::WrongSchemaVersion {
+                found: 2,
+                expected: SCHEMA_VERSION,
+            }
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_too_many_parallel_branches() {
+        let branches: Vec<Vec<ScriptNode>> = (0..5)
+            .map(|_| {
+                vec![ScriptNode::ToolCall {
+                    tool: "scroll".to_string(),
+                    input: json!({"direction": "down", "pixels": 100}),
+                    output: None,
+                }]
+            })
+            .collect();
+
+        let script = ScriptDefinition {
+            schema_version: SCHEMA_VERSION,
+            name: None,
+            steps: vec![ScriptNode::Parallel { branches }],
+        };
+
+        let errors =
+            validate_script(&script, &limits()).expect_err("too many branches should fail");
+        assert!(errors.contains(&ValidationError::TooManyParallelBranches {
+            branch_count: 5,
+            max: 4,
+        }));
+    }
+
+    #[test]
+    fn validate_rejects_empty_top_level_steps() {
+        let script = ScriptDefinition {
+            schema_version: SCHEMA_VERSION,
+            name: None,
+            steps: vec![],
+        };
+
+        let errors = validate_script(&script, &limits()).expect_err("empty steps should fail");
+        assert!(errors.contains(&ValidationError::EmptySteps {
+            context: "top-level script steps".to_string(),
+        }));
+    }
+
+    #[test]
+    fn validate_rejects_empty_for_loop_body() {
+        let script = ScriptDefinition {
+            schema_version: SCHEMA_VERSION,
+            name: None,
+            steps: vec![ScriptNode::ForLoop {
+                variable: "i".to_string(),
+                from: Expression::Literal(json!(0)),
+                to: Expression::Literal(json!(5)),
+                steps: vec![],
+            }],
+        };
+
+        let errors =
+            validate_script(&script, &limits()).expect_err("empty for_loop body should fail");
+        assert!(errors.contains(&ValidationError::EmptySteps {
+            context: "for_loop `i` body".to_string(),
+        }));
+    }
+
+    #[test]
+    fn validate_rejects_empty_parallel_branches() {
+        let script = ScriptDefinition {
+            schema_version: SCHEMA_VERSION,
+            name: None,
+            steps: vec![ScriptNode::Parallel { branches: vec![] }],
+        };
+
+        let errors =
+            validate_script(&script, &limits()).expect_err("empty parallel branches should fail");
+        assert!(errors.contains(&ValidationError::EmptySteps {
+            context: "parallel branches".to_string(),
+        }));
+    }
+
+    #[test]
+    fn validate_rejects_script_too_large() {
+        let tiny_limits = ScriptLimits {
+            max_script_size_bytes: 50,
+            ..limits()
+        };
+
+        let script = ScriptDefinition {
+            schema_version: SCHEMA_VERSION,
+            name: Some("oversized_script_with_a_very_long_name_to_push_size".to_string()),
+            steps: vec![ScriptNode::ToolCall {
+                tool: "navigate".to_string(),
+                input: json!({"url": "https://example.com/a/very/long/path/to/ensure/size/exceeds/limit"}),
+                output: Some("result".to_string()),
+            }],
+        };
+
+        let errors =
+            validate_script(&script, &tiny_limits).expect_err("oversized script should fail");
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::ScriptTooLarge { .. })),
+            "expected ScriptTooLarge error, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_for_loop() {
+        let script = ScriptDefinition {
+            schema_version: SCHEMA_VERSION,
+            name: None,
+            steps: vec![ScriptNode::ForLoop {
+                variable: "page".to_string(),
+                from: Expression::Literal(json!(1)),
+                to: Expression::Literal(json!(10)),
+                steps: vec![ScriptNode::ToolCall {
+                    tool: "navigate".to_string(),
+                    input: json!({"url": "https://example.com"}),
+                    output: None,
+                }],
+            }],
+        };
+
+        assert_eq!(validate_script(&script, &limits()), Ok(()));
+    }
+
+    #[test]
+    fn validate_accepts_while_loop() {
+        let script = ScriptDefinition {
+            schema_version: SCHEMA_VERSION,
+            name: None,
+            steps: vec![ScriptNode::WhileLoop {
+                condition: Expression::JsEval("page < 10".to_string()),
+                steps: vec![ScriptNode::ToolCall {
+                    tool: "scroll".to_string(),
+                    input: json!({"direction": "down", "pixels": 500}),
+                    output: None,
+                }],
+            }],
+        };
+
+        assert_eq!(validate_script(&script, &limits()), Ok(()));
+    }
+
+    #[test]
+    fn validate_accepts_yield_only_script() {
+        let script = ScriptDefinition {
+            schema_version: SCHEMA_VERSION,
+            name: None,
+            steps: vec![ScriptNode::Yield {
+                value: Expression::Literal(json!({"status": "done"})),
+            }],
+        };
+
+        assert_eq!(validate_script(&script, &limits()), Ok(()));
+    }
+
+    #[test]
+    fn validate_loop_variable_accessible_in_body() {
+        let script = ScriptDefinition {
+            schema_version: SCHEMA_VERSION,
+            name: None,
+            steps: vec![ScriptNode::ForLoop {
+                variable: "idx".to_string(),
+                from: Expression::Literal(json!(0)),
+                to: Expression::Literal(json!(3)),
+                steps: vec![ScriptNode::Assign {
+                    variable: "current".to_string(),
+                    value: Expression::Variable("idx".to_string()),
+                }],
+            }],
+        };
+
+        assert_eq!(validate_script(&script, &limits()), Ok(()));
+    }
+
+    #[test]
+    fn validate_accepts_none_name() {
+        let script = ScriptDefinition {
+            schema_version: SCHEMA_VERSION,
+            name: None,
+            steps: vec![ScriptNode::ToolCall {
+                tool: "navigate".to_string(),
+                input: json!({"url": "https://example.com"}),
+                output: None,
+            }],
+        };
+
+        assert_eq!(validate_script(&script, &limits()), Ok(()));
+    }
+
+    #[test]
+    fn validate_accepts_assign_and_collect() {
+        let script = ScriptDefinition {
+            schema_version: SCHEMA_VERSION,
+            name: None,
+            steps: vec![
+                ScriptNode::ToolCall {
+                    tool: "read_content".to_string(),
+                    input: json!({"selector": "h1"}),
+                    output: Some("title".to_string()),
+                },
+                ScriptNode::Assign {
+                    variable: "processed".to_string(),
+                    value: Expression::FieldAccess {
+                        object: Box::new(Expression::Variable("title".to_string())),
+                        field: "text".to_string(),
+                    },
+                },
+                ScriptNode::Collect {
+                    value: Expression::Variable("processed".to_string()),
+                },
+            ],
+        };
+
+        assert_eq!(validate_script(&script, &limits()), Ok(()));
+    }
+
+    #[test]
+    fn validate_accepts_for_each_standalone() {
+        let script = ScriptDefinition {
+            schema_version: SCHEMA_VERSION,
+            name: None,
+            steps: vec![
+                ScriptNode::ToolCall {
+                    tool: "list_resources".to_string(),
+                    input: json!({}),
+                    output: Some("links".to_string()),
+                },
+                ScriptNode::ForEach {
+                    variable: "link".to_string(),
+                    iterable: Expression::Variable("links".to_string()),
+                    steps: vec![ScriptNode::Collect {
+                        value: Expression::Variable("link".to_string()),
+                    }],
+                },
+            ],
+        };
+
+        assert_eq!(validate_script(&script, &limits()), Ok(()));
+    }
+
+    #[test]
+    fn validate_accepts_if_else_standalone() {
+        let script = ScriptDefinition {
+            schema_version: SCHEMA_VERSION,
+            name: None,
+            steps: vec![ScriptNode::IfElse {
+                condition: Expression::JsEval("items.length > 0".to_string()),
+                then_steps: vec![ScriptNode::ToolCall {
+                    tool: "click".to_string(),
+                    input: json!({"selector": ".next"}),
+                    output: None,
+                }],
+                else_steps: Some(vec![ScriptNode::Yield {
+                    value: Expression::Literal(json!("no items")),
+                }]),
+            }],
+        };
+
+        assert_eq!(validate_script(&script, &limits()), Ok(()));
+    }
+
+    #[test]
+    fn validate_accepts_try_catch_standalone() {
+        let script = ScriptDefinition {
+            schema_version: SCHEMA_VERSION,
+            name: None,
+            steps: vec![ScriptNode::TryCatch {
+                try_steps: vec![ScriptNode::ToolCall {
+                    tool: "click".to_string(),
+                    input: json!({"selector": ".submit"}),
+                    output: None,
+                }],
+                catch_steps: Some(vec![ScriptNode::ToolCall {
+                    tool: "screenshot".to_string(),
+                    input: json!({}),
+                    output: None,
+                }]),
+                finally_steps: None,
+                error_var: Some("err".to_string()),
+            }],
+        };
+
+        assert_eq!(validate_script(&script, &limits()), Ok(()));
+    }
+
+    #[test]
+    fn validate_accepts_parallel_standalone() {
+        let script = ScriptDefinition {
+            schema_version: SCHEMA_VERSION,
+            name: None,
+            steps: vec![ScriptNode::Parallel {
+                branches: vec![
+                    vec![ScriptNode::ToolCall {
+                        tool: "navigate".to_string(),
+                        input: json!({"url": "https://a.com"}),
+                        output: None,
+                    }],
+                    vec![ScriptNode::ToolCall {
+                        tool: "navigate".to_string(),
+                        input: json!({"url": "https://b.com"}),
+                        output: None,
+                    }],
+                ],
+            }],
+        };
+
+        assert_eq!(validate_script(&script, &limits()), Ok(()));
+    }
 }

--- a/crates/script/src/persistence.rs
+++ b/crates/script/src/persistence.rs
@@ -67,7 +67,10 @@ pub fn validate_script_name(name: &str) -> Result<(), PersistenceError> {
     }
 
     // Allow alphanumeric, underscore, and hyphen
-    if !name.chars().all(|c| c.is_alphanumeric() || c == '_' || c == '-') {
+    if !name
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+    {
         return Err(PersistenceError::InvalidName(
             "script name must contain only alphanumeric characters, underscores, and hyphens"
                 .to_string(),
@@ -101,8 +104,8 @@ pub fn save_script_to_disk(
     fs::create_dir_all(scripts_dir)?;
 
     // Serialize to pretty JSON
-    let json_str = serde_json::to_string_pretty(script)
-        .map_err(|e| PersistenceError::Parse(e.to_string()))?;
+    let json_str =
+        serde_json::to_string_pretty(script).map_err(|e| PersistenceError::Parse(e.to_string()))?;
 
     // Write to file
     let file_path = scripts_dir.join(format!("{}.json", name));

--- a/crates/script/src/persistence.rs
+++ b/crates/script/src/persistence.rs
@@ -5,7 +5,7 @@
 
 use crate::grammar::ScriptDefinition;
 use std::fs;
-use std::path::Path;
+use std::path::{Component, Path};
 use std::time::SystemTime;
 use thiserror::Error;
 
@@ -54,16 +54,32 @@ pub fn validate_script_name(name: &str) -> Result<(), PersistenceError> {
         ));
     }
 
+    if name.starts_with('-') {
+        return Err(PersistenceError::InvalidName(
+            "script name cannot start with '-'".to_string(),
+        ));
+    }
+
     if name.contains('\0') {
         return Err(PersistenceError::InvalidName(
             "script name cannot contain null bytes".to_string(),
         ));
     }
 
-    if name.contains('/') || name.contains('\\') {
+    if name.contains('/') || name.contains('\\') || name.contains('.') {
         return Err(PersistenceError::InvalidName(
-            "script name cannot contain path separators".to_string(),
+            "script name cannot contain path separators or dots (path traversal not allowed)"
+                .to_string(),
         ));
+    }
+
+    for component in Path::new(name).components() {
+        if !matches!(component, Component::Normal(_)) {
+            return Err(PersistenceError::InvalidName(
+                "script name must be a simple filename without path components (path traversal not allowed)"
+                    .to_string(),
+            ));
+        }
     }
 
     // Allow alphanumeric, underscore, and hyphen
@@ -207,8 +223,10 @@ mod tests {
         assert!(validate_script_name("").is_err());
         assert!(validate_script_name("my/script").is_err());
         assert!(validate_script_name("my\\script").is_err());
+        assert!(validate_script_name("-script").is_err());
         assert!(validate_script_name("my script").is_err());
         assert!(validate_script_name("my.script").is_err());
+        assert!(validate_script_name("..").is_err());
         assert!(validate_script_name("my@script").is_err());
     }
 

--- a/crates/script/src/persistence.rs
+++ b/crates/script/src/persistence.rs
@@ -1,2 +1,301 @@
-//! Persistence layer for scripts.
-//! TODO: implement
+//! Persistence layer for script storage on disk.
+//!
+//! Provides functions to save, load, and list scripts in a directory.
+//! Scripts are stored as pretty-printed JSON files with `.json` extension.
+
+use crate::grammar::ScriptDefinition;
+use std::fs;
+use std::path::Path;
+use std::time::SystemTime;
+use thiserror::Error;
+
+/// Metadata about a stored script.
+#[derive(Debug, Clone)]
+pub struct ScriptMetadata {
+    /// Script name (without `.json` extension).
+    pub name: String,
+    /// File size in bytes.
+    pub size_bytes: u64,
+    /// Last modification time.
+    pub modified_at: SystemTime,
+}
+
+/// Errors that can occur during script persistence operations.
+#[derive(Debug, Error)]
+pub enum PersistenceError {
+    /// I/O error (file not found, permission denied, etc.).
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// JSON parsing or serialization error.
+    #[error("JSON error: {0}")]
+    Parse(String),
+
+    /// Invalid script name (contains path separators, null bytes, etc.).
+    #[error("Invalid script name: {0}")]
+    InvalidName(String),
+}
+
+/// Validates a script name.
+///
+/// Valid names contain only alphanumeric characters, underscores, and hyphens.
+/// Names must not be empty, contain path separators, or null bytes.
+///
+/// # Arguments
+/// * `name` - The script name to validate
+///
+/// # Returns
+/// * `Ok(())` if the name is valid
+/// * `Err(PersistenceError::InvalidName)` if the name is invalid
+pub fn validate_script_name(name: &str) -> Result<(), PersistenceError> {
+    if name.is_empty() {
+        return Err(PersistenceError::InvalidName(
+            "script name cannot be empty".to_string(),
+        ));
+    }
+
+    if name.contains('\0') {
+        return Err(PersistenceError::InvalidName(
+            "script name cannot contain null bytes".to_string(),
+        ));
+    }
+
+    if name.contains('/') || name.contains('\\') {
+        return Err(PersistenceError::InvalidName(
+            "script name cannot contain path separators".to_string(),
+        ));
+    }
+
+    // Allow alphanumeric, underscore, and hyphen
+    if !name.chars().all(|c| c.is_alphanumeric() || c == '_' || c == '-') {
+        return Err(PersistenceError::InvalidName(
+            "script name must contain only alphanumeric characters, underscores, and hyphens"
+                .to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Saves a script to disk.
+///
+/// Creates the scripts directory if it doesn't exist.
+/// The script is serialized to pretty-printed JSON and written to `{scripts_dir}/{name}.json`.
+///
+/// # Arguments
+/// * `scripts_dir` - Directory where scripts are stored
+/// * `name` - Script name (validated before saving)
+/// * `script` - The script definition to save
+///
+/// # Returns
+/// * `Ok(())` on success
+/// * `Err(PersistenceError)` if validation fails, directory creation fails, or writing fails
+pub fn save_script_to_disk(
+    scripts_dir: &Path,
+    name: &str,
+    script: &ScriptDefinition,
+) -> Result<(), PersistenceError> {
+    validate_script_name(name)?;
+
+    // Create directory if it doesn't exist
+    fs::create_dir_all(scripts_dir)?;
+
+    // Serialize to pretty JSON
+    let json_str = serde_json::to_string_pretty(script)
+        .map_err(|e| PersistenceError::Parse(e.to_string()))?;
+
+    // Write to file
+    let file_path = scripts_dir.join(format!("{}.json", name));
+    fs::write(file_path, json_str)?;
+
+    Ok(())
+}
+
+/// Loads a script from disk.
+///
+/// Reads the JSON file at `{scripts_dir}/{name}.json` and deserializes it.
+///
+/// # Arguments
+/// * `scripts_dir` - Directory where scripts are stored
+/// * `name` - Script name (validated before loading)
+///
+/// # Returns
+/// * `Ok(ScriptDefinition)` on success
+/// * `Err(PersistenceError)` if validation fails, file not found, or parsing fails
+pub fn load_script_from_disk(
+    scripts_dir: &Path,
+    name: &str,
+) -> Result<ScriptDefinition, PersistenceError> {
+    validate_script_name(name)?;
+
+    let file_path = scripts_dir.join(format!("{}.json", name));
+    let json_str = fs::read_to_string(file_path)?;
+
+    let script = serde_json::from_str::<ScriptDefinition>(&json_str)
+        .map_err(|e| PersistenceError::Parse(e.to_string()))?;
+
+    Ok(script)
+}
+
+/// Lists all scripts in a directory.
+///
+/// Scans the directory for `.json` files, extracts metadata for each,
+/// and returns them sorted by name.
+///
+/// # Arguments
+/// * `scripts_dir` - Directory where scripts are stored
+///
+/// # Returns
+/// * `Ok(Vec<ScriptMetadata>)` containing all scripts, sorted by name
+/// * `Err(PersistenceError)` if the directory cannot be read
+pub fn list_scripts_on_disk(scripts_dir: &Path) -> Result<Vec<ScriptMetadata>, PersistenceError> {
+    let mut scripts = Vec::new();
+
+    // Return empty list if directory doesn't exist
+    if !scripts_dir.exists() {
+        return Ok(scripts);
+    }
+
+    for entry in fs::read_dir(scripts_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+
+        // Only process `.json` files
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+
+        // Extract script name (filename without `.json`)
+        if let Some(file_name) = path.file_stem().and_then(|s| s.to_str()) {
+            let metadata = entry.metadata()?;
+            let size_bytes = metadata.len();
+            let modified_at = metadata.modified()?;
+
+            scripts.push(ScriptMetadata {
+                name: file_name.to_string(),
+                size_bytes,
+                modified_at,
+            });
+        }
+    }
+
+    // Sort by name
+    scripts.sort_by(|a, b| a.name.cmp(&b.name));
+
+    Ok(scripts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_validate_script_name_valid() {
+        assert!(validate_script_name("my_script").is_ok());
+        assert!(validate_script_name("my-script").is_ok());
+        assert!(validate_script_name("MyScript123").is_ok());
+        assert!(validate_script_name("_script").is_ok());
+        assert!(validate_script_name("script_123-test").is_ok());
+    }
+
+    #[test]
+    fn test_validate_script_name_invalid() {
+        assert!(validate_script_name("").is_err());
+        assert!(validate_script_name("my/script").is_err());
+        assert!(validate_script_name("my\\script").is_err());
+        assert!(validate_script_name("my script").is_err());
+        assert!(validate_script_name("my.script").is_err());
+        assert!(validate_script_name("my@script").is_err());
+    }
+
+    #[test]
+    fn test_save_and_load_script() {
+        let temp_dir = TempDir::new().unwrap();
+        let scripts_dir = temp_dir.path();
+
+        let script = ScriptDefinition {
+            schema_version: 1,
+            name: Some("test_script".to_string()),
+            steps: vec![],
+        };
+
+        // Save
+        assert!(save_script_to_disk(scripts_dir, "test_script", &script).is_ok());
+
+        // Verify file exists
+        let file_path = scripts_dir.join("test_script.json");
+        assert!(file_path.exists());
+
+        // Load
+        let loaded = load_script_from_disk(scripts_dir, "test_script").unwrap();
+        assert_eq!(loaded.schema_version, 1);
+        assert_eq!(loaded.name, Some("test_script".to_string()));
+    }
+
+    #[test]
+    fn test_list_scripts() {
+        let temp_dir = TempDir::new().unwrap();
+        let scripts_dir = temp_dir.path();
+
+        let script1 = ScriptDefinition {
+            schema_version: 1,
+            name: Some("script_a".to_string()),
+            steps: vec![],
+        };
+
+        let script2 = ScriptDefinition {
+            schema_version: 1,
+            name: Some("script_b".to_string()),
+            steps: vec![],
+        };
+
+        save_script_to_disk(scripts_dir, "script_a", &script1).unwrap();
+        save_script_to_disk(scripts_dir, "script_b", &script2).unwrap();
+
+        let scripts = list_scripts_on_disk(scripts_dir).unwrap();
+        assert_eq!(scripts.len(), 2);
+        assert_eq!(scripts[0].name, "script_a");
+        assert_eq!(scripts[1].name, "script_b");
+    }
+
+    #[test]
+    fn test_list_scripts_empty_dir() {
+        let temp_dir = TempDir::new().unwrap();
+        let scripts_dir = temp_dir.path();
+
+        let scripts = list_scripts_on_disk(scripts_dir).unwrap();
+        assert_eq!(scripts.len(), 0);
+    }
+
+    #[test]
+    fn test_list_scripts_nonexistent_dir() {
+        let nonexistent = Path::new("/nonexistent/path/to/scripts");
+        let scripts = list_scripts_on_disk(nonexistent).unwrap();
+        assert_eq!(scripts.len(), 0);
+    }
+
+    #[test]
+    fn test_load_nonexistent_script() {
+        let temp_dir = TempDir::new().unwrap();
+        let scripts_dir = temp_dir.path();
+
+        let result = load_script_from_disk(scripts_dir, "nonexistent");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_save_invalid_name() {
+        let temp_dir = TempDir::new().unwrap();
+        let scripts_dir = temp_dir.path();
+
+        let script = ScriptDefinition {
+            schema_version: 1,
+            name: None,
+            steps: vec![],
+        };
+
+        assert!(save_script_to_disk(scripts_dir, "invalid/name", &script).is_err());
+        assert!(save_script_to_disk(scripts_dir, "", &script).is_err());
+    }
+}

--- a/crates/script/src/persistence.rs
+++ b/crates/script/src/persistence.rs
@@ -1,0 +1,2 @@
+//! Persistence layer for scripts.
+//! TODO: implement

--- a/crates/script/src/persistence.rs
+++ b/crates/script/src/persistence.rs
@@ -108,7 +108,7 @@ pub fn save_script_to_disk(
         serde_json::to_string_pretty(script).map_err(|e| PersistenceError::Parse(e.to_string()))?;
 
     // Write to file
-    let file_path = scripts_dir.join(format!("{}.json", name));
+    let file_path = scripts_dir.join(format!("{name}.json"));
     fs::write(file_path, json_str)?;
 
     Ok(())
@@ -131,7 +131,7 @@ pub fn load_script_from_disk(
 ) -> Result<ScriptDefinition, PersistenceError> {
     validate_script_name(name)?;
 
-    let file_path = scripts_dir.join(format!("{}.json", name));
+    let file_path = scripts_dir.join(format!("{name}.json"));
     let json_str = fs::read_to_string(file_path)?;
 
     let script = serde_json::from_str::<ScriptDefinition>(&json_str)
@@ -241,20 +241,20 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let scripts_dir = temp_dir.path();
 
-        let script1 = ScriptDefinition {
+        let first_script_def = ScriptDefinition {
             schema_version: 1,
             name: Some("script_a".to_string()),
             steps: vec![],
         };
 
-        let script2 = ScriptDefinition {
+        let second_script_def = ScriptDefinition {
             schema_version: 1,
             name: Some("script_b".to_string()),
             steps: vec![],
         };
 
-        save_script_to_disk(scripts_dir, "script_a", &script1).unwrap();
-        save_script_to_disk(scripts_dir, "script_b", &script2).unwrap();
+        save_script_to_disk(scripts_dir, "script_a", &first_script_def).unwrap();
+        save_script_to_disk(scripts_dir, "script_b", &second_script_def).unwrap();
 
         let scripts = list_scripts_on_disk(scripts_dir).unwrap();
         assert_eq!(scripts.len(), 2);


### PR DESCRIPTION
## Summary

Adds a new **Autonomous Script Protocol** that lets the LLM (or an external MCP client) execute deterministic multi-step browser automation without per-step LLM round-trips — dramatically faster and cheaper for repetitive page patterns.

## What's new

**New crate: `crates/script/`**
- AST grammar (`ScriptDefinition`, `ScriptNode`, `Expression`)
- Parser + validator (`parse_script`, `validate_script`)
- Persistence layer (`save_script_to_disk`, `load_script_from_disk`, `list_scripts_on_disk`)

**7 new tools** (exposed via agent loop and MCP server):

| Tool | Description |
|---|---|
| `run_script` | Execute an inline script or load one by name; returns `script_id` immediately |
| `wait_for_scripts` | Block until script(s) complete; returns full `ScriptResult` |
| `script_status` | Non-blocking poll of running script state |
| `cancel_script` | Abort a running script |
| `save_script` | Persist a script definition to `~/.acrawl/scripts/<name>.json` |
| `list_scripts` | List all saved scripts with ISO 8601 timestamps |
| `read_script` | Read back a saved script definition |

**Script nodes:** `tool_call`, `assign`, `collect`, `yield`, `for_loop`, `for_each`, `while_loop`, `if_else`, `try_catch`, `parallel`

**Execution engine** (`crates/agent/src/script_executor/`):
- Step counter, wall-clock timeout, per-step timeout, output byte limit, cancellation token
- Parallel branches share step counter + cancel token; each branch opens its own browser page
- `errors_caught` and `output_bytes` propagated back from parallel branches to parent

## Bugs fixed (post code-review)

| Severity | Fix |
|---|---|
| Critical | `Expression` serde tag changed from internally-tagged to adjacently-tagged (`#[serde(tag="kind", content="value")]`) — `Literal`, `Variable`, `JsEval` now deserialize correctly from JSON |
| Important | `run_script` ToolSpec schema now exposes `name`, `save_as`, `limits`; removed internal `__load_from_disk` |
| Important | `max_output_bytes` enforced via `push_extracted`/`push_yielded` helpers |
| Important | `cleanup_completed()` removed from `spawn_script` — completed scripts survive until explicitly `wait_for_scripts`-ed |
| Important | `validate_script_name` consolidated into `persistence.rs`; rejects leading dash, dots, path traversal |
| Important | `list_scripts` `modified_at` now returns ISO 8601 UTC (e.g. `2026-06-09T13:39:09Z`) |
| Bug | `spawn_script` in MCP server wrapped in `rt.block_on` — was panicking with `no reactor running` and killing the server process |

## Test coverage

- 17 parser unit tests (including `parse_script_expression_round_trip` covering all 5 `Expression` variants through serde round-trip)
- 31 script executor unit tests (including `collect_over_output_byte_limit_fails`, `yield_over_output_byte_limit_fails`)
- 1 script manager unit test (`completed_script_survives_subsequent_spawn_check`)
- 11 script integration tests
- 1 MCP stdio integration test (`stdio_server_run_script_returns_script_id_and_survives`)

## E2E verified (live MCP session)

All 7 tools exercised end-to-end against the running MCP server:

```
run_script  → script_id returned, server alive        ✓
wait_for_scripts → status:Completed, extracted_data:[42], yielded_data:["done"]  ✓
run_script (navigate + literal + variable) → extracted_data:["Example Domain"]  ✓
script_status → live step/items_collected/elapsed_secs  ✓
cancel_script → status:Cancelled, items_collected:0  ✓
save_script → saved to disk  ✓
list_scripts → ISO 8601 modified_at  ✓
read_script → full definition round-tripped including field_access expression  ✓
```
