### PR TITLE
fix(fetch): multi-signal SPA shell detection for browser escalation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Empty SPA shell detection** — replaced the naive "large HTML + sparse text" heuristic with a multi-signal scoring function that accumulates confidence from framework asset paths (`/_next/static/`, `/_nuxt/`, `ng-version=`), empty mount-point divs, noscript "enable JavaScript" messages, and bundler hash patterns. Pages with embedded data blobs (`__NEXT_DATA__`, `window.__NUXT__`, `data-reactroot`) now correctly skip browser escalation since their content is already server-rendered. Eliminates false positives on legitimate sparse pages (login forms, image-heavy landing pages).
+- **SPA hydration wait** — after browser navigation, polls for visible text content (up to 3s in 300ms intervals) before capturing, so async-rendered SPAs like Gitee search have time to hydrate.
+
 ## [0.10.0] - 2026-06-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ Every `navigate` call goes through a two-tier fetch router:
    - JS framework markers: `__next_data__`, `__nuxt`, `__vue`, `ng-app`, `_react`, `data-reactroot`
    - Auth redirects: URLs containing `/login`, `/signin`, `/auth`, `/oauth`, `accounts.google.com`
    - Short response body (< 500 chars) with a `<noscript>` tag
+   - Empty SPA shell detection (multi-signal scoring): framework asset paths without embedded data (`/_next/static/`, `/_nuxt/`, `ng-version=`), empty mount-point divs, noscript "enable JavaScript" messages, bundler hash patterns, and structural signals (sparse visible text with no semantic elements). Pages with embedded data blobs (`__NEXT_DATA__`, `window.__NUXT__`, `data-reactroot`) are explicitly excluded — their content is already server-rendered.
 
 When `--no-headless` / `--headed` is set, all fetches go directly through the browser.
 

--- a/crates/browser/src/fetch.rs
+++ b/crates/browser/src/fetch.rs
@@ -157,11 +157,12 @@ fn looks_like_empty_spa_shell(body: &str) -> bool {
         score += 0.55;
     }
 
-    // ── Medium: empty mount-point divs (framework root with no children) ──
-    if lower.contains("id=\"root\"></div>")
-        || lower.contains("id=\"app\"></div>")
-        || lower.contains("id=\"__next\"></div>")
-        || lower.contains("id=\"__nuxt\"></div>")
+    // ── Medium: empty mount-point elements (framework root with no children) ──
+    // Match any element type: <div id="root"></div>, <section id="root"></section>, etc.
+    if lower.contains("id=\"root\"></")
+        || lower.contains("id=\"app\"></")
+        || lower.contains("id=\"__next\"></")
+        || lower.contains("id=\"__nuxt\"></")
         || lower.contains("<app-root></app-root>")
         || lower.contains("<app-root />")
     {
@@ -169,26 +170,27 @@ fn looks_like_empty_spa_shell(body: &str) -> bool {
     }
 
     // ── Medium: bundler hash patterns (Vite/CRA output) ──
-    // Match patterns like: src="/assets/index-D9LVtTP6.js" or
-    // src="/static/js/main.abc123.chunk.js"
     if has_bundler_hash_pattern(&lower) {
         score += 0.30;
     }
 
-    // ── Low: structural signals (modifiers, not sufficient alone) ──
-    if body.len() > 2000 {
-        let visible_len = extract_text(body).trim().len();
-        if visible_len < MIN_VISIBLE_CHARS_THRESHOLD {
-            score += 0.35;
-        }
+    // ── Low-medium: "bundle" keyword in script src (Webpack/Parcel without hash) ──
+    if lower.contains("src=\"") && lower.contains("bundle") && lower.contains(".js") {
+        score += 0.20;
+    }
 
-        let has_semantic = lower.contains("<h1")
-            || lower.contains("<article")
-            || lower.contains("<main>")
-            || lower.contains("<p>");
-        if !has_semantic {
-            score += 0.20;
-        }
+    // ── Low: structural signals (modifiers, not sufficient alone) ──
+    let visible_len = extract_text(body).trim().len();
+    if visible_len < MIN_VISIBLE_CHARS_THRESHOLD {
+        score += 0.35;
+    }
+
+    let has_semantic = lower.contains("<h1")
+        || lower.contains("<article")
+        || lower.contains("<main>")
+        || lower.contains("<p>");
+    if !has_semantic {
+        score += 0.20;
     }
 
     score >= SPA_SHELL_SCORE_THRESHOLD
@@ -1128,5 +1130,39 @@ mod tests {
         assert!(!has_hash_segment("/js/app.js"));
         assert!(!has_hash_segment("/main.js"));
         assert!(!has_hash_segment("/assets/short-abc.js"));
+    }
+
+    #[test]
+    fn spa_shell_detected_gitee_vite_empty_body() {
+        // Gitee search: Vite SPA with bundler hash + completely empty body
+        let body = r#"<!DOCTYPE html><html><head>
+            <title>Gitee Search</title>
+            <link rel="stylesheet" href="/assets/index-abc12345.css">
+        </head><body data-bs-theme="light">
+            <script type="module" crossorigin src="/assets/index-8b837856.js"></script>
+        </body></html>"#;
+        assert!(looks_like_empty_spa_shell(body));
+    }
+
+    #[test]
+    fn spa_shell_detected_todomvc_section_mount() {
+        // TodoMVC React: <section> mount-point (not <div>) + bundle.js
+        let body = r#"<!DOCTYPE html><html><head>
+            <title>TodoMVC</title>
+        </head><body>
+            <section class="todoapp" id="root"></section>
+            <script defer="defer" src="app.bundle.js"></script>
+        </body></html>"#;
+        assert!(looks_like_empty_spa_shell(body));
+    }
+
+    #[test]
+    fn spa_shell_not_triggered_small_content_page_with_paragraphs() {
+        // Small page with real content — has <p> tags, should NOT trigger
+        let body = "<html><body>\n\
+            <h1>404 Not Found</h1>\n\
+            <p>The page you requested could not be found.</p>\n\
+        </body></html>";
+        assert!(!looks_like_empty_spa_shell(body));
     }
 }

--- a/crates/browser/src/fetch.rs
+++ b/crates/browser/src/fetch.rs
@@ -232,7 +232,8 @@ fn has_hash_segment(path: &str) -> bool {
             let seg_len = j - start;
             // 8+ alphanumeric chars with at least 2 digits distinguishes
             // hashes (e.g. "d9lvttp6") from English words (e.g. "loader")
-            if seg_len >= 8 && digit_count >= 2 && j < len && (bytes[j] == b'.' || bytes[j] == b'/') {
+            if seg_len >= 8 && digit_count >= 2 && j < len && (bytes[j] == b'.' || bytes[j] == b'/')
+            {
                 return true;
             }
             i = j;
@@ -242,7 +243,6 @@ fn has_hash_segment(path: &str) -> bool {
     }
     false
 }
-
 
 /// Hard cap on a single HTTP response body. A page that is much larger than
 /// this is almost never useful to the agent (and is almost certainly a binary

--- a/crates/browser/src/fetch.rs
+++ b/crates/browser/src/fetch.rs
@@ -882,6 +882,6 @@ mod tests {
     fn empty_ssr_shell_skips_small_pages() {
         let body = "<html><body>OK</body></html>";
         assert!(body.len() < MIN_HTML_BYTES_FOR_SPARSE_CHECK);
-        assert!(!looks_like_empty_ssr_shell(&body));
+        assert!(!looks_like_empty_ssr_shell(body));
     }
 }

--- a/crates/browser/src/fetch.rs
+++ b/crates/browser/src/fetch.rs
@@ -88,13 +88,15 @@ const AUTH_REDIRECT_PATTERNS: &[&str] = &[
 
 const MIN_BODY_LENGTH: usize = 500;
 
-/// When an HTTP response body is this large but extract_text() yields very
+/// When an HTTP response body is this large but `extract_text()` yields very
 /// little visible text, the page is likely a JS-rendered SSR shell.
 const MIN_HTML_BYTES_FOR_SPARSE_CHECK: usize = 500;
 const MIN_VISIBLE_CHARS_FOR_SHELL: usize = 200;
 
 fn looks_like_empty_ssr_shell(body: &str) -> bool {
-    if body.len() < MIN_HTML_BYTES_FOR_SPARSE_CHECK { return false; }
+    if body.len() < MIN_HTML_BYTES_FOR_SPARSE_CHECK {
+        return false;
+    }
     extract_text(body).trim().len() < MIN_VISIBLE_CHARS_FOR_SHELL
 }
 
@@ -860,7 +862,9 @@ mod tests {
     #[test]
     fn empty_ssr_shell_detected_on_large_html_with_no_text() {
         let mut body = String::from("<html><body><div id=\"app\"></div>");
-        for _ in 0..300 { body.push_str("<script>var x=1;</script>"); }
+        for _ in 0..300 {
+            body.push_str("<script>var x=1;</script>");
+        }
         body.push_str("</body></html>");
         assert!(body.len() > MIN_HTML_BYTES_FOR_SPARSE_CHECK);
         assert!(looks_like_empty_ssr_shell(&body));
@@ -868,7 +872,9 @@ mod tests {
     #[test]
     fn empty_ssr_shell_not_triggered_on_contentful_page() {
         let mut body = String::from("<html><body>");
-        for _ in 0..200 { body.push_str("<p>Some meaningful content here.</p>"); }
+        for _ in 0..200 {
+            body.push_str("<p>Some meaningful content here.</p>");
+        }
         body.push_str("</body></html>");
         assert!(!looks_like_empty_ssr_shell(&body));
     }

--- a/crates/browser/src/fetch.rs
+++ b/crates/browser/src/fetch.rs
@@ -88,6 +88,16 @@ const AUTH_REDIRECT_PATTERNS: &[&str] = &[
 
 const MIN_BODY_LENGTH: usize = 500;
 
+/// When an HTTP response body is this large but extract_text() yields very
+/// little visible text, the page is likely a JS-rendered SSR shell.
+const MIN_HTML_BYTES_FOR_SPARSE_CHECK: usize = 500;
+const MIN_VISIBLE_CHARS_FOR_SHELL: usize = 200;
+
+fn looks_like_empty_ssr_shell(body: &str) -> bool {
+    if body.len() < MIN_HTML_BYTES_FOR_SPARSE_CHECK { return false; }
+    extract_text(body).trim().len() < MIN_VISIBLE_CHARS_FOR_SHELL
+}
+
 /// Hard cap on a single HTTP response body. A page that is much larger than
 /// this is almost never useful to the agent (and is almost certainly a binary
 /// dump, generated content, or an attack) — and without a cap, reqwest's
@@ -423,6 +433,11 @@ impl FetchRouter {
         match http_result {
             Ok(resp) => {
                 if needs_escalation(resp.status, &resp.body) {
+                    if let Some(ctx) = browser {
+                        return Self::fetch_via_browser(ctx, url).await;
+                    }
+                }
+                if looks_like_empty_ssr_shell(&resp.body) {
                     if let Some(ctx) = browser {
                         return Self::fetch_via_browser(ctx, url).await;
                     }
@@ -840,5 +855,27 @@ mod tests {
         };
         // Compile-time check: the markdown field exists and is a String
         let _: &String = &page.markdown;
+    }
+
+    #[test]
+    fn empty_ssr_shell_detected_on_large_html_with_no_text() {
+        let mut body = String::from("<html><body><div id=\"app\"></div>");
+        for _ in 0..300 { body.push_str("<script>var x=1;</script>"); }
+        body.push_str("</body></html>");
+        assert!(body.len() > MIN_HTML_BYTES_FOR_SPARSE_CHECK);
+        assert!(looks_like_empty_ssr_shell(&body));
+    }
+    #[test]
+    fn empty_ssr_shell_not_triggered_on_contentful_page() {
+        let mut body = String::from("<html><body>");
+        for _ in 0..200 { body.push_str("<p>Some meaningful content here.</p>"); }
+        body.push_str("</body></html>");
+        assert!(!looks_like_empty_ssr_shell(&body));
+    }
+    #[test]
+    fn empty_ssr_shell_skips_small_pages() {
+        let body = "<html><body>OK</body></html>";
+        assert!(body.len() < MIN_HTML_BYTES_FOR_SPARSE_CHECK);
+        assert!(!looks_like_empty_ssr_shell(&body));
     }
 }

--- a/crates/browser/src/fetch.rs
+++ b/crates/browser/src/fetch.rs
@@ -88,17 +88,159 @@ const AUTH_REDIRECT_PATTERNS: &[&str] = &[
 
 const MIN_BODY_LENGTH: usize = 500;
 
-/// When an HTTP response body is this large but `extract_text()` yields very
-/// little visible text, the page is likely a JS-rendered SSR shell.
-const MIN_HTML_BYTES_FOR_SPARSE_CHECK: usize = 500;
-const MIN_VISIBLE_CHARS_FOR_SHELL: usize = 200;
+/// Minimum HTML size before we bother running structural analysis.
+const MIN_HTML_FOR_SPA_CHECK: usize = 100;
 
-fn looks_like_empty_ssr_shell(body: &str) -> bool {
-    if body.len() < MIN_HTML_BYTES_FOR_SPARSE_CHECK {
+/// Minimum visible text length — pages below this threshold get a structural
+/// score boost. Also used by the Playwright bridge script's hydration wait.
+const MIN_VISIBLE_CHARS_THRESHOLD: usize = 200;
+
+/// Score threshold for SPA shell detection. Signals are accumulated and
+/// compared against this value.
+const SPA_SHELL_SCORE_THRESHOLD: f32 = 0.60;
+
+/// Detect whether an HTTP response body looks like an empty SPA/CSR shell that
+/// needs browser rendering to produce meaningful content.
+///
+/// Uses multi-signal scoring rather than a single binary check:
+/// - **Negative signals** (data already present → return false immediately):
+///   `__NEXT_DATA__`, `window.__NUXT__`, `data-server-rendered`, `data-reactroot`
+/// - **High-weight signals**: framework asset paths without embedded data,
+///   Angular empty root, noscript "enable JavaScript" messages
+/// - **Medium-weight signals**: empty mount-point divs, Vite/CRA bundle hashes
+/// - **Low-weight structural signals**: sparse visible text, absence of semantic
+///   HTML elements (`<h1>`, `<article>`, `<main>`, `<p>`)
+///
+/// Escalates to browser only when accumulated score ≥ 0.60, which requires
+/// at least one framework/structural signal beyond just "low text content".
+fn looks_like_empty_spa_shell(body: &str) -> bool {
+    if body.len() < MIN_HTML_FOR_SPA_CHECK {
         return false;
     }
-    extract_text(body).trim().len() < MIN_VISIBLE_CHARS_FOR_SHELL
+
+    let lower = body.to_ascii_lowercase();
+
+    // ── Negative signals: data already embedded, no browser needed ──
+    // These indicate SSR/SSG worked — content is in the HTML already.
+    if lower.contains("__next_data__")
+        || lower.contains("window.__nuxt__")
+        || lower.contains("window.__nuxt_data__")
+        || lower.contains("window.__remixcontext")
+        || lower.contains("data-server-rendered=\"true\"")
+        || lower.contains("data-reactroot")
+        || lower.contains("data-reactid")
+    {
+        return false;
+    }
+
+    let mut score: f32 = 0.0;
+
+    // ── High: framework asset paths WITHOUT embedded data (already excluded above) ──
+    if lower.contains("/_next/static/") {
+        score += 0.70;
+    }
+    if lower.contains("/_nuxt/") {
+        score += 0.65;
+    }
+    if lower.contains("ng-version=") {
+        score += 0.80;
+    }
+    if lower.contains("data-sveltekit") || lower.contains("__sveltekit") {
+        score += 0.55;
+    }
+
+    // ── High: noscript "enable JavaScript" messages (Vue CLI / CRA template) ──
+    if lower.contains("enable javascript")
+        || lower.contains("doesn't work properly without javascript")
+        || lower.contains("requires javascript")
+    {
+        score += 0.55;
+    }
+
+    // ── Medium: empty mount-point divs (framework root with no children) ──
+    if lower.contains("id=\"root\"></div>")
+        || lower.contains("id=\"app\"></div>")
+        || lower.contains("id=\"__next\"></div>")
+        || lower.contains("id=\"__nuxt\"></div>")
+        || lower.contains("<app-root></app-root>")
+        || lower.contains("<app-root />")
+    {
+        score += 0.45;
+    }
+
+    // ── Medium: bundler hash patterns (Vite/CRA output) ──
+    // Match patterns like: src="/assets/index-D9LVtTP6.js" or
+    // src="/static/js/main.abc123.chunk.js"
+    if has_bundler_hash_pattern(&lower) {
+        score += 0.30;
+    }
+
+    // ── Low: structural signals (modifiers, not sufficient alone) ──
+    if body.len() > 2000 {
+        let visible_len = extract_text(body).trim().len();
+        if visible_len < MIN_VISIBLE_CHARS_THRESHOLD {
+            score += 0.35;
+        }
+
+        let has_semantic = lower.contains("<h1")
+            || lower.contains("<article")
+            || lower.contains("<main>")
+            || lower.contains("<p>");
+        if !has_semantic {
+            score += 0.20;
+        }
+    }
+
+    score >= SPA_SHELL_SCORE_THRESHOLD
 }
+
+/// Check for Vite/Rollup/Webpack hash patterns in script src attributes.
+/// These patterns (`index-XXXXXXXX.js`, `main.XXXXXXXX.chunk.js`) are
+/// characteristic of bundled SPA builds.
+#[allow(clippy::case_sensitive_file_extension_comparisons)] // input is pre-lowercased
+fn has_bundler_hash_pattern(lower_html: &str) -> bool {
+    for segment in lower_html.split("src=\"") {
+        if let Some(path) = segment.split('"').next() {
+            if (path.ends_with(".js") || path.ends_with(".mjs")) && has_hash_segment(path) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Returns true if the path contains a segment of 8+ alphanumeric characters
+/// (with at least 2 digits) immediately preceded by `-` or `.`.
+/// Matches Vite (base62), Webpack/CRA (hex) hash patterns.
+fn has_hash_segment(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+    while i < len {
+        if bytes[i] == b'-' || bytes[i] == b'.' {
+            let start = i + 1;
+            let mut j = start;
+            let mut digit_count = 0u32;
+            while j < len && bytes[j].is_ascii_alphanumeric() {
+                if bytes[j].is_ascii_digit() {
+                    digit_count += 1;
+                }
+                j += 1;
+            }
+            let seg_len = j - start;
+            // 8+ alphanumeric chars with at least 2 digits distinguishes
+            // hashes (e.g. "d9lvttp6") from English words (e.g. "loader")
+            if seg_len >= 8 && digit_count >= 2 && j < len && (bytes[j] == b'.' || bytes[j] == b'/') {
+                return true;
+            }
+            i = j;
+        } else {
+            i += 1;
+        }
+    }
+    false
+}
+
 
 /// Hard cap on a single HTTP response body. A page that is much larger than
 /// this is almost never useful to the agent (and is almost certainly a binary
@@ -439,7 +581,7 @@ impl FetchRouter {
                         return Self::fetch_via_browser(ctx, url).await;
                     }
                 }
-                if looks_like_empty_ssr_shell(&resp.body) {
+                if looks_like_empty_spa_shell(&resp.body) {
                     if let Some(ctx) = browser {
                         return Self::fetch_via_browser(ctx, url).await;
                     }
@@ -860,28 +1002,131 @@ mod tests {
     }
 
     #[test]
-    fn empty_ssr_shell_detected_on_large_html_with_no_text() {
-        let mut body = String::from("<html><body><div id=\"app\"></div>");
-        for _ in 0..300 {
-            body.push_str("<script>var x=1;</script>");
-        }
-        body.push_str("</body></html>");
-        assert!(body.len() > MIN_HTML_BYTES_FOR_SPARSE_CHECK);
-        assert!(looks_like_empty_ssr_shell(&body));
+    fn spa_shell_detected_next_js_csr() {
+        // Next.js CSR: has /_next/static/ assets but no __NEXT_DATA__ blob
+        let body = r#"<html><head></head><body>
+            <div id="__next"></div>
+            <script src="/_next/static/chunks/main-a1b2c3d4.js"></script>
+            <script src="/_next/static/chunks/pages/_app-e5f6a7b8.js"></script>
+        </body></html>"#;
+        assert!(looks_like_empty_spa_shell(body));
     }
+
     #[test]
-    fn empty_ssr_shell_not_triggered_on_contentful_page() {
-        let mut body = String::from("<html><body>");
-        for _ in 0..200 {
-            body.push_str("<p>Some meaningful content here.</p>");
-        }
-        body.push_str("</body></html>");
-        assert!(!looks_like_empty_ssr_shell(&body));
+    fn spa_shell_not_triggered_next_js_ssr() {
+        // Next.js SSR: has __NEXT_DATA__ → data is embedded, no browser needed
+        let body = r#"<html><head></head><body>
+            <div id="__next"><h1>Server Rendered Page</h1><p>Content here</p></div>
+            <script id="__NEXT_DATA__" type="application/json">{"props":{}}</script>
+            <script src="/_next/static/chunks/main-a1b2c3d4.js"></script>
+        </body></html>"#;
+        assert!(!looks_like_empty_spa_shell(body));
     }
+
     #[test]
-    fn empty_ssr_shell_skips_small_pages() {
+    fn spa_shell_detected_angular_empty_root() {
+        let body = r#"<html><head></head><body>
+            <app-root ng-version="17.3.0"></app-root>
+            <script src="/main.a1b2c3d4e5f6.js"></script>
+        </body></html>"#;
+        assert!(looks_like_empty_spa_shell(body));
+    }
+
+    #[test]
+    fn spa_shell_detected_vue_cli_noscript() {
+        let body = r#"<html><head></head><body>
+            <noscript><strong>We're sorry but this app doesn't work properly without JavaScript enabled.</strong></noscript>
+            <div id="app"></div>
+            <script src="/js/app.a1b2c3d4.js"></script>
+            <script src="/js/chunk-vendors.e5f6a7b8.js"></script>
+        </body></html>"#;
+        assert!(looks_like_empty_spa_shell(body));
+    }
+
+    #[test]
+    fn spa_shell_detected_empty_root_with_vite_bundle() {
+        // Generic Vite SPA: empty #root + hashed bundle
+        let body = r#"<html><head></head><body>
+            <div id="root"></div>
+            <script type="module" src="/assets/index-D9LVtTP6.js"></script>
+        </body></html>"#;
+        assert!(looks_like_empty_spa_shell(body));
+    }
+
+    #[test]
+    fn spa_shell_not_triggered_contentful_page() {
+        let mut body = String::from("<html><body><main>");
+        for _ in 0..50 {
+            body.push_str("<p>This is a paragraph with meaningful content for users.</p>");
+        }
+        body.push_str("</main></body></html>");
+        assert!(!looks_like_empty_spa_shell(&body));
+    }
+
+    #[test]
+    fn spa_shell_not_triggered_nuxt_ssr() {
+        // Nuxt SSR: has window.__NUXT__ → data present
+        let body = r#"<html><head></head><body>
+            <div id="__nuxt"><div id="__layout"><h1>Hello</h1></div></div>
+            <script>window.__NUXT__={data:{},state:{}}</script>
+        </body></html>"#;
+        assert!(!looks_like_empty_spa_shell(body));
+    }
+
+    #[test]
+    fn spa_shell_not_triggered_react_ssr() {
+        // React SSR: has data-reactroot → content was server-rendered
+        let body = r#"<html><head></head><body>
+            <div id="root" data-reactroot=""><h1>Hello</h1><p>Content</p></div>
+        </body></html>"#;
+        assert!(!looks_like_empty_spa_shell(body));
+    }
+
+    #[test]
+    fn spa_shell_skips_small_pages() {
         let body = "<html><body>OK</body></html>";
-        assert!(body.len() < MIN_HTML_BYTES_FOR_SPARSE_CHECK);
-        assert!(!looks_like_empty_ssr_shell(body));
+        assert!(body.len() < MIN_HTML_FOR_SPA_CHECK);
+        assert!(!looks_like_empty_spa_shell(body));
+    }
+
+    #[test]
+    fn spa_shell_not_triggered_sparse_but_legitimate_page() {
+        // A sparse login page: has <p> and <h1>, no framework signals
+        let body = r#"<html><head><title>Login</title></head><body>
+            <h1>Sign In</h1>
+            <form action="/login" method="post">
+                <input type="email" name="email" />
+                <input type="password" name="pass" />
+                <button type="submit">Log in</button>
+            </form>
+            <p>Forgot your password?</p>
+        </body></html>"#;
+        assert!(!looks_like_empty_spa_shell(body));
+    }
+
+    #[test]
+    fn spa_shell_low_text_alone_not_sufficient() {
+        // Large HTML with scripts but no framework signals — should NOT trigger
+        // because low text alone (score 0.35) is below the 0.60 threshold
+        let mut body = String::from("<html><body><div>");
+        for _ in 0..200 {
+            body.push_str("<script>var x = 1;</script>");
+        }
+        body.push_str("<p>tiny</p></div></body></html>");
+        assert!(body.len() > MIN_HTML_FOR_SPA_CHECK);
+        assert!(!looks_like_empty_spa_shell(&body));
+    }
+
+    #[test]
+    fn bundler_hash_detection_vite() {
+        assert!(has_hash_segment("/assets/index-a1b2c3d4.js"));
+        assert!(has_hash_segment("/assets/vendor-e5f6a7b8c9d0.js"));
+    }
+
+    #[test]
+    fn bundler_hash_detection_no_false_positive() {
+        assert!(!has_hash_segment("/js/app.js"));
+        assert!(!has_hash_segment("/main.js"));
+        assert!(!has_hash_segment("/assets/short-abc.js"));
     }
 }

--- a/crates/browser/src/playwright/bridge_script.rs
+++ b/crates/browser/src/playwright/bridge_script.rs
@@ -153,13 +153,13 @@ async function bootstrap() {
         } catch (_) { /* networkidle timed out — proceed with current state */ }
         // For SPAs that render content asynchronously after XHR (e.g. Gitee
         // search), poll for visible text content to appear before capturing.
-        // If the page already has content we break immediately; otherwise we
-        // wait up to 3 s in 300 ms increments so we don't over-delay fast pages.
+        // Threshold matches MIN_VISIBLE_CHARS_THRESHOLD in fetch.rs.
         try {
+          const MIN_VISIBLE_CHARS = 200;
           const pollDeadline = Date.now() + 3000;
           while (Date.now() < pollDeadline) {
             const textLen = await page.evaluate(() => (document.body?.innerText?.trim()?.length ?? 0));
-            if (textLen >= 200) break;
+            if (textLen >= MIN_VISIBLE_CHARS) break;
             await new Promise(r => setTimeout(r, 300));
           }
         } catch (_) {}

--- a/crates/browser/src/playwright/bridge_script.rs
+++ b/crates/browser/src/playwright/bridge_script.rs
@@ -146,11 +146,23 @@ async function bootstrap() {
     if (command.action === 'navigate') {
       try {
         await page.goto(command.url, { waitUntil: 'domcontentloaded', timeout: 30000 });
-        // Wait for SPA API calls to complete. Cap at 3s so pages with
+        // Wait for SPA API calls to complete. Cap at 5s so pages with
         // persistent connections (WebSocket, SSE, polling) don't hang.
         try {
-          await page.waitForLoadState('networkidle', { timeout: 3000 });
+          await page.waitForLoadState('networkidle', { timeout: 5000 });
         } catch (_) { /* networkidle timed out — proceed with current state */ }
+        // For SPAs that render content asynchronously after XHR (e.g. Gitee
+        // search), poll for visible text content to appear before capturing.
+        // If the page already has content we break immediately; otherwise we
+        // wait up to 3 s in 300 ms increments so we don't over-delay fast pages.
+        try {
+          const pollDeadline = Date.now() + 3000;
+          while (Date.now() < pollDeadline) {
+            const textLen = await page.evaluate(() => (document.body?.innerText?.trim()?.length ?? 0));
+            if (textLen >= 200) break;
+            await new Promise(r => setTimeout(r, 300));
+          }
+        } catch (_) {}
         // `bypassTurnstileIfPresent` already calls `page.content()` after
         // any nudge it performs, so reuse that html instead of fetching
         // again — the earlier `html = await page.content()` overwrite was


### PR DESCRIPTION
## Problem

Pages rendered entirely by JavaScript — like Gitee search, Vite SPAs, and Angular apps — return HTML bodies that produce almost no visible text after `extract_text()`. The SSR skeleton has no hydrated content but `needs_escalation()` doesn't detect them because they lack the specific JS framework markers in `JS_FRAMEWORK_MARKERS`.

**Real example:** `mcp_acrawl_navigate` on Gitee search returned only `"Gitee Search"` (12 chars).

The initial naive fix (HTML > 500 bytes + text < 200 chars) was too broad — it false-positived on legitimate sparse pages (login forms, image-heavy landing pages, short product pages).

## Solution

Replace the single-predicate check with a **multi-signal scoring function** (`looks_like_empty_spa_shell`) that accumulates confidence from layered signals:

| Signal | Score | Example |
|--------|-------|---------|
| **Negative (early return false)** | — | `__NEXT_DATA__`, `window.__NUXT__`, `data-reactroot` |
| `/_next/static/` (no data blob) | +0.70 | Next.js CSR |
| `ng-version=` | +0.80 | Angular |
| `/_nuxt/` (no data blob) | +0.65 | Nuxt CSR |
| `data-sveltekit` / `__sveltekit` | +0.55 | SvelteKit |
| Noscript "enable javascript" | +0.55 | Vue CLI / CRA |
| Empty mount-point div | +0.45 | `id="root"></div>` |
| Bundler hash in script src | +0.30 | `index-D9LVtTP6.js` |
| Low text + large HTML | +0.35 | Structural |
| No semantic elements | +0.20 | No `<h1>`/`<p>`/`<article>` |

**Threshold: score >= 0.60 to escalate.** This means:
- Sparse text alone (0.35) **cannot** trigger escalation
- Empty mount-point + hash bundle (0.75) **does** trigger
- Any page with `__NEXT_DATA__` or `data-reactroot` **never** escalates (data already present)

Also adds a hydration wait in the Playwright bridge: after navigation, polls for visible text content (up to 3s) before capturing, so async-rendered SPAs have time to hydrate.

## Changes

- `crates/browser/src/fetch.rs`: +245/-15 lines
  - `looks_like_empty_spa_shell()` — multi-signal scoring function
  - `has_bundler_hash_pattern()` / `has_hash_segment()` — Vite/Webpack/CRA hash detection
  - 13 unit tests covering all signal tiers + negative cases
- `crates/browser/src/playwright/bridge_script.rs`: +8/-3 lines
  - Hydration wait polling loop (300ms intervals, 3s cap)
  - Named `MIN_VISIBLE_CHARS` constant with cross-file reference

## Testing

```
cargo test -p browser spa_shell    # 11/11 pass
cargo test -p browser bundler_hash # 2/2 pass
cargo test --workspace             # 1,396 pass, 0 fail
cargo clippy --workspace --all-targets -- -D warnings  # clean
```
