### PR TITLE
feat: non-interactive CLI for agent/CI use (auth, config, mcp install)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,20 @@ cargo fmt --check                                            # format check
 ./target/release/acrawl mcp                                  # launch MCP server (stdio)
 ./target/release/acrawl mcp install                          # interactive IDE installer
 ./target/release/acrawl --resume session.json /status /compact        # non-interactive session maintenance
+
+# Non-interactive provider setup (agent/CI use)
+acrawl auth anthropic --api-key "sk-ant-..."      # configure credentials
+acrawl auth openai --api-key "sk-..."             # other providers same pattern
+acrawl auth amazon-bedrock --access-key AKIA... --secret-key ... --region us-east-1
+acrawl config set model anthropic/claude-sonnet-4-6  # set default model
+acrawl auth status --check anthropic              # gate: exit 0 if ready, 3 if not
+acrawl auth status                                # show all configured providers
+acrawl auth list                                  # list all available providers
+acrawl config get headless                        # read a setting
+acrawl config set headless false                  # write a setting
+acrawl mcp install --client opencode             # install MCP for one IDE
+acrawl mcp install --all --yes                   # install for all IDEs
+# Exit codes: 0=ok  1=error  2=usage/config  3=not-configured
 ```
 
 The CLI reads LLM credentials from `~/.acrawl/credentials.json` (managed by `acrawl auth`) and runtime settings from `~/.acrawl/settings.json`. Both paths respect the `ACRAWL_CONFIG_HOME` env var override. Run `acrawl auth [anthropic|openai|other]` to configure a provider.

--- a/README.md
+++ b/README.md
@@ -722,6 +722,31 @@ Options:
 | `/version` | Version and build info | Yes |
 | `/exit` | Exit and save session | No |
 
+### Non-interactive / Agent use
+
+# Configure once
+acrawl auth anthropic --api-key sk-ant-...
+acrawl auth openai --api-key sk-...
+acrawl auth amazon-bedrock --access-key AKIA... --secret-key ... --region us-east-1
+acrawl auth other --base-url http://localhost:11434/v1  # Ollama, no key
+acrawl config set model anthropic/claude-sonnet-4-6
+
+# Verify setup
+acrawl auth status --check anthropic   # exits 0 if configured, 3 if not
+acrawl auth status --json              # full credential table (secrets masked)
+
+# Run
+acrawl prompt "scrape all titles from example.com" --output-format json
+
+# Settings
+acrawl config set headless false
+acrawl config set optimization.html_diff_mode true
+acrawl config get model --effective
+
+# MCP install
+acrawl mcp install --client opencode --scope user
+acrawl mcp install --all --yes
+
 ## Configuration
 
 All config lives in `~/.acrawl/` (override with `ACRAWL_CONFIG_HOME`).

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -177,12 +177,13 @@ fn run(action: CliAction) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn run_repl(model: String, allowed_tools: Option<AllowedToolSet>) -> Result<(), CliError> {
-    if !std::io::stdout().is_terminal() {
-        return Err(CliError::from(
+    if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
+        eprintln!(
             "acrawl REPL requires an interactive terminal. \
              For headless use, run `acrawl prompt \"<goal>\"` (one-shot) \
-             or `acrawl --resume <session.json> <slash-commands>` (session maintenance).",
-        ));
+             or `acrawl --resume <session.json> <slash-commands>` (session maintenance)."
+        );
+        process::exit(2);
     }
     Ok(acrawl_tui::run_tui(model, allowed_tools)?)
 }
@@ -1259,7 +1260,7 @@ fn print_help_to(out: &mut impl Write) -> io::Result<()> {
     )?;
     writeln!(
         out,
-        "                               --resource, --deployment (Azure)"
+        "                               --resource-name, --deployment-name (Azure)"
     )?;
     writeln!(
         out,
@@ -1294,7 +1295,7 @@ fn print_help_to(out: &mut impl Write) -> io::Result<()> {
     )?;
     writeln!(
         out,
-        "  acrawl mcp uninstall [--client a,b,...] [--all] [--json]"
+        "  acrawl mcp uninstall [--client a,b,...] [--all] [--scope user|project] [--json]"
     )?;
     writeln!(out, "  acrawl mcp install --list-clients")?;
     writeln!(out, "      Non-interactive MCP IDE configuration")?;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -67,6 +67,7 @@ fn main() {
     }
 }
 
+#[allow(clippy::too_many_lines)]
 fn run(action: CliAction) -> Result<(), Box<dyn std::error::Error>> {
     match action {
         CliAction::PrintSystemPrompt => print_system_prompt(),
@@ -500,6 +501,7 @@ fn parse_auth_list_args(args: &[String]) -> Result<CliAction, String> {
     Ok(CliAction::AuthList { json })
 }
 
+#[allow(clippy::too_many_lines)]
 fn parse_auth_config_or_interactive_args(args: &[String]) -> Result<CliAction, String> {
     let mut provider = None;
     let mut flags = AuthFlags::default();
@@ -866,6 +868,7 @@ fn client_key(ide: mcp_server::Ide) -> &'static str {
         .unwrap_or_default()
 }
 
+#[allow(clippy::needless_pass_by_value)]
 fn run_mcp_configured(
     clients: Vec<String>,
     all: bool,
@@ -937,10 +940,8 @@ fn run_mcp_configured(
 
     if explicit_client && success_count == 0 {
         3
-    } else if success_count > 0 {
-        0
     } else {
-        1
+        i32::from(success_count == 0)
     }
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5,13 +5,14 @@ use std::collections::BTreeMap;
 use std::env;
 use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
+use std::process;
 
 use acrawl_ui::{
     app::{
         initial_model_from_credentials, run_auth_cli, run_resume_command, AllowedToolSet, LiveCli,
     },
     error::CliError,
-    CliOutputFormat, TOKIO_RUNTIME,
+    AuthFlags, CliOutputFormat, ConfigAction, TOKIO_RUNTIME,
 };
 use agent::mvp_tool_specs;
 use commands::{render_slash_command_help, resume_supported_slash_commands, SlashCommand};
@@ -51,15 +52,23 @@ fn main() {
             .expect("failed to create tokio runtime")
     });
 
-    if let Err(error) = run() {
+    let args: Vec<String> = env::args().skip(1).collect();
+    let action = match parse_args(&args) {
+        Ok(action) => action,
+        Err(error) => {
+            eprintln!("error: {error}");
+            process::exit(2);
+        }
+    };
+
+    if let Err(error) = run(action) {
         eprintln!("error: {error}");
-        std::process::exit(1);
+        process::exit(1);
     }
 }
 
-fn run() -> Result<(), Box<dyn std::error::Error>> {
-    let args: Vec<String> = env::args().skip(1).collect();
-    match parse_args(&args)? {
+fn run(action: CliAction) -> Result<(), Box<dyn std::error::Error>> {
+    match action {
         CliAction::PrintSystemPrompt => print_system_prompt(),
         CliAction::Version => print_version(),
         CliAction::ResumeSession {
@@ -75,7 +84,24 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             LiveCli::new_non_interactive(model, true, allowed_tools)?
                 .run_turn_with_output(&prompt, output_format)?;
         }
-        CliAction::Auth { provider } => run_auth_cli(provider.as_deref())?,
+        CliAction::Auth { provider } => {
+            if !std::io::stdin().is_terminal() {
+                eprintln!(
+                    "interactive `acrawl auth` requires a TTY; use `--api-key` for non-interactive configuration"
+                );
+                process::exit(2);
+            }
+            run_auth_cli(provider.as_deref())?;
+        }
+        CliAction::AuthConfigure {
+            provider,
+            flags,
+            json,
+        } => process::exit(acrawl_ui::run_auth_configure(&provider, flags, json)),
+        CliAction::AuthStatus { check, json } => {
+            process::exit(acrawl_ui::run_auth_status(check.as_deref(), json));
+        }
+        CliAction::AuthList { json } => process::exit(acrawl_ui::run_auth_list(json)),
         CliAction::Update => {
             let rt = TOKIO_RUNTIME.get().expect("tokio runtime not initialized");
             rt.block_on(self_update::run_self_update())?;
@@ -83,8 +109,58 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         CliAction::Uninstall { purge } => uninstall::run_uninstall(purge)?,
         CliAction::InstallBrowser => install_browser()?,
         CliAction::Mcp => mcp_server::run_mcp_server(),
-        CliAction::McpInstall => mcp_server::run_install()?,
-        CliAction::McpUninstall => mcp_server::run_uninstall()?,
+        CliAction::McpInstall => {
+            if !std::io::stdin().is_terminal() {
+                eprintln!(
+                    "interactive `acrawl mcp install` requires a TTY; use `--client` or `--all` for non-interactive mode"
+                );
+                process::exit(2);
+            }
+            mcp_server::run_install()?;
+        }
+        CliAction::McpUninstall => {
+            if !std::io::stdin().is_terminal() {
+                eprintln!(
+                    "interactive `acrawl mcp uninstall` requires a TTY; use `--client` or `--all` for non-interactive mode"
+                );
+                process::exit(2);
+            }
+            mcp_server::run_uninstall()?;
+        }
+        CliAction::ConfigGet {
+            key,
+            effective,
+            json,
+        } => process::exit(acrawl_ui::run_config(
+            ConfigAction::Get { key, effective },
+            json,
+        )),
+        CliAction::ConfigSet { key, value } => {
+            process::exit(acrawl_ui::run_config(
+                ConfigAction::Set { key, value },
+                false,
+            ));
+        }
+        CliAction::ConfigUnset { key } => {
+            process::exit(acrawl_ui::run_config(ConfigAction::Unset { key }, false));
+        }
+        CliAction::ConfigPath => process::exit(acrawl_ui::run_config(ConfigAction::Path, false)),
+        CliAction::McpInstallConfigured {
+            clients,
+            all,
+            scope,
+            json,
+        } => process::exit(run_mcp_configured(clients, all, scope, json, true)),
+        CliAction::McpUninstallConfigured {
+            clients,
+            all,
+            scope,
+            json,
+        } => process::exit(run_mcp_configured(clients, all, scope, json, false)),
+        CliAction::McpListClients { json } => {
+            mcp_server::list_clients(json);
+            process::exit(0);
+        }
         CliAction::Repl {
             model,
             allowed_tools,
@@ -127,6 +203,18 @@ enum CliAction {
     Auth {
         provider: Option<String>,
     },
+    AuthConfigure {
+        provider: String,
+        flags: AuthFlags,
+        json: bool,
+    },
+    AuthStatus {
+        check: Option<String>,
+        json: bool,
+    },
+    AuthList {
+        json: bool,
+    },
     Update,
     Uninstall {
         purge: bool,
@@ -135,6 +223,34 @@ enum CliAction {
     Mcp,
     McpInstall,
     McpUninstall,
+    ConfigGet {
+        key: Option<String>,
+        effective: bool,
+        json: bool,
+    },
+    ConfigSet {
+        key: String,
+        value: String,
+    },
+    ConfigUnset {
+        key: String,
+    },
+    ConfigPath,
+    McpInstallConfigured {
+        clients: Vec<String>,
+        all: bool,
+        scope: Option<String>,
+        json: bool,
+    },
+    McpUninstallConfigured {
+        clients: Vec<String>,
+        all: bool,
+        scope: Option<String>,
+        json: bool,
+    },
+    McpListClients {
+        json: bool,
+    },
     Repl {
         model: Option<String>,
         allowed_tools: Option<AllowedToolSet>,
@@ -255,10 +371,8 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
 
     match rest[0].as_str() {
         "system-prompt" => parse_system_prompt_args(&rest[1..]),
-        "auth" => {
-            let provider = rest.get(1).cloned();
-            Ok(CliAction::Auth { provider })
-        }
+        "auth" => parse_auth_args(&rest[1..]),
+        "config" => parse_config_args(&rest[1..]),
         "login" | "logout" => {
             Err(
                 "`acrawl login` and `acrawl logout` have been removed. Use `acrawl auth` instead."
@@ -270,17 +384,7 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
             purge: rest.iter().any(|a| a == "--purge"),
         }),
         "install-browser" => Ok(CliAction::InstallBrowser),
-        "mcp" => match rest.get(1).map(String::as_str) {
-            None => Ok(CliAction::Mcp),
-            Some("install") if rest.len() == 2 => Ok(CliAction::McpInstall),
-            Some("uninstall") if rest.len() == 2 => Ok(CliAction::McpUninstall),
-            Some("--help" | "-h" | "help") if rest.len() == 2 => Ok(CliAction::Help),
-            Some("install") => Err("`acrawl mcp install` does not accept extra arguments".to_string()),
-            Some("uninstall") => Err("`acrawl mcp uninstall` does not accept extra arguments".to_string()),
-            Some(other) => Err(format!(
-                "unknown mcp subcommand: {other} (supported: install, uninstall)"
-            )),
-        },
+        "mcp" => parse_mcp_args(&rest[1..]),
         "prompt" => {
             let prompt = rest[1..].join(" ");
             if prompt.trim().is_empty() {
@@ -346,6 +450,507 @@ fn normalize_bool_flag(flag: &str, value: &str) -> Result<bool, String> {
             "unsupported value for {flag}: {other} (expected true/false)"
         )),
     }
+}
+
+fn parse_auth_args(args: &[String]) -> Result<CliAction, String> {
+    match args.first().map(String::as_str) {
+        Some("status") => parse_auth_status_args(&args[1..]),
+        Some("list") => parse_auth_list_args(&args[1..]),
+        _ => parse_auth_config_or_interactive_args(args),
+    }
+}
+
+fn parse_auth_status_args(args: &[String]) -> Result<CliAction, String> {
+    let mut check = None;
+    let mut json = false;
+    let mut index = 0;
+
+    while index < args.len() {
+        match args[index].as_str() {
+            "--check" => {
+                let value = args
+                    .get(index + 1)
+                    .ok_or_else(|| "missing value for --check".to_string())?;
+                check = Some(value.clone());
+                index += 2;
+            }
+            flag if flag.starts_with("--check=") => {
+                check = Some(flag[8..].to_string());
+                index += 1;
+            }
+            "--json" => {
+                json = true;
+                index += 1;
+            }
+            other => return Err(format!("unknown auth status option: {other}")),
+        }
+    }
+
+    Ok(CliAction::AuthStatus { check, json })
+}
+
+fn parse_auth_list_args(args: &[String]) -> Result<CliAction, String> {
+    let mut json = false;
+    for arg in args {
+        match arg.as_str() {
+            "--json" => json = true,
+            other => return Err(format!("unknown auth list option: {other}")),
+        }
+    }
+    Ok(CliAction::AuthList { json })
+}
+
+fn parse_auth_config_or_interactive_args(args: &[String]) -> Result<CliAction, String> {
+    let mut provider = None;
+    let mut flags = AuthFlags::default();
+    let mut json = false;
+    let mut saw_cred_flag = false;
+    let mut index = 0;
+
+    if let Some(first) = args.first().filter(|arg| !arg.starts_with('-')) {
+        provider = Some(first.clone());
+        index = 1;
+    }
+
+    while index < args.len() {
+        match args[index].as_str() {
+            "--api-key" => {
+                flags.api_key = Some(required_flag_value(args, index, "--api-key")?.clone());
+                saw_cred_flag = true;
+                index += 2;
+            }
+            flag if flag.starts_with("--api-key=") => {
+                flags.api_key = Some(flag[10..].to_string());
+                saw_cred_flag = true;
+                index += 1;
+            }
+            "--access-key" => {
+                flags.access_key = Some(required_flag_value(args, index, "--access-key")?.clone());
+                saw_cred_flag = true;
+                index += 2;
+            }
+            flag if flag.starts_with("--access-key=") => {
+                flags.access_key = Some(flag[13..].to_string());
+                saw_cred_flag = true;
+                index += 1;
+            }
+            "--secret-key" => {
+                flags.secret_key = Some(required_flag_value(args, index, "--secret-key")?.clone());
+                saw_cred_flag = true;
+                index += 2;
+            }
+            flag if flag.starts_with("--secret-key=") => {
+                flags.secret_key = Some(flag[13..].to_string());
+                saw_cred_flag = true;
+                index += 1;
+            }
+            "--region" => {
+                flags.region = Some(required_flag_value(args, index, "--region")?.clone());
+                saw_cred_flag = true;
+                index += 2;
+            }
+            flag if flag.starts_with("--region=") => {
+                flags.region = Some(flag[9..].to_string());
+                saw_cred_flag = true;
+                index += 1;
+            }
+            "--resource-name" => {
+                flags.resource_name =
+                    Some(required_flag_value(args, index, "--resource-name")?.clone());
+                saw_cred_flag = true;
+                index += 2;
+            }
+            flag if flag.starts_with("--resource-name=") => {
+                flags.resource_name = Some(flag[16..].to_string());
+                saw_cred_flag = true;
+                index += 1;
+            }
+            "--deployment-name" => {
+                flags.deployment_name =
+                    Some(required_flag_value(args, index, "--deployment-name")?.clone());
+                saw_cred_flag = true;
+                index += 2;
+            }
+            flag if flag.starts_with("--deployment-name=") => {
+                flags.deployment_name = Some(flag[18..].to_string());
+                saw_cred_flag = true;
+                index += 1;
+            }
+            "--base-url" => {
+                flags.base_url = Some(required_flag_value(args, index, "--base-url")?.clone());
+                saw_cred_flag = true;
+                index += 2;
+            }
+            flag if flag.starts_with("--base-url=") => {
+                flags.base_url = Some(flag[11..].to_string());
+                saw_cred_flag = true;
+                index += 1;
+            }
+            "--gcp-project" => {
+                flags.gcp_project =
+                    Some(required_flag_value(args, index, "--gcp-project")?.clone());
+                saw_cred_flag = true;
+                index += 2;
+            }
+            flag if flag.starts_with("--gcp-project=") => {
+                flags.gcp_project = Some(flag[14..].to_string());
+                saw_cred_flag = true;
+                index += 1;
+            }
+            "--gcp-region" => {
+                flags.gcp_region = Some(required_flag_value(args, index, "--gcp-region")?.clone());
+                saw_cred_flag = true;
+                index += 2;
+            }
+            flag if flag.starts_with("--gcp-region=") => {
+                flags.gcp_region = Some(flag[13..].to_string());
+                saw_cred_flag = true;
+                index += 1;
+            }
+            "--json" => {
+                json = true;
+                index += 1;
+            }
+            other => return Err(format!("unknown auth option: {other}")),
+        }
+    }
+
+    if saw_cred_flag {
+        let provider = provider.ok_or_else(|| {
+            "non-interactive `acrawl auth` requires a provider before credential flags".to_string()
+        })?;
+        return Ok(CliAction::AuthConfigure {
+            provider,
+            flags,
+            json,
+        });
+    }
+
+    if json {
+        return Err(
+            "`--json` requires credential flags, `auth status`, or `auth list`".to_string(),
+        );
+    }
+
+    if index < args.len() {
+        return Err(format!("unknown auth option: {}", args[index]));
+    }
+
+    Ok(CliAction::Auth { provider })
+}
+
+fn parse_config_args(args: &[String]) -> Result<CliAction, String> {
+    match args.first().map(String::as_str) {
+        Some("get") => parse_config_get_args(&args[1..]),
+        Some("set") => parse_config_set_args(&args[1..]),
+        Some("unset") => parse_config_unset_args(&args[1..]),
+        Some("path") => parse_config_path_args(&args[1..]),
+        Some(other) => Err(format!(
+            "unknown config subcommand: {other} (supported: get, set, unset, path)"
+        )),
+        None => Err("missing config subcommand (supported: get, set, unset, path)".to_string()),
+    }
+}
+
+fn parse_config_get_args(args: &[String]) -> Result<CliAction, String> {
+    let mut key = None;
+    let mut effective = false;
+    let mut json = false;
+
+    for arg in args {
+        match arg.as_str() {
+            "--effective" => effective = true,
+            "--json" => json = true,
+            other if other.starts_with('-') => {
+                return Err(format!("unknown config get option: {other}"))
+            }
+            other => {
+                if key.is_some() {
+                    return Err("config get accepts at most one key".to_string());
+                }
+                key = Some(other.to_string());
+            }
+        }
+    }
+
+    Ok(CliAction::ConfigGet {
+        key,
+        effective,
+        json,
+    })
+}
+
+fn parse_config_set_args(args: &[String]) -> Result<CliAction, String> {
+    if args.len() != 2 {
+        return Err("usage: acrawl config set <key> <value>".to_string());
+    }
+    Ok(CliAction::ConfigSet {
+        key: args[0].clone(),
+        value: args[1].clone(),
+    })
+}
+
+fn parse_config_unset_args(args: &[String]) -> Result<CliAction, String> {
+    if args.len() != 1 {
+        return Err("usage: acrawl config unset <key>".to_string());
+    }
+    Ok(CliAction::ConfigUnset {
+        key: args[0].clone(),
+    })
+}
+
+fn parse_config_path_args(args: &[String]) -> Result<CliAction, String> {
+    if let Some(other) = args.first() {
+        return Err(format!("unknown config path option: {other}"));
+    }
+    Ok(CliAction::ConfigPath)
+}
+
+fn parse_mcp_args(args: &[String]) -> Result<CliAction, String> {
+    match args.first().map(String::as_str) {
+        None => Ok(CliAction::Mcp),
+        Some("install") => parse_mcp_configured_args(&args[1..], true),
+        Some("uninstall") => parse_mcp_configured_args(&args[1..], false),
+        Some("--help" | "-h" | "help") if args.len() == 1 => Ok(CliAction::Help),
+        Some(other) => Err(format!(
+            "unknown mcp subcommand: {other} (supported: install, uninstall)"
+        )),
+    }
+}
+
+fn parse_mcp_configured_args(args: &[String], install: bool) -> Result<CliAction, String> {
+    if args.is_empty() {
+        return Ok(if install {
+            CliAction::McpInstall
+        } else {
+            CliAction::McpUninstall
+        });
+    }
+
+    let mut clients = Vec::new();
+    let mut all = false;
+    let mut scope = None;
+    let mut json = false;
+    let mut list_clients = false;
+    let mut saw_config_flag = false;
+    let mut index = 0;
+
+    while index < args.len() {
+        match args[index].as_str() {
+            "--client" => {
+                saw_config_flag = true;
+                let value = required_flag_value(args, index, "--client")?;
+                extend_clients(&mut clients, value)?;
+                index += 2;
+            }
+            flag if flag.starts_with("--client=") => {
+                saw_config_flag = true;
+                extend_clients(&mut clients, &flag[9..])?;
+                index += 1;
+            }
+            "--all" => {
+                all = true;
+                saw_config_flag = true;
+                index += 1;
+            }
+            "--scope" => {
+                scope = Some(required_flag_value(args, index, "--scope")?.clone());
+                saw_config_flag = true;
+                index += 2;
+            }
+            flag if flag.starts_with("--scope=") => {
+                scope = Some(flag[8..].to_string());
+                saw_config_flag = true;
+                index += 1;
+            }
+            "--yes" => {
+                saw_config_flag = true;
+                index += 1;
+            }
+            "--json" => {
+                json = true;
+                saw_config_flag = true;
+                index += 1;
+            }
+            "--list-clients" => {
+                list_clients = true;
+                saw_config_flag = true;
+                index += 1;
+            }
+            other => {
+                return Err(format!(
+                    "`acrawl mcp {}` does not accept extra arguments: {other}",
+                    if install { "install" } else { "uninstall" }
+                ));
+            }
+        }
+    }
+
+    if !saw_config_flag {
+        return Ok(if install {
+            CliAction::McpInstall
+        } else {
+            CliAction::McpUninstall
+        });
+    }
+
+    if list_clients {
+        return Ok(CliAction::McpListClients { json });
+    }
+
+    if let Some(scope_value) = scope.as_deref() {
+        parse_scope(scope_value)?;
+    }
+
+    Ok(if install {
+        CliAction::McpInstallConfigured {
+            clients,
+            all,
+            scope,
+            json,
+        }
+    } else {
+        CliAction::McpUninstallConfigured {
+            clients,
+            all,
+            scope,
+            json,
+        }
+    })
+}
+
+fn required_flag_value<'a>(
+    args: &'a [String],
+    index: usize,
+    flag: &str,
+) -> Result<&'a String, String> {
+    args.get(index + 1)
+        .ok_or_else(|| format!("missing value for {flag}"))
+}
+
+fn extend_clients(clients: &mut Vec<String>, value: &str) -> Result<(), String> {
+    for token in value.split(',') {
+        let trimmed = token.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let ide = mcp_server::client_from_key(trimmed).ok_or_else(|| {
+            format!(
+                "unknown MCP client `{trimmed}` (supported: {})",
+                mcp_server::all_client_keys()
+                    .iter()
+                    .map(|(key, _)| *key)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        })?;
+        clients.push(client_key(ide).to_string());
+    }
+    Ok(())
+}
+
+fn parse_scope(value: &str) -> Result<mcp_server::Scope, String> {
+    match value {
+        "user" => Ok(mcp_server::Scope::Global),
+        "project" => Ok(mcp_server::Scope::Project),
+        other => Err(format!(
+            "unsupported value for --scope: {other} (expected user or project)"
+        )),
+    }
+}
+
+fn client_key(ide: mcp_server::Ide) -> &'static str {
+    mcp_server::all_client_keys()
+        .iter()
+        .find_map(|(key, _)| (mcp_server::client_from_key(key) == Some(ide)).then_some(*key))
+        .unwrap_or_default()
+}
+
+fn run_mcp_configured(
+    clients: Vec<String>,
+    all: bool,
+    scope: Option<String>,
+    json: bool,
+    install: bool,
+) -> i32 {
+    let explicit_client = !clients.is_empty();
+    if !all && clients.is_empty() {
+        return emit_subcommand_error(
+            json,
+            "non-interactive MCP mode requires `--client` or `--all`",
+            2,
+        );
+    }
+
+    let selected = if all {
+        mcp_server::all_client_keys()
+            .iter()
+            .map(|(key, _)| mcp_server::client_from_key(key).unwrap_or(mcp_server::Ide::Cursor))
+            .collect::<Vec<_>>()
+    } else {
+        clients
+            .iter()
+            .filter_map(|key| mcp_server::client_from_key(key))
+            .collect::<Vec<_>>()
+    };
+
+    let scope = match scope.as_deref() {
+        Some(value) => match parse_scope(value) {
+            Ok(scope) => scope,
+            Err(error) => return emit_subcommand_error(json, &error, 2),
+        },
+        None => mcp_server::Scope::Global,
+    };
+
+    let report = if install {
+        mcp_server::run_install_for(&selected, scope, json)
+    } else {
+        mcp_server::run_uninstall_for(&selected, scope, json)
+    };
+
+    if json {
+        match serde_json::to_string_pretty(&report) {
+            Ok(output) => println!("{output}"),
+            Err(error) => {
+                return emit_subcommand_error(
+                    true,
+                    &format!("failed to serialize MCP report: {error}"),
+                    1,
+                );
+            }
+        }
+    }
+
+    let success_count = report
+        .results
+        .iter()
+        .filter(|result| {
+            matches!(
+                result.status,
+                mcp_server::installer::ClientStatus::Configured
+                    | mcp_server::installer::ClientStatus::ManualInstructions
+                    | mcp_server::installer::ClientStatus::Removed
+                    | mcp_server::installer::ClientStatus::NotFound
+            )
+        })
+        .count();
+
+    if explicit_client && success_count == 0 {
+        3
+    } else if success_count > 0 {
+        0
+    } else {
+        1
+    }
+}
+
+fn emit_subcommand_error(json: bool, error: &str, code: i32) -> i32 {
+    if json {
+        println!("{}", serde_json::json!({ "ok": false, "error": error }));
+    } else {
+        eprintln!("{error}");
+    }
+    code
 }
 
 fn parse_system_prompt_args(args: &[String]) -> Result<CliAction, String> {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1244,13 +1244,72 @@ fn print_help_to(out: &mut impl Write) -> io::Result<()> {
         out,
         "      Configure credentials for a provider interactively"
     )?;
+    writeln!(
+        out,
+        "  acrawl auth <provider> --api-key KEY [provider-flags] [--json]"
+    )?;
+    writeln!(
+        out,
+        "      Configure provider credentials non-interactively"
+    )?;
+    writeln!(
+        out,
+        "      Provider-specific flags: --access-key, --secret-key, --region (Bedrock)"
+    )?;
+    writeln!(
+        out,
+        "                               --resource, --deployment (Azure)"
+    )?;
+    writeln!(
+        out,
+        "                               --base-url (Custom/Other)"
+    )?;
+    writeln!(
+        out,
+        "                               --gcp-project, --gcp-region (Vertex)"
+    )?;
+    writeln!(
+        out,
+        "      Warning: --api-key is visible in process list and shell history"
+    )?;
+    writeln!(out, "  acrawl auth status [--check <provider>] [--json]")?;
+    writeln!(
+        out,
+        "      Show configured providers (exit 3 if --check provider not configured)"
+    )?;
+    writeln!(out, "  acrawl auth list [--json]")?;
+    writeln!(out, "      List all available providers and their env vars")?;
+    writeln!(out, "  acrawl config get [<key>] [--effective] [--json]")?;
+    writeln!(out, "  acrawl config set <key> <value>")?;
+    writeln!(out, "  acrawl config unset <key>")?;
+    writeln!(out, "  acrawl config path")?;
+    writeln!(
+        out,
+        "      Read/write settings.json (dot-notation: optimization.html_diff_mode)"
+    )?;
+    writeln!(
+        out,
+        "  acrawl mcp install [--client a,b,...] [--all] [--scope user|project] [--json]"
+    )?;
+    writeln!(
+        out,
+        "  acrawl mcp uninstall [--client a,b,...] [--all] [--json]"
+    )?;
+    writeln!(out, "  acrawl mcp install --list-clients")?;
+    writeln!(out, "      Non-interactive MCP IDE configuration")?;
     writeln!(out, "  acrawl update")?;
     writeln!(out, "  acrawl mcp")?;
     writeln!(out, "      Start the built-in MCP server over stdio")?;
     writeln!(out, "  acrawl mcp install")?;
-    writeln!(out, "      Configure supported IDEs to launch `acrawl mcp`")?;
+    writeln!(
+        out,
+        "      Configure supported IDEs to launch `acrawl mcp` (interactive)"
+    )?;
     writeln!(out, "  acrawl mcp uninstall")?;
-    writeln!(out, "      Remove acrawl from IDE MCP configurations")?;
+    writeln!(
+        out,
+        "      Remove acrawl from IDE MCP configurations (interactive)"
+    )?;
     writeln!(out, "  acrawl install-browser")?;
     writeln!(
         out,
@@ -1300,6 +1359,16 @@ fn print_help_to(out: &mut impl Write) -> io::Result<()> {
         .collect::<Vec<_>>()
         .join(", ");
     writeln!(out, "Resume-safe commands: {resume_commands}")?;
+    writeln!(out)?;
+    writeln!(out, "Exit codes:")?;
+    writeln!(out, "  0  Success")?;
+    writeln!(out, "  1  Runtime or I/O error")?;
+    writeln!(out, "  2  Usage or configuration error")?;
+    writeln!(
+        out,
+        "  3  State check failed (e.g. --check provider not configured)"
+    )?;
+    writeln!(out)?;
     writeln!(out, "Examples:")?;
     writeln!(
         out,
@@ -1764,5 +1833,277 @@ mod tests {
         assert!(help.contains("--purge"));
         assert!(help.contains("acrawl mcp"));
         assert!(help.contains("acrawl mcp install"));
+    }
+
+    #[test]
+    fn parses_auth_status_without_flags() {
+        with_clean_config_env(|| {
+            assert_eq!(
+                parse_args(&["auth".to_string(), "status".to_string()]).expect("auth status"),
+                CliAction::AuthStatus {
+                    check: None,
+                    json: false,
+                }
+            );
+        });
+    }
+
+    #[test]
+    fn parses_auth_status_with_check_provider() {
+        with_clean_config_env(|| {
+            let args = vec![
+                "auth".to_string(),
+                "status".to_string(),
+                "--check".to_string(),
+                "openai".to_string(),
+            ];
+            assert_eq!(
+                parse_args(&args).expect("auth status --check openai"),
+                CliAction::AuthStatus {
+                    check: Some("openai".to_string()),
+                    json: false,
+                }
+            );
+        });
+    }
+
+    #[test]
+    fn parses_auth_status_with_json_flag() {
+        with_clean_config_env(|| {
+            let args = vec![
+                "auth".to_string(),
+                "status".to_string(),
+                "--json".to_string(),
+            ];
+            assert_eq!(
+                parse_args(&args).expect("auth status --json"),
+                CliAction::AuthStatus {
+                    check: None,
+                    json: true,
+                }
+            );
+        });
+    }
+
+    #[test]
+    fn parses_auth_list_without_flags() {
+        with_clean_config_env(|| {
+            assert_eq!(
+                parse_args(&["auth".to_string(), "list".to_string()]).expect("auth list"),
+                CliAction::AuthList { json: false }
+            );
+        });
+    }
+
+    #[test]
+    fn parses_auth_list_with_json_flag() {
+        with_clean_config_env(|| {
+            let args = vec!["auth".to_string(), "list".to_string(), "--json".to_string()];
+            assert_eq!(
+                parse_args(&args).expect("auth list --json"),
+                CliAction::AuthList { json: true }
+            );
+        });
+    }
+
+    #[test]
+    fn parses_auth_configure_openai_with_api_key() {
+        with_clean_config_env(|| {
+            let args = vec![
+                "auth".to_string(),
+                "openai".to_string(),
+                "--api-key".to_string(),
+                "sk-test".to_string(),
+            ];
+            assert_eq!(
+                parse_args(&args).expect("auth openai --api-key sk-test"),
+                CliAction::AuthConfigure {
+                    provider: "openai".to_string(),
+                    flags: AuthFlags {
+                        api_key: Some("sk-test".to_string()),
+                        ..AuthFlags::default()
+                    },
+                    json: false,
+                }
+            );
+        });
+    }
+
+    #[test]
+    fn parses_auth_configure_bedrock_with_equals_flags() {
+        with_clean_config_env(|| {
+            let args = vec![
+                "auth".to_string(),
+                "amazon-bedrock".to_string(),
+                "--access-key=AKIA".to_string(),
+                "--secret-key=sec".to_string(),
+                "--region=eu-west-1".to_string(),
+            ];
+            assert_eq!(
+                parse_args(&args).expect("auth amazon-bedrock with equals flags"),
+                CliAction::AuthConfigure {
+                    provider: "amazon-bedrock".to_string(),
+                    flags: AuthFlags {
+                        access_key: Some("AKIA".to_string()),
+                        secret_key: Some("sec".to_string()),
+                        region: Some("eu-west-1".to_string()),
+                        ..AuthFlags::default()
+                    },
+                    json: false,
+                }
+            );
+        });
+    }
+
+    #[test]
+    fn parses_config_get_without_key() {
+        with_clean_config_env(|| {
+            assert_eq!(
+                parse_args(&["config".to_string(), "get".to_string()]).expect("config get"),
+                CliAction::ConfigGet {
+                    key: None,
+                    effective: false,
+                    json: false,
+                }
+            );
+        });
+    }
+
+    #[test]
+    fn parses_config_get_with_key_and_effective() {
+        with_clean_config_env(|| {
+            let args = vec![
+                "config".to_string(),
+                "get".to_string(),
+                "max_steps".to_string(),
+                "--effective".to_string(),
+            ];
+            assert_eq!(
+                parse_args(&args).expect("config get max_steps --effective"),
+                CliAction::ConfigGet {
+                    key: Some("max_steps".to_string()),
+                    effective: true,
+                    json: false,
+                }
+            );
+        });
+    }
+
+    #[test]
+    fn parses_config_set_key_value() {
+        with_clean_config_env(|| {
+            let args = vec![
+                "config".to_string(),
+                "set".to_string(),
+                "headless".to_string(),
+                "true".to_string(),
+            ];
+            assert_eq!(
+                parse_args(&args).expect("config set headless true"),
+                CliAction::ConfigSet {
+                    key: "headless".to_string(),
+                    value: "true".to_string(),
+                }
+            );
+        });
+    }
+
+    #[test]
+    fn rejects_config_set_missing_value() {
+        with_clean_config_env(|| {
+            let args = vec![
+                "config".to_string(),
+                "set".to_string(),
+                "headless".to_string(),
+            ];
+            let err = parse_args(&args).expect_err("config set without value should fail");
+            assert!(
+                err.contains("usage: acrawl config set <key> <value>"),
+                "{err}"
+            );
+        });
+    }
+
+    #[test]
+    fn parses_config_unset_key() {
+        with_clean_config_env(|| {
+            let args = vec![
+                "config".to_string(),
+                "unset".to_string(),
+                "headless".to_string(),
+            ];
+            assert_eq!(
+                parse_args(&args).expect("config unset headless"),
+                CliAction::ConfigUnset {
+                    key: "headless".to_string(),
+                }
+            );
+        });
+    }
+
+    #[test]
+    fn parses_config_path() {
+        with_clean_config_env(|| {
+            assert_eq!(
+                parse_args(&["config".to_string(), "path".to_string()]).expect("config path"),
+                CliAction::ConfigPath
+            );
+        });
+    }
+
+    #[test]
+    fn parses_mcp_install_with_client() {
+        with_clean_config_env(|| {
+            let args = vec![
+                "mcp".to_string(),
+                "install".to_string(),
+                "--client".to_string(),
+                "cursor".to_string(),
+            ];
+            assert_eq!(
+                parse_args(&args).expect("mcp install --client cursor"),
+                CliAction::McpInstallConfigured {
+                    clients: vec!["cursor".to_string()],
+                    all: false,
+                    scope: None,
+                    json: false,
+                }
+            );
+        });
+    }
+
+    #[test]
+    fn parses_mcp_install_with_all_flag() {
+        with_clean_config_env(|| {
+            let args = vec![
+                "mcp".to_string(),
+                "install".to_string(),
+                "--all".to_string(),
+            ];
+            assert_eq!(
+                parse_args(&args).expect("mcp install --all"),
+                CliAction::McpInstallConfigured {
+                    clients: Vec::new(),
+                    all: true,
+                    scope: None,
+                    json: false,
+                }
+            );
+        });
+    }
+
+    #[test]
+    fn parses_mcp_install_list_clients() {
+        with_clean_config_env(|| {
+            let args = vec![
+                "mcp".to_string(),
+                "install".to_string(),
+                "--list-clients".to_string(),
+            ];
+            assert_eq!(
+                parse_args(&args).expect("mcp install --list-clients"),
+                CliAction::McpListClients { json: false }
+            );
+        });
     }
 }

--- a/crates/mcp-server/src/installer.rs
+++ b/crates/mcp-server/src/installer.rs
@@ -9,7 +9,7 @@ use dialoguer::{theme::ColorfulTheme, MultiSelect, Select};
 use serde_json::{json, Value};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Ide {
+pub enum Ide {
     ClaudeCode,
     Cursor,
     Windsurf,
@@ -72,6 +72,28 @@ impl Ide {
         }
     }
 
+    fn key(self) -> &'static str {
+        match self {
+            Self::ClaudeCode => "claude-code",
+            Self::Cursor => "cursor",
+            Self::Windsurf => "windsurf",
+            Self::VsCode => "vscode",
+            Self::OpenCode => "opencode",
+            Self::ClaudeDesktop => "claude-desktop",
+            Self::JetBrains => "jetbrains",
+            Self::Trae => "trae",
+            Self::GeminiCli => "gemini-cli",
+            Self::QwenCode => "qwen-code",
+            Self::Crush => "crush",
+            Self::Zed => "zed",
+            Self::OpenClaw => "openclaw",
+            Self::CodexCli => "codex-cli",
+            Self::Hermes => "hermes",
+            Self::Goose => "goose",
+            Self::Aider => "aider",
+        }
+    }
+
     fn supports_project_scope(self) -> bool {
         !matches!(
             self,
@@ -93,7 +115,7 @@ impl Ide {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Scope {
+pub enum Scope {
     Global,
     Project,
 }
@@ -1032,28 +1054,17 @@ pub fn run_uninstall() -> Result<(), Box<dyn std::error::Error>> {
 
     let scope = prompt_scope()?;
 
-    eprintln!("\nRemoving acrawl MCP server configuration...\n");
-
-    let mut success_count = 0u32;
-    for ide in &selected {
-        if scope == Scope::Global && !ide.supports_global_scope() {
-            eprintln!("  ⚠ {} — skipped (project-level config only)", ide.name());
-            continue;
-        }
-        if scope == Scope::Project && !ide.supports_project_scope() {
-            eprintln!("  ⚠ {} — skipped (global config only)", ide.name());
-            continue;
-        }
-        match uninstall_for_ide(*ide, scope) {
-            Ok(detail) => {
-                eprintln!("  ✓ {} — {detail}", ide.name());
-                success_count += 1;
-            }
-            Err(e) => {
-                eprintln!("  ✗ {} — error: {e}", ide.name());
-            }
-        }
-    }
+    let report = run_uninstall_for(&selected, scope, false);
+    let success_count = report
+        .results
+        .iter()
+        .filter(|r| {
+            matches!(
+                r.status,
+                ClientStatus::Removed | ClientStatus::NotFound | ClientStatus::ManualInstructions
+            )
+        })
+        .count();
 
     if success_count > 0 {
         eprintln!(
@@ -1064,6 +1075,203 @@ pub fn run_uninstall() -> Result<(), Box<dyn std::error::Error>> {
         eprintln!("\nNo configurations were removed.");
     }
     Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub enum ClientStatus {
+    Configured,
+    Removed,
+    NotFound,
+    SkippedScope,
+    ManualInstructions,
+    Error(String),
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct ClientResult {
+    pub key: String,
+    pub display_name: String,
+    pub status: ClientStatus,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct InstallReport {
+    pub results: Vec<ClientResult>,
+}
+
+const CLIENT_KEYS: &[(&str, &str)] = &[
+    ("claude-code", "Claude Code"),
+    ("cursor", "Cursor"),
+    ("windsurf", "Windsurf"),
+    ("vscode", "VS Code (Copilot)"),
+    ("opencode", "OpenCode"),
+    ("claude-desktop", "Claude Desktop"),
+    ("jetbrains", "JetBrains IDEs"),
+    ("trae", "TRAE"),
+    ("gemini-cli", "Gemini CLI"),
+    ("qwen-code", "Qwen Code"),
+    ("crush", "Crush"),
+    ("zed", "Zed"),
+    ("openclaw", "OpenClaw"),
+    ("codex-cli", "Codex CLI"),
+    ("hermes", "Hermes"),
+    ("goose", "Goose"),
+    ("aider", "Aider"),
+];
+
+#[must_use]
+pub fn all_client_keys() -> &'static [(&'static str, &'static str)] {
+    CLIENT_KEYS
+}
+
+#[must_use]
+pub fn client_from_key(key: &str) -> Option<Ide> {
+    let needle = key.to_ascii_lowercase();
+    Ide::ALL.iter().copied().find(|ide| ide.key() == needle)
+}
+
+pub fn list_clients(json: bool) {
+    if json {
+        let arr: Vec<Value> = all_client_keys()
+            .iter()
+            .map(|(key, name)| json!({ "key": key, "display_name": name }))
+            .collect();
+        let out =
+            serde_json::to_string_pretty(&Value::Array(arr)).unwrap_or_else(|_| "[]".to_string());
+        println!("{out}");
+    } else {
+        println!("Supported MCP clients ({} total):", all_client_keys().len());
+        for (key, name) in all_client_keys() {
+            println!("  {key:<14} {name}");
+        }
+    }
+}
+
+fn classify_install_status(ide: Ide) -> ClientStatus {
+    if matches!(ide, Ide::JetBrains | Ide::Goose) {
+        ClientStatus::ManualInstructions
+    } else {
+        ClientStatus::Configured
+    }
+}
+
+fn classify_uninstall_status(ide: Ide, detail: &str) -> ClientStatus {
+    if matches!(ide, Ide::JetBrains | Ide::Goose) {
+        ClientStatus::ManualInstructions
+    } else if detail.starts_with("not found") {
+        ClientStatus::NotFound
+    } else {
+        ClientStatus::Removed
+    }
+}
+
+fn skipped_for_scope(ide: Ide, scope: Scope, json: bool) -> bool {
+    if scope == Scope::Global && !ide.supports_global_scope() {
+        if !json {
+            eprintln!("  ⚠ {} — skipped (project-level config only)", ide.name());
+        }
+        return true;
+    }
+    if scope == Scope::Project && !ide.supports_project_scope() {
+        if !json {
+            eprintln!("  ⚠ {} — skipped (global config only)", ide.name());
+        }
+        return true;
+    }
+    false
+}
+
+fn install_client_result(ide: Ide, scope: Scope, acrawl_path: &str, json: bool) -> ClientResult {
+    let key = ide.key().to_string();
+    let display_name = ide.name().to_string();
+
+    if skipped_for_scope(ide, scope, json) {
+        return ClientResult {
+            key,
+            display_name,
+            status: ClientStatus::SkippedScope,
+        };
+    }
+
+    let status = match install_for_ide(ide, scope, acrawl_path) {
+        Ok(detail) => {
+            if !json {
+                eprintln!("  ✓ {} — {detail}", ide.name());
+            }
+            classify_install_status(ide)
+        }
+        Err(e) => {
+            if !json {
+                eprintln!("  ✗ {} — error: {e}", ide.name());
+            }
+            ClientStatus::Error(e.to_string())
+        }
+    };
+
+    ClientResult {
+        key,
+        display_name,
+        status,
+    }
+}
+
+fn uninstall_client_result(ide: Ide, scope: Scope, json: bool) -> ClientResult {
+    let key = ide.key().to_string();
+    let display_name = ide.name().to_string();
+
+    if skipped_for_scope(ide, scope, json) {
+        return ClientResult {
+            key,
+            display_name,
+            status: ClientStatus::SkippedScope,
+        };
+    }
+
+    let status = match uninstall_for_ide(ide, scope) {
+        Ok(detail) => {
+            if !json {
+                eprintln!("  ✓ {} — {detail}", ide.name());
+            }
+            classify_uninstall_status(ide, &detail)
+        }
+        Err(e) => {
+            if !json {
+                eprintln!("  ✗ {} — error: {e}", ide.name());
+            }
+            ClientStatus::Error(e.to_string())
+        }
+    };
+
+    ClientResult {
+        key,
+        display_name,
+        status,
+    }
+}
+
+#[must_use]
+pub fn run_install_for(clients: &[Ide], scope: Scope, json: bool) -> InstallReport {
+    let acrawl_path = resolve_acrawl_path();
+    if !json {
+        eprintln!("\nInstalling acrawl MCP server (binary: {acrawl_path})...\n");
+    }
+    let results = clients
+        .iter()
+        .map(|ide| install_client_result(*ide, scope, &acrawl_path, json))
+        .collect();
+    InstallReport { results }
+}
+
+#[must_use]
+pub fn run_uninstall_for(clients: &[Ide], scope: Scope, json: bool) -> InstallReport {
+    if !json {
+        eprintln!("\nRemoving acrawl MCP server configuration...\n");
+    }
+    let results = clients
+        .iter()
+        .map(|ide| uninstall_client_result(*ide, scope, json))
+        .collect();
+    InstallReport { results }
 }
 
 pub fn run_install() -> Result<(), Box<dyn std::error::Error>> {
@@ -1082,30 +1290,18 @@ pub fn run_install() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let scope = prompt_scope()?;
-    let acrawl_path = resolve_acrawl_path();
 
-    eprintln!("\nInstalling acrawl MCP server (binary: {acrawl_path})...\n");
-
-    let mut success_count = 0u32;
-    for ide in &selected {
-        if scope == Scope::Global && !ide.supports_global_scope() {
-            eprintln!("  ⚠ {} — skipped (project-level config only)", ide.name());
-            continue;
-        }
-        if scope == Scope::Project && !ide.supports_project_scope() {
-            eprintln!("  ⚠ {} — skipped (global config only)", ide.name());
-            continue;
-        }
-        match install_for_ide(*ide, scope, &acrawl_path) {
-            Ok(detail) => {
-                eprintln!("  ✓ {} — {detail}", ide.name());
-                success_count += 1;
-            }
-            Err(e) => {
-                eprintln!("  ✗ {} — error: {e}", ide.name());
-            }
-        }
-    }
+    let report = run_install_for(&selected, scope, false);
+    let success_count = report
+        .results
+        .iter()
+        .filter(|r| {
+            matches!(
+                r.status,
+                ClientStatus::Configured | ClientStatus::ManualInstructions
+            )
+        })
+        .count();
 
     if success_count > 0 {
         eprintln!(
@@ -1122,6 +1318,136 @@ pub fn run_install() -> Result<(), Box<dyn std::error::Error>> {
 mod tests {
     use super::*;
     use std::fs;
+
+    #[test]
+    fn client_keys_match_expected_kebab_set() {
+        let expected = [
+            "claude-code",
+            "claude-desktop",
+            "cursor",
+            "windsurf",
+            "vscode",
+            "opencode",
+            "zed",
+            "trae",
+            "jetbrains",
+            "gemini-cli",
+            "qwen-code",
+            "codex-cli",
+            "hermes",
+            "openclaw",
+            "goose",
+            "crush",
+            "aider",
+        ];
+        assert_eq!(all_client_keys().len(), 17);
+        let mut actual: Vec<&str> = all_client_keys().iter().map(|(k, _)| *k).collect();
+        actual.sort_unstable();
+        let mut expected_sorted = expected.to_vec();
+        expected_sorted.sort_unstable();
+        assert_eq!(actual, expected_sorted);
+    }
+
+    #[test]
+    fn all_client_keys_matches_ide_all_order() {
+        let pairs: Vec<(&str, &str)> = Ide::ALL.iter().map(|ide| (ide.key(), ide.name())).collect();
+        assert_eq!(pairs.as_slice(), all_client_keys());
+    }
+
+    #[test]
+    fn client_from_key_is_case_insensitive_and_round_trips() {
+        for (key, _name) in all_client_keys() {
+            let ide = client_from_key(key).expect("known key should resolve");
+            assert_eq!(ide.key(), *key);
+            assert_eq!(client_from_key(&key.to_uppercase()), Some(ide));
+        }
+        assert_eq!(client_from_key("nonexistent"), None);
+        assert_eq!(client_from_key(""), None);
+        assert_eq!(client_from_key("vs-code"), None);
+    }
+
+    #[test]
+    fn classify_install_status_marks_manual_clients() {
+        assert_eq!(
+            classify_install_status(Ide::JetBrains),
+            ClientStatus::ManualInstructions
+        );
+        assert_eq!(
+            classify_install_status(Ide::Goose),
+            ClientStatus::ManualInstructions
+        );
+        assert_eq!(
+            classify_install_status(Ide::Cursor),
+            ClientStatus::Configured
+        );
+        assert_eq!(
+            classify_install_status(Ide::ClaudeCode),
+            ClientStatus::Configured
+        );
+    }
+
+    #[test]
+    fn classify_uninstall_status_distinguishes_outcomes() {
+        assert_eq!(
+            classify_uninstall_status(Ide::Cursor, "removed from /tmp/x"),
+            ClientStatus::Removed
+        );
+        assert_eq!(
+            classify_uninstall_status(Ide::Cursor, "not found in /tmp/x"),
+            ClientStatus::NotFound
+        );
+        assert_eq!(
+            classify_uninstall_status(Ide::JetBrains, "printed removal instructions"),
+            ClientStatus::ManualInstructions
+        );
+        assert_eq!(
+            classify_uninstall_status(Ide::Goose, "anything"),
+            ClientStatus::ManualInstructions
+        );
+    }
+
+    #[test]
+    fn run_install_for_skips_incompatible_scope_without_writing() {
+        let report = run_install_for(&[Ide::Trae], Scope::Global, true);
+        assert_eq!(report.results.len(), 1);
+        assert_eq!(report.results[0].key, "trae");
+        assert_eq!(report.results[0].display_name, "TRAE");
+        assert_eq!(report.results[0].status, ClientStatus::SkippedScope);
+
+        let report = run_install_for(&[Ide::Windsurf], Scope::Project, true);
+        assert_eq!(report.results[0].key, "windsurf");
+        assert_eq!(report.results[0].status, ClientStatus::SkippedScope);
+    }
+
+    #[test]
+    fn run_uninstall_for_skips_incompatible_scope() {
+        let report = run_uninstall_for(&[Ide::Crush], Scope::Global, true);
+        assert_eq!(report.results.len(), 1);
+        assert_eq!(report.results[0].key, "crush");
+        assert_eq!(report.results[0].status, ClientStatus::SkippedScope);
+    }
+
+    #[test]
+    fn install_report_serializes_to_json() {
+        let report = InstallReport {
+            results: vec![
+                ClientResult {
+                    key: "cursor".to_string(),
+                    display_name: "Cursor".to_string(),
+                    status: ClientStatus::Configured,
+                },
+                ClientResult {
+                    key: "jetbrains".to_string(),
+                    display_name: "JetBrains IDEs".to_string(),
+                    status: ClientStatus::Error("boom".to_string()),
+                },
+            ],
+        };
+        let value = serde_json::to_value(&report).expect("report serializes");
+        assert_eq!(value["results"][0]["key"], "cursor");
+        assert_eq!(value["results"][0]["status"], "Configured");
+        assert_eq!(value["results"][1]["status"]["Error"], "boom");
+    }
 
     #[test]
     fn resolve_acrawl_path_returns_non_empty() {

--- a/crates/mcp-server/src/lib.rs
+++ b/crates/mcp-server/src/lib.rs
@@ -1,5 +1,8 @@
 pub mod installer;
 pub mod server;
 
-pub use installer::{run_install, run_uninstall};
+pub use installer::{
+    all_client_keys, client_from_key, list_clients, run_install, run_install_for, run_uninstall,
+    run_uninstall_for, Ide, Scope,
+};
 pub use server::run_mcp_server;

--- a/crates/runtime/src/config_ops.rs
+++ b/crates/runtime/src/config_ops.rs
@@ -1,0 +1,1286 @@
+use std::fmt;
+use std::io;
+use std::path::PathBuf;
+
+use serde_json::{json, Value};
+
+use crate::settings::{
+    load_settings, save_settings, settings_file_path, settings_get_action_cache_ttl_secs,
+    settings_get_action_caching, settings_get_auto_compact_tokens, settings_get_budget_enforcement,
+    settings_get_budget_max_session_cost_usd, settings_get_budget_warn_threshold_pct,
+    settings_get_compaction_llm_summarization, settings_get_compaction_max_summary_chars,
+    settings_get_compaction_preserve_recent_messages_floor,
+    settings_get_compaction_preserve_recent_tokens, settings_get_compaction_prune_max_output_chars,
+    settings_get_compaction_prune_protect_tokens, settings_get_compound_enrichment,
+    settings_get_confidence_tracking, settings_get_content_aware_profiles,
+    settings_get_failure_classification, settings_get_fork_child_max_steps,
+    settings_get_fork_wait_timeout_secs, settings_get_headless, settings_get_html_diff_mode,
+    settings_get_loop_detection, settings_get_loop_detection_window,
+    settings_get_loop_nudge_threshold, settings_get_max_concurrent_per_parent,
+    settings_get_max_fork_depth, settings_get_max_steps, settings_get_max_total_agents,
+    settings_get_output_dir, settings_get_page_fingerprinting,
+    settings_get_per_agent_cost_tracking, settings_get_planning_interval,
+    settings_get_self_healing, settings_get_self_healing_max_retries, OptimizationSettings,
+    ScriptSettings, Settings,
+};
+
+const REASONING_EFFORT_VALUES: &[&str] = &["high", "medium", "low"];
+const BROWSER_BACKEND_VALUES: &[&str] = &["extension"];
+const BUDGET_ENFORCEMENT_VALUES: &[&str] = &["warn", "block"];
+
+#[derive(Debug)]
+pub enum ConfigError {
+    UnknownKey(String),
+    BadValue {
+        key: String,
+        value: String,
+        reason: String,
+    },
+    Io(io::Error),
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnknownKey(key) => write!(f, "unknown config key: {key}"),
+            Self::BadValue { key, value, reason } => {
+                write!(f, "bad value for {key}: {value} ({reason})")
+            }
+            Self::Io(err) => write!(f, "{err}"),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(err) => Some(err),
+            Self::UnknownKey(_) | Self::BadValue { .. } => None,
+        }
+    }
+}
+
+impl From<io::Error> for ConfigError {
+    fn from(value: io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum ValueKind {
+    Bool,
+    U16,
+    U32,
+    U64,
+    Usize,
+    String,
+    Path,
+    Enum(&'static [&'static str]),
+    NullableEnum(&'static [&'static str]),
+    NullableFloat,
+    Model,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct KeySpec {
+    key: &'static str,
+    kind: ValueKind,
+}
+
+const KEY_SPECS: &[KeySpec] = &[
+    KeySpec {
+        key: "headless",
+        kind: ValueKind::Bool,
+    },
+    KeySpec {
+        key: "max_steps",
+        kind: ValueKind::U32,
+    },
+    KeySpec {
+        key: "model",
+        kind: ValueKind::Model,
+    },
+    KeySpec {
+        key: "reasoning_effort",
+        kind: ValueKind::Enum(REASONING_EFFORT_VALUES),
+    },
+    KeySpec {
+        key: "output_dir",
+        kind: ValueKind::Path,
+    },
+    KeySpec {
+        key: "auto_compact_input_tokens",
+        kind: ValueKind::U64,
+    },
+    KeySpec {
+        key: "max_concurrent_per_parent",
+        kind: ValueKind::U32,
+    },
+    KeySpec {
+        key: "max_fork_depth",
+        kind: ValueKind::U32,
+    },
+    KeySpec {
+        key: "max_total_agents",
+        kind: ValueKind::U32,
+    },
+    KeySpec {
+        key: "fork_child_max_steps",
+        kind: ValueKind::U32,
+    },
+    KeySpec {
+        key: "fork_wait_timeout_secs",
+        kind: ValueKind::U32,
+    },
+    KeySpec {
+        key: "extension_bridge_token",
+        kind: ValueKind::String,
+    },
+    KeySpec {
+        key: "extension_bridge_port",
+        kind: ValueKind::U16,
+    },
+    KeySpec {
+        key: "browser_backend",
+        kind: ValueKind::NullableEnum(BROWSER_BACKEND_VALUES),
+    },
+    KeySpec {
+        key: "compaction_prune_protect_tokens",
+        kind: ValueKind::U64,
+    },
+    KeySpec {
+        key: "compaction_prune_max_output_chars",
+        kind: ValueKind::U64,
+    },
+    KeySpec {
+        key: "compaction_preserve_recent_tokens",
+        kind: ValueKind::U64,
+    },
+    KeySpec {
+        key: "compaction_preserve_recent_messages_floor",
+        kind: ValueKind::U32,
+    },
+    KeySpec {
+        key: "compaction_max_summary_chars",
+        kind: ValueKind::U64,
+    },
+    KeySpec {
+        key: "compaction_llm_summarization",
+        kind: ValueKind::Bool,
+    },
+    KeySpec {
+        key: "optimization.html_diff_mode",
+        kind: ValueKind::Bool,
+    },
+    KeySpec {
+        key: "optimization.loop_detection",
+        kind: ValueKind::Bool,
+    },
+    KeySpec {
+        key: "optimization.loop_detection_window",
+        kind: ValueKind::Usize,
+    },
+    KeySpec {
+        key: "optimization.loop_nudge_threshold",
+        kind: ValueKind::Usize,
+    },
+    KeySpec {
+        key: "optimization.page_fingerprinting",
+        kind: ValueKind::Bool,
+    },
+    KeySpec {
+        key: "optimization.planning_interval",
+        kind: ValueKind::Usize,
+    },
+    KeySpec {
+        key: "optimization.failure_classification",
+        kind: ValueKind::Bool,
+    },
+    KeySpec {
+        key: "optimization.self_healing",
+        kind: ValueKind::Bool,
+    },
+    KeySpec {
+        key: "optimization.self_healing_max_retries",
+        kind: ValueKind::Usize,
+    },
+    KeySpec {
+        key: "optimization.action_caching",
+        kind: ValueKind::Bool,
+    },
+    KeySpec {
+        key: "optimization.action_cache_ttl_secs",
+        kind: ValueKind::U64,
+    },
+    KeySpec {
+        key: "optimization.confidence_tracking",
+        kind: ValueKind::Bool,
+    },
+    KeySpec {
+        key: "optimization.compound_enrichment",
+        kind: ValueKind::Bool,
+    },
+    KeySpec {
+        key: "optimization.budget_max_session_cost_usd",
+        kind: ValueKind::NullableFloat,
+    },
+    KeySpec {
+        key: "optimization.budget_enforcement",
+        kind: ValueKind::NullableEnum(BUDGET_ENFORCEMENT_VALUES),
+    },
+    KeySpec {
+        key: "optimization.budget_warn_threshold_pct",
+        kind: ValueKind::U32,
+    },
+    KeySpec {
+        key: "optimization.per_agent_cost_tracking",
+        kind: ValueKind::Bool,
+    },
+    KeySpec {
+        key: "optimization.content_aware_profiles",
+        kind: ValueKind::Bool,
+    },
+    KeySpec {
+        key: "script.max_steps",
+        kind: ValueKind::Usize,
+    },
+    KeySpec {
+        key: "script.max_timeout_secs",
+        kind: ValueKind::U64,
+    },
+    KeySpec {
+        key: "script.max_output_bytes",
+        kind: ValueKind::Usize,
+    },
+    KeySpec {
+        key: "script.max_parallel_branches",
+        kind: ValueKind::Usize,
+    },
+    KeySpec {
+        key: "script.max_concurrent_scripts",
+        kind: ValueKind::Usize,
+    },
+    KeySpec {
+        key: "script.per_step_timeout_secs",
+        kind: ValueKind::U64,
+    },
+    KeySpec {
+        key: "script.max_script_size_bytes",
+        kind: ValueKind::Usize,
+    },
+    KeySpec {
+        key: "script.max_nesting_depth",
+        kind: ValueKind::Usize,
+    },
+    KeySpec {
+        key: "script.scripts_dir",
+        kind: ValueKind::Path,
+    },
+];
+
+#[must_use]
+pub fn config_path() -> PathBuf {
+    settings_file_path()
+}
+
+pub fn config_set(key: &str, value: &str) -> Result<(), ConfigError> {
+    let spec = lookup_key_spec(key).ok_or_else(|| ConfigError::UnknownKey(key.to_string()))?;
+    let mut settings = load_settings();
+    apply_set(&mut settings, spec, value)?;
+    save_settings(&settings)?;
+    Ok(())
+}
+
+pub fn config_get(key: &str, effective: bool) -> Result<String, ConfigError> {
+    let settings = load_settings();
+    if key.is_empty() {
+        let json = if effective {
+            serde_json::to_string_pretty(&effective_settings(&settings))
+        } else {
+            serde_json::to_string_pretty(&settings)
+        };
+        return json.map_err(json_error_to_io).map_err(ConfigError::Io);
+    }
+
+    let _ = lookup_key_spec(key).ok_or_else(|| ConfigError::UnknownKey(key.to_string()))?;
+    let value = if effective {
+        effective_value(&settings, key)
+    } else {
+        stored_value(&settings, key)
+    };
+    serde_json::to_string(&value)
+        .map_err(json_error_to_io)
+        .map_err(ConfigError::Io)
+}
+
+pub fn config_unset(key: &str) -> Result<(), ConfigError> {
+    let mut settings = load_settings();
+    match key {
+        "optimization" => settings.optimization = None,
+        "script" => settings.script = None,
+        _ => {
+            let _ = lookup_key_spec(key).ok_or_else(|| ConfigError::UnknownKey(key.to_string()))?;
+            apply_unset(&mut settings, key);
+            prune_empty_blocks(&mut settings);
+        }
+    }
+    save_settings(&settings)?;
+    Ok(())
+}
+
+fn json_error_to_io(err: serde_json::Error) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, err)
+}
+
+fn lookup_key_spec(key: &str) -> Option<&'static KeySpec> {
+    KEY_SPECS.iter().find(|spec| spec.key == key)
+}
+
+fn bad_value(key: &str, value: &str, reason: impl Into<String>) -> ConfigError {
+    ConfigError::BadValue {
+        key: key.to_string(),
+        value: value.to_string(),
+        reason: reason.into(),
+    }
+}
+
+fn parse_bool(key: &str, value: &str) -> Result<bool, ConfigError> {
+    value
+        .parse::<bool>()
+        .map_err(|_| bad_value(key, value, "expected bool (true or false)"))
+}
+
+fn parse_u16(key: &str, value: &str) -> Result<u16, ConfigError> {
+    value
+        .parse::<u16>()
+        .map_err(|_| bad_value(key, value, "expected unsigned integer"))
+}
+
+fn parse_u32(key: &str, value: &str) -> Result<u32, ConfigError> {
+    value
+        .parse::<u32>()
+        .map_err(|_| bad_value(key, value, "expected unsigned integer"))
+}
+
+fn parse_u64(key: &str, value: &str) -> Result<u64, ConfigError> {
+    value
+        .parse::<u64>()
+        .map_err(|_| bad_value(key, value, "expected unsigned integer"))
+}
+
+fn parse_usize(key: &str, value: &str) -> Result<usize, ConfigError> {
+    value
+        .parse::<usize>()
+        .map_err(|_| bad_value(key, value, "expected unsigned integer"))
+}
+
+fn parse_float(key: &str, value: &str) -> Result<f64, ConfigError> {
+    value
+        .parse::<f64>()
+        .map_err(|_| bad_value(key, value, "expected float"))
+}
+
+fn parse_enum<'a>(
+    key: &str,
+    value: &'a str,
+    allowed: &'static [&'static str],
+) -> Result<&'a str, ConfigError> {
+    if allowed.contains(&value) {
+        Ok(value)
+    } else {
+        Err(bad_value(
+            key,
+            value,
+            format!("expected one of: {}", allowed.join(", ")),
+        ))
+    }
+}
+
+fn parse_nullable_enum(
+    key: &str,
+    value: &str,
+    allowed: &'static [&'static str],
+) -> Result<Option<String>, ConfigError> {
+    if value == "null" {
+        Ok(None)
+    } else {
+        parse_enum(key, value, allowed).map(|parsed| Some(parsed.to_string()))
+    }
+}
+
+fn parse_nullable_float(key: &str, value: &str) -> Result<Option<f64>, ConfigError> {
+    if value == "null" {
+        Ok(None)
+    } else {
+        parse_float(key, value).map(Some)
+    }
+}
+
+fn parse_model(key: &str, value: &str) -> Result<String, ConfigError> {
+    if value.contains('/') {
+        Ok(value.to_string())
+    } else {
+        Err(bad_value(
+            key,
+            value,
+            "expected provider/model format containing '/'",
+        ))
+    }
+}
+
+fn apply_set(settings: &mut Settings, spec: &KeySpec, value: &str) -> Result<(), ConfigError> {
+    match (spec.key, spec.kind) {
+        ("headless", ValueKind::Bool) => settings.headless = Some(parse_bool(spec.key, value)?),
+        ("max_steps", ValueKind::U32) => settings.max_steps = Some(parse_u32(spec.key, value)?),
+        ("model", ValueKind::Model) => settings.model = Some(parse_model(spec.key, value)?),
+        ("reasoning_effort", ValueKind::Enum(allowed)) => {
+            settings.reasoning_effort = Some(parse_enum(spec.key, value, allowed)?.to_string())
+        }
+        ("output_dir", ValueKind::Path | ValueKind::String) => {
+            settings.output_dir = Some(value.to_string())
+        }
+        ("auto_compact_input_tokens", ValueKind::U64) => {
+            settings.auto_compact_input_tokens = Some(parse_u64(spec.key, value)?)
+        }
+        ("max_concurrent_per_parent", ValueKind::U32) => {
+            settings.max_concurrent_per_parent = Some(parse_u32(spec.key, value)?)
+        }
+        ("max_fork_depth", ValueKind::U32) => {
+            settings.max_fork_depth = Some(parse_u32(spec.key, value)?)
+        }
+        ("max_total_agents", ValueKind::U32) => {
+            settings.max_total_agents = Some(parse_u32(spec.key, value)?)
+        }
+        ("fork_child_max_steps", ValueKind::U32) => {
+            settings.fork_child_max_steps = Some(parse_u32(spec.key, value)?)
+        }
+        ("fork_wait_timeout_secs", ValueKind::U32) => {
+            settings.fork_wait_timeout_secs = Some(parse_u32(spec.key, value)?)
+        }
+        ("extension_bridge_token", ValueKind::String) => {
+            settings.extension_bridge_token = Some(value.to_string())
+        }
+        ("extension_bridge_port", ValueKind::U16) => {
+            settings.extension_bridge_port = Some(parse_u16(spec.key, value)?)
+        }
+        ("browser_backend", ValueKind::NullableEnum(allowed)) => {
+            settings.browser_backend = parse_nullable_enum(spec.key, value, allowed)?
+        }
+        ("compaction_prune_protect_tokens", ValueKind::U64) => {
+            settings.compaction_prune_protect_tokens = Some(parse_u64(spec.key, value)?)
+        }
+        ("compaction_prune_max_output_chars", ValueKind::U64) => {
+            settings.compaction_prune_max_output_chars = Some(parse_u64(spec.key, value)?)
+        }
+        ("compaction_preserve_recent_tokens", ValueKind::U64) => {
+            settings.compaction_preserve_recent_tokens = Some(parse_u64(spec.key, value)?)
+        }
+        ("compaction_preserve_recent_messages_floor", ValueKind::U32) => {
+            settings.compaction_preserve_recent_messages_floor = Some(parse_u32(spec.key, value)?)
+        }
+        ("compaction_max_summary_chars", ValueKind::U64) => {
+            settings.compaction_max_summary_chars = Some(parse_u64(spec.key, value)?)
+        }
+        ("compaction_llm_summarization", ValueKind::Bool) => {
+            settings.compaction_llm_summarization = Some(parse_bool(spec.key, value)?)
+        }
+        ("optimization.html_diff_mode", ValueKind::Bool) => {
+            optimization_mut(settings).html_diff_mode = Some(parse_bool(spec.key, value)?)
+        }
+        ("optimization.loop_detection", ValueKind::Bool) => {
+            optimization_mut(settings).loop_detection = Some(parse_bool(spec.key, value)?)
+        }
+        ("optimization.loop_detection_window", ValueKind::Usize) => {
+            optimization_mut(settings).loop_detection_window = Some(parse_usize(spec.key, value)?)
+        }
+        ("optimization.loop_nudge_threshold", ValueKind::Usize) => {
+            optimization_mut(settings).loop_nudge_threshold = Some(parse_usize(spec.key, value)?)
+        }
+        ("optimization.page_fingerprinting", ValueKind::Bool) => {
+            optimization_mut(settings).page_fingerprinting = Some(parse_bool(spec.key, value)?)
+        }
+        ("optimization.planning_interval", ValueKind::Usize) => {
+            optimization_mut(settings).planning_interval = Some(parse_usize(spec.key, value)?)
+        }
+        ("optimization.failure_classification", ValueKind::Bool) => {
+            optimization_mut(settings).failure_classification = Some(parse_bool(spec.key, value)?)
+        }
+        ("optimization.self_healing", ValueKind::Bool) => {
+            optimization_mut(settings).self_healing = Some(parse_bool(spec.key, value)?)
+        }
+        ("optimization.self_healing_max_retries", ValueKind::Usize) => {
+            optimization_mut(settings).self_healing_max_retries =
+                Some(parse_usize(spec.key, value)?)
+        }
+        ("optimization.action_caching", ValueKind::Bool) => {
+            optimization_mut(settings).action_caching = Some(parse_bool(spec.key, value)?)
+        }
+        ("optimization.action_cache_ttl_secs", ValueKind::U64) => {
+            optimization_mut(settings).action_cache_ttl_secs = Some(parse_u64(spec.key, value)?)
+        }
+        ("optimization.confidence_tracking", ValueKind::Bool) => {
+            optimization_mut(settings).confidence_tracking = Some(parse_bool(spec.key, value)?)
+        }
+        ("optimization.compound_enrichment", ValueKind::Bool) => {
+            optimization_mut(settings).compound_enrichment = Some(parse_bool(spec.key, value)?)
+        }
+        ("optimization.budget_max_session_cost_usd", ValueKind::NullableFloat) => {
+            optimization_mut(settings).budget_max_session_cost_usd =
+                parse_nullable_float(spec.key, value)?
+        }
+        ("optimization.budget_enforcement", ValueKind::NullableEnum(allowed)) => {
+            optimization_mut(settings).budget_enforcement =
+                parse_nullable_enum(spec.key, value, allowed)?
+        }
+        ("optimization.budget_warn_threshold_pct", ValueKind::U32) => {
+            optimization_mut(settings).budget_warn_threshold_pct = Some(parse_u32(spec.key, value)?)
+        }
+        ("optimization.per_agent_cost_tracking", ValueKind::Bool) => {
+            optimization_mut(settings).per_agent_cost_tracking = Some(parse_bool(spec.key, value)?)
+        }
+        ("optimization.content_aware_profiles", ValueKind::Bool) => {
+            optimization_mut(settings).content_aware_profiles = Some(parse_bool(spec.key, value)?)
+        }
+        ("script.max_steps", ValueKind::Usize) => {
+            script_mut(settings).max_steps = Some(parse_usize(spec.key, value)?)
+        }
+        ("script.max_timeout_secs", ValueKind::U64) => {
+            script_mut(settings).max_timeout_secs = Some(parse_u64(spec.key, value)?)
+        }
+        ("script.max_output_bytes", ValueKind::Usize) => {
+            script_mut(settings).max_output_bytes = Some(parse_usize(spec.key, value)?)
+        }
+        ("script.max_parallel_branches", ValueKind::Usize) => {
+            script_mut(settings).max_parallel_branches = Some(parse_usize(spec.key, value)?)
+        }
+        ("script.max_concurrent_scripts", ValueKind::Usize) => {
+            script_mut(settings).max_concurrent_scripts = Some(parse_usize(spec.key, value)?)
+        }
+        ("script.per_step_timeout_secs", ValueKind::U64) => {
+            script_mut(settings).per_step_timeout_secs = Some(parse_u64(spec.key, value)?)
+        }
+        ("script.max_script_size_bytes", ValueKind::Usize) => {
+            script_mut(settings).max_script_size_bytes = Some(parse_usize(spec.key, value)?)
+        }
+        ("script.max_nesting_depth", ValueKind::Usize) => {
+            script_mut(settings).max_nesting_depth = Some(parse_usize(spec.key, value)?)
+        }
+        ("script.scripts_dir", ValueKind::Path | ValueKind::String) => {
+            script_mut(settings).scripts_dir = Some(PathBuf::from(value))
+        }
+        _ => return Err(bad_value(spec.key, value, "unsupported schema mapping")),
+    }
+    Ok(())
+}
+
+fn apply_unset(settings: &mut Settings, key: &str) {
+    match key {
+        "headless" => settings.headless = None,
+        "max_steps" => settings.max_steps = None,
+        "model" => settings.model = None,
+        "reasoning_effort" => settings.reasoning_effort = None,
+        "output_dir" => settings.output_dir = None,
+        "auto_compact_input_tokens" => settings.auto_compact_input_tokens = None,
+        "max_concurrent_per_parent" => settings.max_concurrent_per_parent = None,
+        "max_fork_depth" => settings.max_fork_depth = None,
+        "max_total_agents" => settings.max_total_agents = None,
+        "fork_child_max_steps" => settings.fork_child_max_steps = None,
+        "fork_wait_timeout_secs" => settings.fork_wait_timeout_secs = None,
+        "extension_bridge_token" => settings.extension_bridge_token = None,
+        "extension_bridge_port" => settings.extension_bridge_port = None,
+        "browser_backend" => settings.browser_backend = None,
+        "compaction_prune_protect_tokens" => settings.compaction_prune_protect_tokens = None,
+        "compaction_prune_max_output_chars" => settings.compaction_prune_max_output_chars = None,
+        "compaction_preserve_recent_tokens" => settings.compaction_preserve_recent_tokens = None,
+        "compaction_preserve_recent_messages_floor" => {
+            settings.compaction_preserve_recent_messages_floor = None
+        }
+        "compaction_max_summary_chars" => settings.compaction_max_summary_chars = None,
+        "compaction_llm_summarization" => settings.compaction_llm_summarization = None,
+        "optimization.html_diff_mode" => {
+            set_optimization_field(settings, |o| o.html_diff_mode = None)
+        }
+        "optimization.loop_detection" => {
+            set_optimization_field(settings, |o| o.loop_detection = None)
+        }
+        "optimization.loop_detection_window" => {
+            set_optimization_field(settings, |o| o.loop_detection_window = None)
+        }
+        "optimization.loop_nudge_threshold" => {
+            set_optimization_field(settings, |o| o.loop_nudge_threshold = None)
+        }
+        "optimization.page_fingerprinting" => {
+            set_optimization_field(settings, |o| o.page_fingerprinting = None)
+        }
+        "optimization.planning_interval" => {
+            set_optimization_field(settings, |o| o.planning_interval = None)
+        }
+        "optimization.failure_classification" => {
+            set_optimization_field(settings, |o| o.failure_classification = None)
+        }
+        "optimization.self_healing" => set_optimization_field(settings, |o| o.self_healing = None),
+        "optimization.self_healing_max_retries" => {
+            set_optimization_field(settings, |o| o.self_healing_max_retries = None)
+        }
+        "optimization.action_caching" => {
+            set_optimization_field(settings, |o| o.action_caching = None)
+        }
+        "optimization.action_cache_ttl_secs" => {
+            set_optimization_field(settings, |o| o.action_cache_ttl_secs = None)
+        }
+        "optimization.confidence_tracking" => {
+            set_optimization_field(settings, |o| o.confidence_tracking = None)
+        }
+        "optimization.compound_enrichment" => {
+            set_optimization_field(settings, |o| o.compound_enrichment = None)
+        }
+        "optimization.budget_max_session_cost_usd" => {
+            set_optimization_field(settings, |o| o.budget_max_session_cost_usd = None)
+        }
+        "optimization.budget_enforcement" => {
+            set_optimization_field(settings, |o| o.budget_enforcement = None)
+        }
+        "optimization.budget_warn_threshold_pct" => {
+            set_optimization_field(settings, |o| o.budget_warn_threshold_pct = None)
+        }
+        "optimization.per_agent_cost_tracking" => {
+            set_optimization_field(settings, |o| o.per_agent_cost_tracking = None)
+        }
+        "optimization.content_aware_profiles" => {
+            set_optimization_field(settings, |o| o.content_aware_profiles = None)
+        }
+        "script.max_steps" => set_script_field(settings, |s| s.max_steps = None),
+        "script.max_timeout_secs" => set_script_field(settings, |s| s.max_timeout_secs = None),
+        "script.max_output_bytes" => set_script_field(settings, |s| s.max_output_bytes = None),
+        "script.max_parallel_branches" => {
+            set_script_field(settings, |s| s.max_parallel_branches = None)
+        }
+        "script.max_concurrent_scripts" => {
+            set_script_field(settings, |s| s.max_concurrent_scripts = None)
+        }
+        "script.per_step_timeout_secs" => {
+            set_script_field(settings, |s| s.per_step_timeout_secs = None)
+        }
+        "script.max_script_size_bytes" => {
+            set_script_field(settings, |s| s.max_script_size_bytes = None)
+        }
+        "script.max_nesting_depth" => set_script_field(settings, |s| s.max_nesting_depth = None),
+        "script.scripts_dir" => set_script_field(settings, |s| s.scripts_dir = None),
+        _ => {}
+    }
+}
+
+fn optimization_mut(settings: &mut Settings) -> &mut OptimizationSettings {
+    settings
+        .optimization
+        .get_or_insert_with(empty_optimization_settings)
+}
+
+fn script_mut(settings: &mut Settings) -> &mut ScriptSettings {
+    settings.script.get_or_insert_with(empty_script_settings)
+}
+
+fn set_optimization_field(settings: &mut Settings, mutate: impl FnOnce(&mut OptimizationSettings)) {
+    if let Some(optimization) = settings.optimization.as_mut() {
+        mutate(optimization);
+    }
+}
+
+fn set_script_field(settings: &mut Settings, mutate: impl FnOnce(&mut ScriptSettings)) {
+    if let Some(script) = settings.script.as_mut() {
+        mutate(script);
+    }
+}
+
+fn empty_optimization_settings() -> OptimizationSettings {
+    OptimizationSettings::default()
+}
+
+fn empty_script_settings() -> ScriptSettings {
+    ScriptSettings {
+        max_steps: None,
+        max_timeout_secs: None,
+        max_output_bytes: None,
+        max_parallel_branches: None,
+        max_concurrent_scripts: None,
+        per_step_timeout_secs: None,
+        max_script_size_bytes: None,
+        max_nesting_depth: None,
+        scripts_dir: None,
+    }
+}
+
+fn prune_empty_blocks(settings: &mut Settings) {
+    if settings
+        .optimization
+        .as_ref()
+        .is_some_and(optimization_is_empty)
+    {
+        settings.optimization = None;
+    }
+    if settings.script.as_ref().is_some_and(script_is_empty) {
+        settings.script = None;
+    }
+}
+
+fn optimization_is_empty(optimization: &OptimizationSettings) -> bool {
+    optimization.html_diff_mode.is_none()
+        && optimization.loop_detection.is_none()
+        && optimization.loop_detection_window.is_none()
+        && optimization.loop_nudge_threshold.is_none()
+        && optimization.page_fingerprinting.is_none()
+        && optimization.planning_interval.is_none()
+        && optimization.failure_classification.is_none()
+        && optimization.self_healing.is_none()
+        && optimization.self_healing_max_retries.is_none()
+        && optimization.action_caching.is_none()
+        && optimization.action_cache_ttl_secs.is_none()
+        && optimization.confidence_tracking.is_none()
+        && optimization.compound_enrichment.is_none()
+        && optimization.content_aware_profiles.is_none()
+        && optimization.budget_max_session_cost_usd.is_none()
+        && optimization.budget_enforcement.is_none()
+        && optimization.budget_warn_threshold_pct.is_none()
+        && optimization.per_agent_cost_tracking.is_none()
+}
+
+fn script_is_empty(script: &ScriptSettings) -> bool {
+    script.max_steps.is_none()
+        && script.max_timeout_secs.is_none()
+        && script.max_output_bytes.is_none()
+        && script.max_parallel_branches.is_none()
+        && script.max_concurrent_scripts.is_none()
+        && script.per_step_timeout_secs.is_none()
+        && script.max_script_size_bytes.is_none()
+        && script.max_nesting_depth.is_none()
+        && script.scripts_dir.is_none()
+}
+
+fn stored_value(settings: &Settings, key: &str) -> Value {
+    match key {
+        "headless" => json!(settings.headless),
+        "max_steps" => json!(settings.max_steps),
+        "model" => json!(settings.model),
+        "reasoning_effort" => json!(settings.reasoning_effort),
+        "output_dir" => json!(settings.output_dir),
+        "auto_compact_input_tokens" => json!(settings.auto_compact_input_tokens),
+        "max_concurrent_per_parent" => json!(settings.max_concurrent_per_parent),
+        "max_fork_depth" => json!(settings.max_fork_depth),
+        "max_total_agents" => json!(settings.max_total_agents),
+        "fork_child_max_steps" => json!(settings.fork_child_max_steps),
+        "fork_wait_timeout_secs" => json!(settings.fork_wait_timeout_secs),
+        "extension_bridge_token" => json!(settings.extension_bridge_token),
+        "extension_bridge_port" => json!(settings.extension_bridge_port),
+        "browser_backend" => json!(settings.browser_backend),
+        "compaction_prune_protect_tokens" => json!(settings.compaction_prune_protect_tokens),
+        "compaction_prune_max_output_chars" => json!(settings.compaction_prune_max_output_chars),
+        "compaction_preserve_recent_tokens" => json!(settings.compaction_preserve_recent_tokens),
+        "compaction_preserve_recent_messages_floor" => {
+            json!(settings.compaction_preserve_recent_messages_floor)
+        }
+        "compaction_max_summary_chars" => json!(settings.compaction_max_summary_chars),
+        "compaction_llm_summarization" => json!(settings.compaction_llm_summarization),
+        "optimization.html_diff_mode" => {
+            json!(settings
+                .optimization
+                .as_ref()
+                .and_then(|o| o.html_diff_mode))
+        }
+        "optimization.loop_detection" => {
+            json!(settings
+                .optimization
+                .as_ref()
+                .and_then(|o| o.loop_detection))
+        }
+        "optimization.loop_detection_window" => {
+            json!(settings
+                .optimization
+                .as_ref()
+                .and_then(|o| o.loop_detection_window))
+        }
+        "optimization.loop_nudge_threshold" => {
+            json!(settings
+                .optimization
+                .as_ref()
+                .and_then(|o| o.loop_nudge_threshold))
+        }
+        "optimization.page_fingerprinting" => {
+            json!(settings
+                .optimization
+                .as_ref()
+                .and_then(|o| o.page_fingerprinting))
+        }
+        "optimization.planning_interval" => {
+            json!(settings
+                .optimization
+                .as_ref()
+                .and_then(|o| o.planning_interval))
+        }
+        "optimization.failure_classification" => {
+            json!(settings
+                .optimization
+                .as_ref()
+                .and_then(|o| o.failure_classification))
+        }
+        "optimization.self_healing" => {
+            json!(settings.optimization.as_ref().and_then(|o| o.self_healing))
+        }
+        "optimization.self_healing_max_retries" => {
+            json!(settings
+                .optimization
+                .as_ref()
+                .and_then(|o| o.self_healing_max_retries))
+        }
+        "optimization.action_caching" => {
+            json!(settings
+                .optimization
+                .as_ref()
+                .and_then(|o| o.action_caching))
+        }
+        "optimization.action_cache_ttl_secs" => {
+            json!(settings
+                .optimization
+                .as_ref()
+                .and_then(|o| o.action_cache_ttl_secs))
+        }
+        "optimization.confidence_tracking" => {
+            json!(settings
+                .optimization
+                .as_ref()
+                .and_then(|o| o.confidence_tracking))
+        }
+        "optimization.compound_enrichment" => {
+            json!(settings
+                .optimization
+                .as_ref()
+                .and_then(|o| o.compound_enrichment))
+        }
+        "optimization.budget_max_session_cost_usd" => {
+            json!(settings
+                .optimization
+                .as_ref()
+                .and_then(|o| o.budget_max_session_cost_usd))
+        }
+        "optimization.budget_enforcement" => {
+            json!(settings
+                .optimization
+                .as_ref()
+                .and_then(|o| o.budget_enforcement.clone()))
+        }
+        "optimization.budget_warn_threshold_pct" => {
+            json!(settings
+                .optimization
+                .as_ref()
+                .and_then(|o| o.budget_warn_threshold_pct))
+        }
+        "optimization.per_agent_cost_tracking" => {
+            json!(settings
+                .optimization
+                .as_ref()
+                .and_then(|o| o.per_agent_cost_tracking))
+        }
+        "optimization.content_aware_profiles" => {
+            json!(settings
+                .optimization
+                .as_ref()
+                .and_then(|o| o.content_aware_profiles))
+        }
+        "script.max_steps" => json!(settings.script.as_ref().and_then(|s| s.max_steps)),
+        "script.max_timeout_secs" => {
+            json!(settings.script.as_ref().and_then(|s| s.max_timeout_secs))
+        }
+        "script.max_output_bytes" => {
+            json!(settings.script.as_ref().and_then(|s| s.max_output_bytes))
+        }
+        "script.max_parallel_branches" => {
+            json!(settings
+                .script
+                .as_ref()
+                .and_then(|s| s.max_parallel_branches))
+        }
+        "script.max_concurrent_scripts" => {
+            json!(settings
+                .script
+                .as_ref()
+                .and_then(|s| s.max_concurrent_scripts))
+        }
+        "script.per_step_timeout_secs" => {
+            json!(settings
+                .script
+                .as_ref()
+                .and_then(|s| s.per_step_timeout_secs))
+        }
+        "script.max_script_size_bytes" => {
+            json!(settings
+                .script
+                .as_ref()
+                .and_then(|s| s.max_script_size_bytes))
+        }
+        "script.max_nesting_depth" => {
+            json!(settings.script.as_ref().and_then(|s| s.max_nesting_depth))
+        }
+        "script.scripts_dir" => json!(settings.script.as_ref().and_then(|s| s.scripts_dir.clone())),
+        _ => Value::Null,
+    }
+}
+
+fn effective_value(settings: &Settings, key: &str) -> Value {
+    match key {
+        "headless" => json!(settings_get_headless(settings)),
+        "max_steps" => json!(settings_get_max_steps(settings)),
+        "model" => json!(settings.model.clone()),
+        "reasoning_effort" => json!(settings
+            .reasoning_effort
+            .clone()
+            .unwrap_or_else(|| "high".to_string())),
+        "output_dir" => json!(settings_get_output_dir(settings)),
+        "auto_compact_input_tokens" => json!(settings_get_auto_compact_tokens(settings)),
+        "max_concurrent_per_parent" => json!(settings_get_max_concurrent_per_parent(settings)),
+        "max_fork_depth" => json!(settings_get_max_fork_depth(settings)),
+        "max_total_agents" => json!(settings_get_max_total_agents(settings)),
+        "fork_child_max_steps" => json!(settings_get_fork_child_max_steps(settings)),
+        "fork_wait_timeout_secs" => json!(settings_get_fork_wait_timeout_secs(settings)),
+        "extension_bridge_token" => json!(settings.extension_bridge_token.clone()),
+        "extension_bridge_port" => json!(settings.extension_bridge_port.unwrap_or(19_876)),
+        "browser_backend" => json!(settings.browser_backend.clone()),
+        "compaction_prune_protect_tokens" => {
+            json!(settings_get_compaction_prune_protect_tokens(settings))
+        }
+        "compaction_prune_max_output_chars" => {
+            json!(settings_get_compaction_prune_max_output_chars(settings))
+        }
+        "compaction_preserve_recent_tokens" => {
+            json!(settings_get_compaction_preserve_recent_tokens(settings))
+        }
+        "compaction_preserve_recent_messages_floor" => {
+            json!(settings_get_compaction_preserve_recent_messages_floor(
+                settings
+            ))
+        }
+        "compaction_max_summary_chars" => {
+            json!(settings_get_compaction_max_summary_chars(settings))
+        }
+        "compaction_llm_summarization" => {
+            json!(settings_get_compaction_llm_summarization(settings))
+        }
+        "optimization.html_diff_mode" => json!(settings_get_html_diff_mode(settings)),
+        "optimization.loop_detection" => json!(settings_get_loop_detection(settings)),
+        "optimization.loop_detection_window" => json!(settings_get_loop_detection_window(settings)),
+        "optimization.loop_nudge_threshold" => json!(settings_get_loop_nudge_threshold(settings)),
+        "optimization.page_fingerprinting" => json!(settings_get_page_fingerprinting(settings)),
+        "optimization.planning_interval" => json!(settings_get_planning_interval(settings)),
+        "optimization.failure_classification" => {
+            json!(settings_get_failure_classification(settings))
+        }
+        "optimization.self_healing" => json!(settings_get_self_healing(settings)),
+        "optimization.self_healing_max_retries" => {
+            json!(settings_get_self_healing_max_retries(settings))
+        }
+        "optimization.action_caching" => json!(settings_get_action_caching(settings)),
+        "optimization.action_cache_ttl_secs" => json!(settings_get_action_cache_ttl_secs(settings)),
+        "optimization.confidence_tracking" => json!(settings_get_confidence_tracking(settings)),
+        "optimization.compound_enrichment" => json!(settings_get_compound_enrichment(settings)),
+        "optimization.budget_max_session_cost_usd" => {
+            json!(settings_get_budget_max_session_cost_usd(settings))
+        }
+        "optimization.budget_enforcement" => json!(settings_get_budget_enforcement(settings)),
+        "optimization.budget_warn_threshold_pct" => {
+            json!(settings_get_budget_warn_threshold_pct(settings))
+        }
+        "optimization.per_agent_cost_tracking" => {
+            json!(settings_get_per_agent_cost_tracking(settings))
+        }
+        "optimization.content_aware_profiles" => {
+            json!(settings_get_content_aware_profiles(settings))
+        }
+        "script.max_steps" => json!(effective_script_settings(settings).max_steps),
+        "script.max_timeout_secs" => json!(effective_script_settings(settings).max_timeout_secs),
+        "script.max_output_bytes" => json!(effective_script_settings(settings).max_output_bytes),
+        "script.max_parallel_branches" => {
+            json!(effective_script_settings(settings).max_parallel_branches)
+        }
+        "script.max_concurrent_scripts" => {
+            json!(effective_script_settings(settings).max_concurrent_scripts)
+        }
+        "script.per_step_timeout_secs" => {
+            json!(effective_script_settings(settings).per_step_timeout_secs)
+        }
+        "script.max_script_size_bytes" => {
+            json!(effective_script_settings(settings).max_script_size_bytes)
+        }
+        "script.max_nesting_depth" => json!(effective_script_settings(settings).max_nesting_depth),
+        "script.scripts_dir" => json!(effective_script_settings(settings).scripts_dir),
+        _ => Value::Null,
+    }
+}
+
+fn effective_settings(settings: &Settings) -> Settings {
+    Settings {
+        headless: Some(settings_get_headless(settings)),
+        max_steps: Some(settings_get_max_steps(settings)),
+        model: settings.model.clone(),
+        reasoning_effort: Some(
+            settings
+                .reasoning_effort
+                .clone()
+                .unwrap_or_else(|| "high".to_string()),
+        ),
+        output_dir: Some(settings_get_output_dir(settings).to_string()),
+        auto_compact_input_tokens: Some(settings_get_auto_compact_tokens(settings)),
+        max_concurrent_per_parent: Some(settings_get_max_concurrent_per_parent(settings)),
+        max_fork_depth: Some(settings_get_max_fork_depth(settings)),
+        max_total_agents: Some(settings_get_max_total_agents(settings)),
+        fork_child_max_steps: Some(settings_get_fork_child_max_steps(settings)),
+        fork_wait_timeout_secs: Some(settings_get_fork_wait_timeout_secs(settings)),
+        extension_bridge_token: settings.extension_bridge_token.clone(),
+        extension_bridge_port: Some(settings.extension_bridge_port.unwrap_or(19_876)),
+        browser_backend: settings.browser_backend.clone(),
+        compaction_prune_protect_tokens: Some(
+            settings_get_compaction_prune_protect_tokens(settings) as u64,
+        ),
+        compaction_prune_max_output_chars: Some(settings_get_compaction_prune_max_output_chars(
+            settings,
+        ) as u64),
+        compaction_preserve_recent_tokens: Some(settings_get_compaction_preserve_recent_tokens(
+            settings,
+        ) as u64),
+        compaction_preserve_recent_messages_floor: Some(
+            settings_get_compaction_preserve_recent_messages_floor(settings) as u32,
+        ),
+        compaction_max_summary_chars: Some(
+            settings_get_compaction_max_summary_chars(settings) as u64
+        ),
+        compaction_llm_summarization: Some(settings_get_compaction_llm_summarization(settings)),
+        script: Some(effective_script_settings(settings)),
+        optimization: Some(OptimizationSettings {
+            html_diff_mode: Some(settings_get_html_diff_mode(settings)),
+            loop_detection: Some(settings_get_loop_detection(settings)),
+            loop_detection_window: Some(settings_get_loop_detection_window(settings)),
+            loop_nudge_threshold: Some(settings_get_loop_nudge_threshold(settings)),
+            page_fingerprinting: Some(settings_get_page_fingerprinting(settings)),
+            planning_interval: Some(settings_get_planning_interval(settings)),
+            failure_classification: Some(settings_get_failure_classification(settings)),
+            self_healing: Some(settings_get_self_healing(settings)),
+            self_healing_max_retries: Some(settings_get_self_healing_max_retries(settings)),
+            action_caching: Some(settings_get_action_caching(settings)),
+            action_cache_ttl_secs: Some(settings_get_action_cache_ttl_secs(settings)),
+            confidence_tracking: Some(settings_get_confidence_tracking(settings)),
+            compound_enrichment: Some(settings_get_compound_enrichment(settings)),
+            content_aware_profiles: Some(settings_get_content_aware_profiles(settings)),
+            budget_max_session_cost_usd: settings_get_budget_max_session_cost_usd(settings),
+            budget_enforcement: settings_get_budget_enforcement(settings),
+            budget_warn_threshold_pct: Some(settings_get_budget_warn_threshold_pct(settings)),
+            per_agent_cost_tracking: Some(settings_get_per_agent_cost_tracking(settings)),
+        }),
+    }
+}
+
+fn effective_script_settings(settings: &Settings) -> ScriptSettings {
+    let mut effective = ScriptSettings::default();
+    if let Some(script) = settings.script.as_ref() {
+        if let Some(value) = script.max_steps {
+            effective.max_steps = Some(value);
+        }
+        if let Some(value) = script.max_timeout_secs {
+            effective.max_timeout_secs = Some(value);
+        }
+        if let Some(value) = script.max_output_bytes {
+            effective.max_output_bytes = Some(value);
+        }
+        if let Some(value) = script.max_parallel_branches {
+            effective.max_parallel_branches = Some(value);
+        }
+        if let Some(value) = script.max_concurrent_scripts {
+            effective.max_concurrent_scripts = Some(value);
+        }
+        if let Some(value) = script.per_step_timeout_secs {
+            effective.per_step_timeout_secs = Some(value);
+        }
+        if let Some(value) = script.max_script_size_bytes {
+            effective.max_script_size_bytes = Some(value);
+        }
+        if let Some(value) = script.max_nesting_depth {
+            effective.max_nesting_depth = Some(value);
+        }
+        if let Some(value) = script.scripts_dir.clone() {
+            effective.scripts_dir = Some(value);
+        }
+    }
+    effective
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn test_env_lock() -> std::sync::MutexGuard<'static, ()> {
+        crate::test_env_lock()
+    }
+
+    fn unique_temp_dir() -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or(0);
+        std::env::temp_dir().join(format!(
+            "acrawl_config_ops_test_{}_{}",
+            std::process::id(),
+            nanos
+        ))
+    }
+
+    fn setup_temp_dir() -> PathBuf {
+        let temp_dir = unique_temp_dir();
+        fs::create_dir_all(&temp_dir).expect("create temp dir");
+        temp_dir
+    }
+
+    fn cleanup_temp_dir(path: &Path) {
+        let _ = fs::remove_dir_all(path);
+    }
+
+    #[test]
+    fn config_round_trip_and_get_dump_work() {
+        let _lock = test_env_lock();
+        let temp_dir = setup_temp_dir();
+        std::env::set_var("ACRAWL_CONFIG_HOME", &temp_dir);
+
+        config_set("headless", "false").expect("set headless");
+        config_set("max_steps", "77").expect("set max_steps");
+        config_set("optimization.loop_detection", "true").expect("set nested bool");
+        config_set("script.max_timeout_secs", "999").expect("set nested uint");
+
+        assert_eq!(
+            config_get("headless", false).expect("get headless"),
+            "false"
+        );
+        assert_eq!(config_get("max_steps", false).expect("get max_steps"), "77");
+        assert_eq!(
+            config_get("optimization.loop_detection", false).expect("get loop_detection"),
+            "true"
+        );
+        assert_eq!(
+            config_get("script.max_timeout_secs", false).expect("get script timeout"),
+            "999"
+        );
+
+        let dumped = config_get("", false).expect("dump settings");
+        let parsed: Value = serde_json::from_str(&dumped).expect("parse dumped json");
+        assert_eq!(parsed["headless"], Value::Bool(false));
+        assert_eq!(parsed["max_steps"], Value::from(77));
+        assert_eq!(parsed["optimization"]["loop_detection"], Value::Bool(true));
+        assert_eq!(parsed["script"]["max_timeout_secs"], Value::from(999));
+
+        cleanup_temp_dir(&temp_dir);
+    }
+
+    #[test]
+    fn config_set_unknown_key_returns_error() {
+        let _lock = test_env_lock();
+        let temp_dir = setup_temp_dir();
+        std::env::set_var("ACRAWL_CONFIG_HOME", &temp_dir);
+
+        let err = config_set("nope", "true").expect_err("unknown key should fail");
+        assert!(matches!(err, ConfigError::UnknownKey(key) if key == "nope"));
+
+        cleanup_temp_dir(&temp_dir);
+    }
+
+    #[test]
+    fn config_set_bad_type_returns_error() {
+        let _lock = test_env_lock();
+        let temp_dir = setup_temp_dir();
+        std::env::set_var("ACRAWL_CONFIG_HOME", &temp_dir);
+
+        let err = config_set("max_steps", "abc").expect_err("bad type should fail");
+        assert!(matches!(
+            err,
+            ConfigError::BadValue { key, value, .. } if key == "max_steps" && value == "abc"
+        ));
+
+        cleanup_temp_dir(&temp_dir);
+    }
+
+    #[test]
+    fn output_dir_stays_literal_string() {
+        let _lock = test_env_lock();
+        let temp_dir = setup_temp_dir();
+        std::env::set_var("ACRAWL_CONFIG_HOME", &temp_dir);
+
+        config_set("output_dir", "true").expect("set output dir");
+        assert_eq!(
+            config_get("output_dir", false).expect("get output dir"),
+            "\"true\""
+        );
+
+        let settings = load_settings();
+        assert_eq!(settings.output_dir.as_deref(), Some("true"));
+
+        cleanup_temp_dir(&temp_dir);
+    }
+
+    #[test]
+    fn dot_path_nesting_and_block_unset_work() {
+        let _lock = test_env_lock();
+        let temp_dir = setup_temp_dir();
+        std::env::set_var("ACRAWL_CONFIG_HOME", &temp_dir);
+
+        config_set("optimization.self_healing", "true").expect("set nested field");
+        config_set("script.max_steps", "321").expect("set nested script field");
+
+        let settings = load_settings();
+        assert_eq!(
+            settings
+                .optimization
+                .as_ref()
+                .and_then(|optimization| optimization.self_healing),
+            Some(true)
+        );
+        assert_eq!(
+            settings.script.as_ref().and_then(|script| script.max_steps),
+            Some(321)
+        );
+
+        config_unset("optimization").expect("unset optimization block");
+        config_unset("script").expect("unset script block");
+
+        let settings = load_settings();
+        assert!(settings.optimization.is_none());
+        assert!(settings.script.is_none());
+
+        cleanup_temp_dir(&temp_dir);
+    }
+
+    #[test]
+    fn effective_fallback_uses_getters() {
+        let _lock = test_env_lock();
+        let temp_dir = setup_temp_dir();
+        std::env::set_var("ACRAWL_CONFIG_HOME", &temp_dir);
+
+        config_set("max_steps", "88").expect("set max_steps");
+        config_unset("max_steps").expect("unset max_steps");
+
+        assert_eq!(config_get("max_steps", false).expect("raw get"), "null");
+        assert_eq!(config_get("max_steps", true).expect("effective get"), "50");
+
+        cleanup_temp_dir(&temp_dir);
+    }
+
+    #[test]
+    fn model_requires_provider_prefix_slash() {
+        let _lock = test_env_lock();
+        let temp_dir = setup_temp_dir();
+        std::env::set_var("ACRAWL_CONFIG_HOME", &temp_dir);
+
+        let err = config_set("model", "gpt-5").expect_err("model without slash should fail");
+        assert!(matches!(
+            err,
+            ConfigError::BadValue { key, value, .. } if key == "model" && value == "gpt-5"
+        ));
+
+        cleanup_temp_dir(&temp_dir);
+    }
+}

--- a/crates/runtime/src/config_ops.rs
+++ b/crates/runtime/src/config_ops.rs
@@ -428,145 +428,147 @@ fn parse_model(key: &str, value: &str) -> Result<String, ConfigError> {
     }
 }
 
+#[allow(clippy::too_many_lines)]
 fn apply_set(settings: &mut Settings, spec: &KeySpec, value: &str) -> Result<(), ConfigError> {
     match (spec.key, spec.kind) {
         ("headless", ValueKind::Bool) => settings.headless = Some(parse_bool(spec.key, value)?),
         ("max_steps", ValueKind::U32) => settings.max_steps = Some(parse_u32(spec.key, value)?),
         ("model", ValueKind::Model) => settings.model = Some(parse_model(spec.key, value)?),
         ("reasoning_effort", ValueKind::Enum(allowed)) => {
-            settings.reasoning_effort = Some(parse_enum(spec.key, value, allowed)?.to_string())
+            settings.reasoning_effort = Some(parse_enum(spec.key, value, allowed)?.to_string());
         }
         ("output_dir", ValueKind::Path | ValueKind::String) => {
-            settings.output_dir = Some(value.to_string())
+            settings.output_dir = Some(value.to_string());
         }
         ("auto_compact_input_tokens", ValueKind::U64) => {
-            settings.auto_compact_input_tokens = Some(parse_u64(spec.key, value)?)
+            settings.auto_compact_input_tokens = Some(parse_u64(spec.key, value)?);
         }
         ("max_concurrent_per_parent", ValueKind::U32) => {
-            settings.max_concurrent_per_parent = Some(parse_u32(spec.key, value)?)
+            settings.max_concurrent_per_parent = Some(parse_u32(spec.key, value)?);
         }
         ("max_fork_depth", ValueKind::U32) => {
-            settings.max_fork_depth = Some(parse_u32(spec.key, value)?)
+            settings.max_fork_depth = Some(parse_u32(spec.key, value)?);
         }
         ("max_total_agents", ValueKind::U32) => {
-            settings.max_total_agents = Some(parse_u32(spec.key, value)?)
+            settings.max_total_agents = Some(parse_u32(spec.key, value)?);
         }
         ("fork_child_max_steps", ValueKind::U32) => {
-            settings.fork_child_max_steps = Some(parse_u32(spec.key, value)?)
+            settings.fork_child_max_steps = Some(parse_u32(spec.key, value)?);
         }
         ("fork_wait_timeout_secs", ValueKind::U32) => {
-            settings.fork_wait_timeout_secs = Some(parse_u32(spec.key, value)?)
+            settings.fork_wait_timeout_secs = Some(parse_u32(spec.key, value)?);
         }
         ("extension_bridge_token", ValueKind::String) => {
-            settings.extension_bridge_token = Some(value.to_string())
+            settings.extension_bridge_token = Some(value.to_string());
         }
         ("extension_bridge_port", ValueKind::U16) => {
-            settings.extension_bridge_port = Some(parse_u16(spec.key, value)?)
+            settings.extension_bridge_port = Some(parse_u16(spec.key, value)?);
         }
         ("browser_backend", ValueKind::NullableEnum(allowed)) => {
-            settings.browser_backend = parse_nullable_enum(spec.key, value, allowed)?
+            settings.browser_backend = parse_nullable_enum(spec.key, value, allowed)?;
         }
         ("compaction_prune_protect_tokens", ValueKind::U64) => {
-            settings.compaction_prune_protect_tokens = Some(parse_u64(spec.key, value)?)
+            settings.compaction_prune_protect_tokens = Some(parse_u64(spec.key, value)?);
         }
         ("compaction_prune_max_output_chars", ValueKind::U64) => {
-            settings.compaction_prune_max_output_chars = Some(parse_u64(spec.key, value)?)
+            settings.compaction_prune_max_output_chars = Some(parse_u64(spec.key, value)?);
         }
         ("compaction_preserve_recent_tokens", ValueKind::U64) => {
-            settings.compaction_preserve_recent_tokens = Some(parse_u64(spec.key, value)?)
+            settings.compaction_preserve_recent_tokens = Some(parse_u64(spec.key, value)?);
         }
         ("compaction_preserve_recent_messages_floor", ValueKind::U32) => {
-            settings.compaction_preserve_recent_messages_floor = Some(parse_u32(spec.key, value)?)
+            settings.compaction_preserve_recent_messages_floor = Some(parse_u32(spec.key, value)?);
         }
         ("compaction_max_summary_chars", ValueKind::U64) => {
-            settings.compaction_max_summary_chars = Some(parse_u64(spec.key, value)?)
+            settings.compaction_max_summary_chars = Some(parse_u64(spec.key, value)?);
         }
         ("compaction_llm_summarization", ValueKind::Bool) => {
-            settings.compaction_llm_summarization = Some(parse_bool(spec.key, value)?)
+            settings.compaction_llm_summarization = Some(parse_bool(spec.key, value)?);
         }
         ("optimization.html_diff_mode", ValueKind::Bool) => {
-            optimization_mut(settings).html_diff_mode = Some(parse_bool(spec.key, value)?)
+            optimization_mut(settings).html_diff_mode = Some(parse_bool(spec.key, value)?);
         }
         ("optimization.loop_detection", ValueKind::Bool) => {
-            optimization_mut(settings).loop_detection = Some(parse_bool(spec.key, value)?)
+            optimization_mut(settings).loop_detection = Some(parse_bool(spec.key, value)?);
         }
         ("optimization.loop_detection_window", ValueKind::Usize) => {
-            optimization_mut(settings).loop_detection_window = Some(parse_usize(spec.key, value)?)
+            optimization_mut(settings).loop_detection_window = Some(parse_usize(spec.key, value)?);
         }
         ("optimization.loop_nudge_threshold", ValueKind::Usize) => {
-            optimization_mut(settings).loop_nudge_threshold = Some(parse_usize(spec.key, value)?)
+            optimization_mut(settings).loop_nudge_threshold = Some(parse_usize(spec.key, value)?);
         }
         ("optimization.page_fingerprinting", ValueKind::Bool) => {
-            optimization_mut(settings).page_fingerprinting = Some(parse_bool(spec.key, value)?)
+            optimization_mut(settings).page_fingerprinting = Some(parse_bool(spec.key, value)?);
         }
         ("optimization.planning_interval", ValueKind::Usize) => {
-            optimization_mut(settings).planning_interval = Some(parse_usize(spec.key, value)?)
+            optimization_mut(settings).planning_interval = Some(parse_usize(spec.key, value)?);
         }
         ("optimization.failure_classification", ValueKind::Bool) => {
-            optimization_mut(settings).failure_classification = Some(parse_bool(spec.key, value)?)
+            optimization_mut(settings).failure_classification = Some(parse_bool(spec.key, value)?);
         }
         ("optimization.self_healing", ValueKind::Bool) => {
-            optimization_mut(settings).self_healing = Some(parse_bool(spec.key, value)?)
+            optimization_mut(settings).self_healing = Some(parse_bool(spec.key, value)?);
         }
         ("optimization.self_healing_max_retries", ValueKind::Usize) => {
             optimization_mut(settings).self_healing_max_retries =
-                Some(parse_usize(spec.key, value)?)
+                Some(parse_usize(spec.key, value)?);
         }
         ("optimization.action_caching", ValueKind::Bool) => {
-            optimization_mut(settings).action_caching = Some(parse_bool(spec.key, value)?)
+            optimization_mut(settings).action_caching = Some(parse_bool(spec.key, value)?);
         }
         ("optimization.action_cache_ttl_secs", ValueKind::U64) => {
-            optimization_mut(settings).action_cache_ttl_secs = Some(parse_u64(spec.key, value)?)
+            optimization_mut(settings).action_cache_ttl_secs = Some(parse_u64(spec.key, value)?);
         }
         ("optimization.confidence_tracking", ValueKind::Bool) => {
-            optimization_mut(settings).confidence_tracking = Some(parse_bool(spec.key, value)?)
+            optimization_mut(settings).confidence_tracking = Some(parse_bool(spec.key, value)?);
         }
         ("optimization.compound_enrichment", ValueKind::Bool) => {
-            optimization_mut(settings).compound_enrichment = Some(parse_bool(spec.key, value)?)
+            optimization_mut(settings).compound_enrichment = Some(parse_bool(spec.key, value)?);
         }
         ("optimization.budget_max_session_cost_usd", ValueKind::NullableFloat) => {
             optimization_mut(settings).budget_max_session_cost_usd =
-                parse_nullable_float(spec.key, value)?
+                parse_nullable_float(spec.key, value)?;
         }
         ("optimization.budget_enforcement", ValueKind::NullableEnum(allowed)) => {
             optimization_mut(settings).budget_enforcement =
-                parse_nullable_enum(spec.key, value, allowed)?
+                parse_nullable_enum(spec.key, value, allowed)?;
         }
         ("optimization.budget_warn_threshold_pct", ValueKind::U32) => {
-            optimization_mut(settings).budget_warn_threshold_pct = Some(parse_u32(spec.key, value)?)
+            optimization_mut(settings).budget_warn_threshold_pct =
+                Some(parse_u32(spec.key, value)?);
         }
         ("optimization.per_agent_cost_tracking", ValueKind::Bool) => {
-            optimization_mut(settings).per_agent_cost_tracking = Some(parse_bool(spec.key, value)?)
+            optimization_mut(settings).per_agent_cost_tracking = Some(parse_bool(spec.key, value)?);
         }
         ("optimization.content_aware_profiles", ValueKind::Bool) => {
-            optimization_mut(settings).content_aware_profiles = Some(parse_bool(spec.key, value)?)
+            optimization_mut(settings).content_aware_profiles = Some(parse_bool(spec.key, value)?);
         }
         ("script.max_steps", ValueKind::Usize) => {
-            script_mut(settings).max_steps = Some(parse_usize(spec.key, value)?)
+            script_mut(settings).max_steps = Some(parse_usize(spec.key, value)?);
         }
         ("script.max_timeout_secs", ValueKind::U64) => {
-            script_mut(settings).max_timeout_secs = Some(parse_u64(spec.key, value)?)
+            script_mut(settings).max_timeout_secs = Some(parse_u64(spec.key, value)?);
         }
         ("script.max_output_bytes", ValueKind::Usize) => {
-            script_mut(settings).max_output_bytes = Some(parse_usize(spec.key, value)?)
+            script_mut(settings).max_output_bytes = Some(parse_usize(spec.key, value)?);
         }
         ("script.max_parallel_branches", ValueKind::Usize) => {
-            script_mut(settings).max_parallel_branches = Some(parse_usize(spec.key, value)?)
+            script_mut(settings).max_parallel_branches = Some(parse_usize(spec.key, value)?);
         }
         ("script.max_concurrent_scripts", ValueKind::Usize) => {
-            script_mut(settings).max_concurrent_scripts = Some(parse_usize(spec.key, value)?)
+            script_mut(settings).max_concurrent_scripts = Some(parse_usize(spec.key, value)?);
         }
         ("script.per_step_timeout_secs", ValueKind::U64) => {
-            script_mut(settings).per_step_timeout_secs = Some(parse_u64(spec.key, value)?)
+            script_mut(settings).per_step_timeout_secs = Some(parse_u64(spec.key, value)?);
         }
         ("script.max_script_size_bytes", ValueKind::Usize) => {
-            script_mut(settings).max_script_size_bytes = Some(parse_usize(spec.key, value)?)
+            script_mut(settings).max_script_size_bytes = Some(parse_usize(spec.key, value)?);
         }
         ("script.max_nesting_depth", ValueKind::Usize) => {
-            script_mut(settings).max_nesting_depth = Some(parse_usize(spec.key, value)?)
+            script_mut(settings).max_nesting_depth = Some(parse_usize(spec.key, value)?);
         }
         ("script.scripts_dir", ValueKind::Path | ValueKind::String) => {
-            script_mut(settings).scripts_dir = Some(PathBuf::from(value))
+            script_mut(settings).scripts_dir = Some(PathBuf::from(value));
         }
         _ => return Err(bad_value(spec.key, value, "unsupported schema mapping")),
     }
@@ -593,76 +595,76 @@ fn apply_unset(settings: &mut Settings, key: &str) {
         "compaction_prune_max_output_chars" => settings.compaction_prune_max_output_chars = None,
         "compaction_preserve_recent_tokens" => settings.compaction_preserve_recent_tokens = None,
         "compaction_preserve_recent_messages_floor" => {
-            settings.compaction_preserve_recent_messages_floor = None
+            settings.compaction_preserve_recent_messages_floor = None;
         }
         "compaction_max_summary_chars" => settings.compaction_max_summary_chars = None,
         "compaction_llm_summarization" => settings.compaction_llm_summarization = None,
         "optimization.html_diff_mode" => {
-            set_optimization_field(settings, |o| o.html_diff_mode = None)
+            set_optimization_field(settings, |o| o.html_diff_mode = None);
         }
         "optimization.loop_detection" => {
-            set_optimization_field(settings, |o| o.loop_detection = None)
+            set_optimization_field(settings, |o| o.loop_detection = None);
         }
         "optimization.loop_detection_window" => {
-            set_optimization_field(settings, |o| o.loop_detection_window = None)
+            set_optimization_field(settings, |o| o.loop_detection_window = None);
         }
         "optimization.loop_nudge_threshold" => {
-            set_optimization_field(settings, |o| o.loop_nudge_threshold = None)
+            set_optimization_field(settings, |o| o.loop_nudge_threshold = None);
         }
         "optimization.page_fingerprinting" => {
-            set_optimization_field(settings, |o| o.page_fingerprinting = None)
+            set_optimization_field(settings, |o| o.page_fingerprinting = None);
         }
         "optimization.planning_interval" => {
-            set_optimization_field(settings, |o| o.planning_interval = None)
+            set_optimization_field(settings, |o| o.planning_interval = None);
         }
         "optimization.failure_classification" => {
-            set_optimization_field(settings, |o| o.failure_classification = None)
+            set_optimization_field(settings, |o| o.failure_classification = None);
         }
         "optimization.self_healing" => set_optimization_field(settings, |o| o.self_healing = None),
         "optimization.self_healing_max_retries" => {
-            set_optimization_field(settings, |o| o.self_healing_max_retries = None)
+            set_optimization_field(settings, |o| o.self_healing_max_retries = None);
         }
         "optimization.action_caching" => {
-            set_optimization_field(settings, |o| o.action_caching = None)
+            set_optimization_field(settings, |o| o.action_caching = None);
         }
         "optimization.action_cache_ttl_secs" => {
-            set_optimization_field(settings, |o| o.action_cache_ttl_secs = None)
+            set_optimization_field(settings, |o| o.action_cache_ttl_secs = None);
         }
         "optimization.confidence_tracking" => {
-            set_optimization_field(settings, |o| o.confidence_tracking = None)
+            set_optimization_field(settings, |o| o.confidence_tracking = None);
         }
         "optimization.compound_enrichment" => {
-            set_optimization_field(settings, |o| o.compound_enrichment = None)
+            set_optimization_field(settings, |o| o.compound_enrichment = None);
         }
         "optimization.budget_max_session_cost_usd" => {
-            set_optimization_field(settings, |o| o.budget_max_session_cost_usd = None)
+            set_optimization_field(settings, |o| o.budget_max_session_cost_usd = None);
         }
         "optimization.budget_enforcement" => {
-            set_optimization_field(settings, |o| o.budget_enforcement = None)
+            set_optimization_field(settings, |o| o.budget_enforcement = None);
         }
         "optimization.budget_warn_threshold_pct" => {
-            set_optimization_field(settings, |o| o.budget_warn_threshold_pct = None)
+            set_optimization_field(settings, |o| o.budget_warn_threshold_pct = None);
         }
         "optimization.per_agent_cost_tracking" => {
-            set_optimization_field(settings, |o| o.per_agent_cost_tracking = None)
+            set_optimization_field(settings, |o| o.per_agent_cost_tracking = None);
         }
         "optimization.content_aware_profiles" => {
-            set_optimization_field(settings, |o| o.content_aware_profiles = None)
+            set_optimization_field(settings, |o| o.content_aware_profiles = None);
         }
         "script.max_steps" => set_script_field(settings, |s| s.max_steps = None),
         "script.max_timeout_secs" => set_script_field(settings, |s| s.max_timeout_secs = None),
         "script.max_output_bytes" => set_script_field(settings, |s| s.max_output_bytes = None),
         "script.max_parallel_branches" => {
-            set_script_field(settings, |s| s.max_parallel_branches = None)
+            set_script_field(settings, |s| s.max_parallel_branches = None);
         }
         "script.max_concurrent_scripts" => {
-            set_script_field(settings, |s| s.max_concurrent_scripts = None)
+            set_script_field(settings, |s| s.max_concurrent_scripts = None);
         }
         "script.per_step_timeout_secs" => {
-            set_script_field(settings, |s| s.per_step_timeout_secs = None)
+            set_script_field(settings, |s| s.per_step_timeout_secs = None);
         }
         "script.max_script_size_bytes" => {
-            set_script_field(settings, |s| s.max_script_size_bytes = None)
+            set_script_field(settings, |s| s.max_script_size_bytes = None);
         }
         "script.max_nesting_depth" => set_script_field(settings, |s| s.max_nesting_depth = None),
         "script.scripts_dir" => set_script_field(settings, |s| s.scripts_dir = None),
@@ -756,6 +758,7 @@ fn script_is_empty(script: &ScriptSettings) -> bool {
         && script.scripts_dir.is_none()
 }
 
+#[allow(clippy::too_many_lines)]
 fn stored_value(settings: &Settings, key: &str) -> Value {
     match key {
         "headless" => json!(settings.headless),
@@ -1045,7 +1048,10 @@ fn effective_settings(settings: &Settings) -> Settings {
             settings,
         ) as u64),
         compaction_preserve_recent_messages_floor: Some(
-            settings_get_compaction_preserve_recent_messages_floor(settings) as u32,
+            u32::try_from(settings_get_compaction_preserve_recent_messages_floor(
+                settings,
+            ))
+            .unwrap_or(u32::MAX),
         ),
         compaction_max_summary_chars: Some(
             settings_get_compaction_max_summary_chars(settings) as u64
@@ -1123,8 +1129,7 @@ mod tests {
     fn unique_temp_dir() -> PathBuf {
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .map(|duration| duration.as_nanos())
-            .unwrap_or(0);
+            .map_or(0, |duration| duration.as_nanos());
         std::env::temp_dir().join(format!(
             "acrawl_config_ops_test_{}_{}",
             std::process::id(),

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod budget;
 mod compact;
 mod config;
+pub mod config_ops;
 mod control;
 mod conversation;
 mod json;

--- a/crates/ui/src/auth/anthropic.rs
+++ b/crates/ui/src/auth/anthropic.rs
@@ -9,8 +9,9 @@ use api::{AnthropicClient, AuthSource};
 use runtime::ConfigLoader;
 
 use super::{
-    bind_oauth_listener, open_browser, persist_provider_credentials, wait_for_oauth_callback,
-    Provider,
+    bind_oauth_listener,
+    builder::{build_provider_config, CredGroup, CredInputs},
+    open_browser, persist_provider_credentials, wait_for_oauth_callback, Provider,
 };
 
 const DEFAULT_OAUTH_CALLBACK_PORT: u16 = 4545;
@@ -54,11 +55,13 @@ pub(super) fn run_auth() -> Result<(), Box<dyn std::error::Error>> {
             }
             persist_provider_credentials(
                 Provider::Anthropic,
-                api::StoredProviderConfig {
-                    auth_method: "api_key".to_string(),
-                    api_key: Some(key),
-                    ..Default::default()
-                },
+                build_provider_config(
+                    CredGroup::Simple,
+                    CredInputs {
+                        api_key: Some(key),
+                        ..CredInputs::default()
+                    },
+                ),
             )?;
         }
     }

--- a/crates/ui/src/auth/builder.rs
+++ b/crates/ui/src/auth/builder.rs
@@ -1,0 +1,272 @@
+use api::StoredProviderConfig;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CredGroup {
+    Simple,
+    Bedrock,
+    Azure,
+    Custom,
+    Vertex,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CredInputs {
+    pub api_key: Option<String>,
+    pub access_key: Option<String>,
+    pub secret_key: Option<String>,
+    pub region: Option<String>,
+    pub resource_name: Option<String>,
+    pub deployment_name: Option<String>,
+    pub base_url: Option<String>,
+    pub gcp_project: Option<String>,
+    pub gcp_region: Option<String>,
+}
+
+#[must_use]
+pub fn build_provider_config(group: CredGroup, inputs: CredInputs) -> StoredProviderConfig {
+    let api_key = normalize(inputs.api_key);
+    let access_key = normalize(inputs.access_key);
+    let secret_key = normalize(inputs.secret_key);
+    let region = normalize(inputs.region);
+    let resource_name = normalize(inputs.resource_name);
+    let deployment_name = normalize(inputs.deployment_name);
+    let base_url = normalize(inputs.base_url);
+    let gcp_project_id = normalize(inputs.gcp_project);
+    let gcp_region = normalize(inputs.gcp_region);
+
+    match group {
+        CredGroup::Simple => StoredProviderConfig {
+            auth_method: simple_auth_method(api_key.as_deref(), base_url.as_deref()).to_string(),
+            api_key,
+            base_url,
+            ..StoredProviderConfig::default()
+        },
+        CredGroup::Bedrock => StoredProviderConfig {
+            auth_method: "api_key".to_string(),
+            api_key: access_key,
+            aws_secret_access_key: secret_key,
+            region,
+            ..StoredProviderConfig::default()
+        },
+        CredGroup::Azure => StoredProviderConfig {
+            auth_method: "api_key".to_string(),
+            api_key,
+            resource_name,
+            deployment_name,
+            ..StoredProviderConfig::default()
+        },
+        CredGroup::Custom => {
+            let auth_method = if api_key.is_some() { "api_key" } else { "none" };
+            StoredProviderConfig {
+                auth_method: auth_method.to_string(),
+                api_key,
+                base_url,
+                ..StoredProviderConfig::default()
+            }
+        }
+        CredGroup::Vertex => StoredProviderConfig {
+            auth_method: "api_key".to_string(),
+            api_key,
+            gcp_project_id,
+            gcp_region,
+            ..StoredProviderConfig::default()
+        },
+    }
+}
+
+fn normalize(value: Option<String>) -> Option<String> {
+    value.and_then(|value| {
+        let trimmed = value.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    })
+}
+
+fn simple_auth_method(api_key: Option<&str>, base_url: Option<&str>) -> &'static str {
+    if base_url.is_some() || api_key.is_some_and(|key| key.starts_with("sk-ant-")) {
+        "api_key"
+    } else {
+        "openai_key"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_provider_config, CredGroup, CredInputs};
+    use api::StoredProviderConfig;
+
+    #[test]
+    fn simple_openai_matches_interactive_shape() {
+        let config = build_provider_config(
+            CredGroup::Simple,
+            CredInputs {
+                api_key: Some("sk-test-123".to_string()),
+                ..CredInputs::default()
+            },
+        );
+
+        assert_eq!(
+            config,
+            StoredProviderConfig {
+                auth_method: "openai_key".to_string(),
+                api_key: Some("sk-test-123".to_string()),
+                ..StoredProviderConfig::default()
+            }
+        );
+    }
+
+    #[test]
+    fn simple_anthropic_matches_interactive_shape() {
+        let config = build_provider_config(
+            CredGroup::Simple,
+            CredInputs {
+                api_key: Some("sk-ant-test-123".to_string()),
+                ..CredInputs::default()
+            },
+        );
+
+        assert_eq!(
+            config,
+            StoredProviderConfig {
+                auth_method: "api_key".to_string(),
+                api_key: Some("sk-ant-test-123".to_string()),
+                ..StoredProviderConfig::default()
+            }
+        );
+    }
+
+    #[test]
+    fn simple_preset_matches_interactive_shape() {
+        let config = build_provider_config(
+            CredGroup::Simple,
+            CredInputs {
+                api_key: Some("gemini-test-123".to_string()),
+                base_url: Some("https://generativelanguage.googleapis.com/v1beta".to_string()),
+                ..CredInputs::default()
+            },
+        );
+
+        assert_eq!(
+            config,
+            StoredProviderConfig {
+                auth_method: "api_key".to_string(),
+                api_key: Some("gemini-test-123".to_string()),
+                base_url: Some("https://generativelanguage.googleapis.com/v1beta".to_string()),
+                ..StoredProviderConfig::default()
+            }
+        );
+    }
+
+    #[test]
+    fn bedrock_matches_interactive_shape() {
+        let config = build_provider_config(
+            CredGroup::Bedrock,
+            CredInputs {
+                access_key: Some("AKIA_TEST".to_string()),
+                secret_key: Some("secret-test".to_string()),
+                region: Some("us-east-1".to_string()),
+                ..CredInputs::default()
+            },
+        );
+
+        assert_eq!(
+            config,
+            StoredProviderConfig {
+                auth_method: "api_key".to_string(),
+                api_key: Some("AKIA_TEST".to_string()),
+                aws_secret_access_key: Some("secret-test".to_string()),
+                region: Some("us-east-1".to_string()),
+                ..StoredProviderConfig::default()
+            }
+        );
+    }
+
+    #[test]
+    fn azure_matches_interactive_shape() {
+        let config = build_provider_config(
+            CredGroup::Azure,
+            CredInputs {
+                api_key: Some("azure-test-123".to_string()),
+                resource_name: Some("myresource".to_string()),
+                deployment_name: Some("gpt-4o".to_string()),
+                ..CredInputs::default()
+            },
+        );
+
+        assert_eq!(
+            config,
+            StoredProviderConfig {
+                auth_method: "api_key".to_string(),
+                api_key: Some("azure-test-123".to_string()),
+                resource_name: Some("myresource".to_string()),
+                deployment_name: Some("gpt-4o".to_string()),
+                ..StoredProviderConfig::default()
+            }
+        );
+    }
+
+    #[test]
+    fn custom_without_api_key_matches_interactive_shape() {
+        let config = build_provider_config(
+            CredGroup::Custom,
+            CredInputs {
+                base_url: Some("http://localhost:11434/v1".to_string()),
+                ..CredInputs::default()
+            },
+        );
+
+        assert_eq!(
+            config,
+            StoredProviderConfig {
+                auth_method: "none".to_string(),
+                base_url: Some("http://localhost:11434/v1".to_string()),
+                ..StoredProviderConfig::default()
+            }
+        );
+    }
+
+    #[test]
+    fn custom_with_api_key_matches_interactive_shape() {
+        let config = build_provider_config(
+            CredGroup::Custom,
+            CredInputs {
+                api_key: Some("local-key".to_string()),
+                base_url: Some("http://localhost:11434/v1".to_string()),
+                ..CredInputs::default()
+            },
+        );
+
+        assert_eq!(
+            config,
+            StoredProviderConfig {
+                auth_method: "api_key".to_string(),
+                api_key: Some("local-key".to_string()),
+                base_url: Some("http://localhost:11434/v1".to_string()),
+                ..StoredProviderConfig::default()
+            }
+        );
+    }
+
+    #[test]
+    fn vertex_matches_expected_shape() {
+        let config = build_provider_config(
+            CredGroup::Vertex,
+            CredInputs {
+                api_key: Some("ya29.test-token".to_string()),
+                gcp_project: Some("my-project".to_string()),
+                gcp_region: Some("us-central1".to_string()),
+                ..CredInputs::default()
+            },
+        );
+
+        assert_eq!(
+            config,
+            StoredProviderConfig {
+                auth_method: "api_key".to_string(),
+                api_key: Some("ya29.test-token".to_string()),
+                gcp_project_id: Some("my-project".to_string()),
+                gcp_region: Some("us-central1".to_string()),
+                ..StoredProviderConfig::default()
+            }
+        );
+    }
+}

--- a/crates/ui/src/auth/configure.rs
+++ b/crates/ui/src/auth/configure.rs
@@ -36,12 +36,9 @@ pub fn run_auth_configure(provider: &str, flags: AuthFlags, json: bool) -> i32 {
         return 2;
     }
 
-    let group = match flag_group_for(canonical_id) {
-        Some(group) => group,
-        None => {
-            eprintln!("provider `{canonical_id}` does not support non-interactive configuration");
-            return 2;
-        }
+    let Some(group) = flag_group_for(canonical_id) else {
+        eprintln!("provider `{canonical_id}` does not support non-interactive configuration");
+        return 2;
     };
 
     let inputs = match validated_inputs(group, flags) {
@@ -122,31 +119,31 @@ fn validated_inputs(group: CredGroup, flags: AuthFlags) -> Result<CredInputs, &'
 
     match group {
         CredGroup::Simple => {
-            require(&inputs.api_key, "api-key")?;
+            require(inputs.api_key.as_deref(), "api-key")?;
             Ok(inputs)
         }
         CredGroup::Bedrock => {
-            require(&inputs.access_key, "access-key")?;
-            require(&inputs.secret_key, "secret-key")?;
+            require(inputs.access_key.as_deref(), "access-key")?;
+            require(inputs.secret_key.as_deref(), "secret-key")?;
             Ok(CredInputs {
                 region: Some(inputs.region.unwrap_or_else(|| "us-east-1".to_string())),
                 ..inputs
             })
         }
         CredGroup::Azure => {
-            require(&inputs.resource_name, "resource-name")?;
-            require(&inputs.deployment_name, "deployment-name")?;
-            require(&inputs.api_key, "api-key")?;
+            require(inputs.resource_name.as_deref(), "resource-name")?;
+            require(inputs.deployment_name.as_deref(), "deployment-name")?;
+            require(inputs.api_key.as_deref(), "api-key")?;
             Ok(inputs)
         }
         CredGroup::Custom => {
-            require(&inputs.base_url, "base-url")?;
+            require(inputs.base_url.as_deref(), "base-url")?;
             Ok(inputs)
         }
         CredGroup::Vertex => {
-            require(&inputs.gcp_project, "gcp-project")?;
-            require(&inputs.gcp_region, "gcp-region")?;
-            require(&inputs.api_key, "api-key")?;
+            require(inputs.gcp_project.as_deref(), "gcp-project")?;
+            require(inputs.gcp_region.as_deref(), "gcp-region")?;
+            require(inputs.api_key.as_deref(), "api-key")?;
             Ok(inputs)
         }
     }
@@ -159,7 +156,7 @@ fn normalized(value: Option<String>) -> Option<String> {
     })
 }
 
-fn require(value: &Option<String>, flag: &'static str) -> Result<(), &'static str> {
+fn require(value: Option<&str>, flag: &'static str) -> Result<(), &'static str> {
     if value.is_some() {
         Ok(())
     } else {

--- a/crates/ui/src/auth/configure.rs
+++ b/crates/ui/src/auth/configure.rs
@@ -1,0 +1,421 @@
+use super::{
+    builder::{build_provider_config, CredGroup, CredInputs},
+    group::{flag_group_for, is_scriptable},
+    persist_preset_credentials, persist_provider_credentials, provider_choice_label,
+    provider_label, resolve_provider_arg, ProviderChoice,
+};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AuthFlags {
+    pub api_key: Option<String>,
+    pub access_key: Option<String>,
+    pub secret_key: Option<String>,
+    pub region: Option<String>,
+    pub resource_name: Option<String>,
+    pub deployment_name: Option<String>,
+    pub base_url: Option<String>,
+    pub gcp_project: Option<String>,
+    pub gcp_region: Option<String>,
+}
+
+#[must_use]
+pub fn run_auth_configure(provider: &str, flags: AuthFlags, json: bool) -> i32 {
+    let choice = match resolve_provider_arg(provider) {
+        Ok(choice) => choice,
+        Err(error) => {
+            eprintln!("{error}");
+            return 2;
+        }
+    };
+
+    let canonical_id = canonical_provider_id(&choice);
+    if !is_scriptable(canonical_id) {
+        eprintln!(
+            "provider `{canonical_id}` is not scriptable non-interactively; run `acrawl auth {canonical_id}` to authenticate via interactive flow"
+        );
+        return 2;
+    }
+
+    let group = match flag_group_for(canonical_id) {
+        Some(group) => group,
+        None => {
+            eprintln!("provider `{canonical_id}` does not support non-interactive configuration");
+            return 2;
+        }
+    };
+
+    let inputs = match validated_inputs(group, flags) {
+        Ok(inputs) => inputs,
+        Err(flag) => {
+            eprintln!("missing required flag --{flag}");
+            return 2;
+        }
+    };
+
+    let inputs = preset_backfilled_inputs(group, &choice, inputs);
+
+    let config = build_provider_config(group, inputs);
+    let auth_method = config.auth_method.clone();
+    let persist_result = match choice {
+        ProviderChoice::Legacy(provider) => persist_provider_credentials(provider, config),
+        ProviderChoice::Preset(preset) => persist_preset_credentials(preset.id, config),
+    };
+
+    if let Err(error) = persist_result {
+        eprintln!("{error}");
+        return 1;
+    }
+
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "ok": true,
+                "provider": canonical_id,
+                "auth_method": auth_method,
+            })
+        );
+    } else {
+        eprintln!("✓ {} credentials configured.", display_name(&choice));
+    }
+
+    0
+}
+
+fn canonical_provider_id(choice: &ProviderChoice) -> &str {
+    match choice {
+        ProviderChoice::Legacy(provider) => provider_label(*provider),
+        ProviderChoice::Preset(preset) => preset.id,
+    }
+}
+
+fn display_name(choice: &ProviderChoice) -> &str {
+    match choice {
+        ProviderChoice::Legacy(_) => provider_choice_label(choice),
+        ProviderChoice::Preset(preset) => preset.display_name,
+    }
+}
+
+fn preset_backfilled_inputs(
+    group: CredGroup,
+    choice: &ProviderChoice,
+    mut inputs: CredInputs,
+) -> CredInputs {
+    if let (CredGroup::Simple, ProviderChoice::Preset(preset)) = (group, choice) {
+        inputs.base_url = Some(preset.base_url.to_string());
+    }
+    inputs
+}
+
+fn validated_inputs(group: CredGroup, flags: AuthFlags) -> Result<CredInputs, &'static str> {
+    let inputs = CredInputs {
+        api_key: normalized(flags.api_key),
+        access_key: normalized(flags.access_key),
+        secret_key: normalized(flags.secret_key),
+        region: normalized(flags.region),
+        resource_name: normalized(flags.resource_name),
+        deployment_name: normalized(flags.deployment_name),
+        base_url: normalized(flags.base_url),
+        gcp_project: normalized(flags.gcp_project),
+        gcp_region: normalized(flags.gcp_region),
+    };
+
+    match group {
+        CredGroup::Simple => {
+            require(&inputs.api_key, "api-key")?;
+            Ok(inputs)
+        }
+        CredGroup::Bedrock => {
+            require(&inputs.access_key, "access-key")?;
+            require(&inputs.secret_key, "secret-key")?;
+            Ok(CredInputs {
+                region: Some(inputs.region.unwrap_or_else(|| "us-east-1".to_string())),
+                ..inputs
+            })
+        }
+        CredGroup::Azure => {
+            require(&inputs.resource_name, "resource-name")?;
+            require(&inputs.deployment_name, "deployment-name")?;
+            require(&inputs.api_key, "api-key")?;
+            Ok(inputs)
+        }
+        CredGroup::Custom => {
+            require(&inputs.base_url, "base-url")?;
+            Ok(inputs)
+        }
+        CredGroup::Vertex => {
+            require(&inputs.gcp_project, "gcp-project")?;
+            require(&inputs.gcp_region, "gcp-region")?;
+            require(&inputs.api_key, "api-key")?;
+            Ok(inputs)
+        }
+    }
+}
+
+fn normalized(value: Option<String>) -> Option<String> {
+    value.and_then(|value| {
+        let trimmed = value.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    })
+}
+
+fn require(value: &Option<String>, flag: &'static str) -> Result<(), &'static str> {
+    if value.is_some() {
+        Ok(())
+    } else {
+        Err(flag)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{run_auth_configure, AuthFlags};
+    use api::load_credentials;
+    use std::fs;
+    use std::sync::{Mutex, OnceLock};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn test_env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn with_clean_config_env<T>(f: impl FnOnce() -> T) -> T {
+        let _guard = test_env_lock();
+        let saved_config_home = std::env::var_os("ACRAWL_CONFIG_HOME");
+        let temp_dir = std::env::temp_dir().join(format!(
+            "auth-configure-tests-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("time should be after epoch")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&temp_dir).expect("create temp config home");
+        std::env::set_var("ACRAWL_CONFIG_HOME", &temp_dir);
+        let result = f();
+        match saved_config_home {
+            Some(value) => std::env::set_var("ACRAWL_CONFIG_HOME", value),
+            None => std::env::remove_var("ACRAWL_CONFIG_HOME"),
+        }
+        fs::remove_dir_all(temp_dir).expect("cleanup temp config home");
+        result
+    }
+
+    #[test]
+    fn openai_happy_path_stores_expected_shape() {
+        with_clean_config_env(|| {
+            let exit_code = run_auth_configure(
+                "openai",
+                AuthFlags {
+                    api_key: Some("sk-test-123".to_string()),
+                    ..AuthFlags::default()
+                },
+                false,
+            );
+
+            assert_eq!(exit_code, 0);
+
+            let store = load_credentials().expect("load credentials");
+            let config = store
+                .providers
+                .get("openai")
+                .expect("openai config should be stored");
+            assert_eq!(config.auth_method, "openai_key");
+            assert_eq!(config.api_key.as_deref(), Some("sk-test-123"));
+            assert_eq!(config.base_url, None);
+        });
+    }
+
+    #[test]
+    fn missing_required_flag_returns_usage_error() {
+        with_clean_config_env(|| {
+            let exit_code = run_auth_configure("azure", AuthFlags::default(), false);
+            assert_eq!(exit_code, 2);
+
+            let store = load_credentials().expect("load credentials");
+            assert!(store.providers.is_empty());
+        });
+    }
+
+    #[test]
+    fn copilot_returns_usage_error() {
+        with_clean_config_env(|| {
+            let exit_code = run_auth_configure(
+                "copilot",
+                AuthFlags {
+                    api_key: Some("ignored".to_string()),
+                    ..AuthFlags::default()
+                },
+                false,
+            );
+            assert_eq!(exit_code, 2);
+
+            let store = load_credentials().expect("load credentials");
+            assert!(store.providers.is_empty());
+        });
+    }
+
+    #[test]
+    fn bedrock_defaults_region_when_omitted() {
+        with_clean_config_env(|| {
+            let exit_code = run_auth_configure(
+                "amazon-bedrock",
+                AuthFlags {
+                    access_key: Some("AKIA_TEST".to_string()),
+                    secret_key: Some("secret-test".to_string()),
+                    ..AuthFlags::default()
+                },
+                false,
+            );
+
+            assert_eq!(exit_code, 0);
+
+            let store = load_credentials().expect("load credentials");
+            let config = store
+                .providers
+                .get("amazon-bedrock")
+                .expect("bedrock config should be stored");
+            assert_eq!(config.region.as_deref(), Some("us-east-1"));
+            assert_eq!(config.api_key.as_deref(), Some("AKIA_TEST"));
+            assert_eq!(config.aws_secret_access_key.as_deref(), Some("secret-test"));
+        });
+    }
+
+    #[test]
+    fn legacy_alias_persists_under_canonical_provider_key() {
+        with_clean_config_env(|| {
+            let exit_code = run_auth_configure(
+                "gpt",
+                AuthFlags {
+                    api_key: Some("sk-test-456".to_string()),
+                    ..AuthFlags::default()
+                },
+                false,
+            );
+
+            assert_eq!(exit_code, 0);
+
+            let store = load_credentials().expect("load credentials");
+            assert!(store.providers.contains_key("openai"));
+            assert!(!store.providers.contains_key("gpt"));
+        });
+    }
+
+    #[test]
+    fn preset_provider_persists_under_preset_id() {
+        with_clean_config_env(|| {
+            let exit_code = run_auth_configure(
+                "groq",
+                AuthFlags {
+                    api_key: Some("groq-key".to_string()),
+                    ..AuthFlags::default()
+                },
+                false,
+            );
+
+            assert_eq!(exit_code, 0);
+
+            let store = load_credentials().expect("load credentials");
+            let config = store
+                .providers
+                .get("groq")
+                .expect("groq config should be stored");
+            assert_eq!(config.auth_method, "api_key");
+            assert_eq!(
+                config.base_url.as_deref(),
+                Some("https://api.groq.com/openai/v1")
+            );
+        });
+    }
+
+    #[test]
+    fn custom_requires_base_url_but_api_key_is_optional() {
+        with_clean_config_env(|| {
+            let exit_code = run_auth_configure(
+                "other",
+                AuthFlags {
+                    base_url: Some("http://localhost:11434/v1".to_string()),
+                    ..AuthFlags::default()
+                },
+                false,
+            );
+
+            assert_eq!(exit_code, 0);
+
+            let store = load_credentials().expect("load credentials");
+            let config = store
+                .providers
+                .get("other")
+                .expect("other config should be stored");
+            assert_eq!(config.auth_method, "none");
+            assert_eq!(
+                config.base_url.as_deref(),
+                Some("http://localhost:11434/v1")
+            );
+            assert_eq!(config.api_key, None);
+        });
+    }
+
+    #[test]
+    fn unknown_provider_returns_usage_error() {
+        with_clean_config_env(|| {
+            let exit_code = run_auth_configure("does-not-exist", AuthFlags::default(), false);
+            assert_eq!(exit_code, 2);
+        });
+    }
+
+    #[test]
+    fn vertex_requires_project_region_and_api_key() {
+        with_clean_config_env(|| {
+            let exit_code = run_auth_configure(
+                "vertex",
+                AuthFlags {
+                    api_key: Some("ya29.test-token".to_string()),
+                    gcp_project: Some("my-project".to_string()),
+                    gcp_region: Some("us-central1".to_string()),
+                    ..AuthFlags::default()
+                },
+                false,
+            );
+
+            assert_eq!(exit_code, 0);
+
+            let store = load_credentials().expect("load credentials");
+            let config = store
+                .providers
+                .get("vertex")
+                .expect("vertex config should be stored");
+            assert_eq!(config.auth_method, "api_key");
+            assert_eq!(config.gcp_project_id.as_deref(), Some("my-project"));
+            assert_eq!(config.gcp_region.as_deref(), Some("us-central1"));
+            assert_eq!(config.api_key.as_deref(), Some("ya29.test-token"));
+        });
+    }
+
+    #[test]
+    fn anthropic_alias_uses_canonical_key() {
+        with_clean_config_env(|| {
+            let exit_code = run_auth_configure(
+                "claude",
+                AuthFlags {
+                    api_key: Some("sk-ant-test-123".to_string()),
+                    ..AuthFlags::default()
+                },
+                false,
+            );
+
+            assert_eq!(exit_code, 0);
+
+            let store = load_credentials().expect("load credentials");
+            let config = store
+                .providers
+                .get("anthropic")
+                .expect("anthropic config should be stored");
+            assert_eq!(config.auth_method, "api_key");
+            assert!(!store.providers.contains_key("claude"));
+        });
+    }
+}

--- a/crates/ui/src/auth/custom.rs
+++ b/crates/ui/src/auth/custom.rs
@@ -1,6 +1,9 @@
 use std::io::{self, Write};
 
-use super::{persist_provider_credentials, Provider};
+use super::{
+    builder::{build_provider_config, CredGroup, CredInputs},
+    persist_provider_credentials, Provider,
+};
 
 pub(super) fn run_auth() -> Result<(), Box<dyn std::error::Error>> {
     let existing = api::load_credentials()
@@ -35,16 +38,13 @@ pub(super) fn run_auth() -> Result<(), Box<dyn std::error::Error>> {
 
     persist_provider_credentials(
         Provider::Other,
-        api::StoredProviderConfig {
-            auth_method: if key.is_empty() {
-                "none".to_string()
-            } else {
-                "api_key".to_string()
+        build_provider_config(
+            CredGroup::Custom,
+            CredInputs {
+                api_key: (!key.is_empty()).then_some(key),
+                base_url: Some(base_url),
+                ..CredInputs::default()
             },
-            api_key: (!key.is_empty()).then_some(key),
-            base_url: Some(base_url),
-            default_model: existing.default_model,
-            ..Default::default()
-        },
+        ),
     )
 }

--- a/crates/ui/src/auth/group.rs
+++ b/crates/ui/src/auth/group.rs
@@ -1,0 +1,1 @@
+//! Placeholder for provider-to-credential-group helpers.

--- a/crates/ui/src/auth/group.rs
+++ b/crates/ui/src/auth/group.rs
@@ -1,1 +1,79 @@
-//! Placeholder for provider-to-credential-group helpers.
+use super::builder::CredGroup;
+
+#[must_use]
+pub fn flag_group_for(provider_id: &str) -> Option<CredGroup> {
+    match provider_id {
+        "amazon-bedrock" => Some(CredGroup::Bedrock),
+        "azure" => Some(CredGroup::Azure),
+        "vertex" => Some(CredGroup::Vertex),
+        "other" | "custom" => Some(CredGroup::Custom),
+        // `claude`/`gpt` are legacy aliases with no matching preset id.
+        "anthropic" | "claude" | "openai" | "gpt" => Some(CredGroup::Simple),
+        other => api::find_preset(other).map(|_| CredGroup::Simple),
+    }
+}
+
+#[must_use]
+pub fn is_scriptable(provider_id: &str) -> bool {
+    provider_id != "copilot"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{flag_group_for, is_scriptable, CredGroup};
+
+    #[test]
+    fn every_builtin_preset_maps_to_a_group() {
+        for preset in api::builtin_presets() {
+            assert!(
+                flag_group_for(preset.id).is_some(),
+                "preset `{}` should map to a credential group",
+                preset.id
+            );
+        }
+    }
+
+    #[test]
+    fn enterprise_providers_map_to_dedicated_groups() {
+        assert_eq!(flag_group_for("amazon-bedrock"), Some(CredGroup::Bedrock));
+        assert_eq!(flag_group_for("azure"), Some(CredGroup::Azure));
+        assert_eq!(flag_group_for("vertex"), Some(CredGroup::Vertex));
+    }
+
+    #[test]
+    fn custom_aliases_map_to_custom() {
+        assert_eq!(flag_group_for("other"), Some(CredGroup::Custom));
+        assert_eq!(flag_group_for("custom"), Some(CredGroup::Custom));
+    }
+
+    #[test]
+    fn legacy_aliases_map_to_simple() {
+        assert_eq!(flag_group_for("anthropic"), Some(CredGroup::Simple));
+        assert_eq!(flag_group_for("claude"), Some(CredGroup::Simple));
+        assert_eq!(flag_group_for("openai"), Some(CredGroup::Simple));
+        assert_eq!(flag_group_for("gpt"), Some(CredGroup::Simple));
+    }
+
+    #[test]
+    fn registered_preset_maps_to_simple() {
+        assert_eq!(flag_group_for("google"), Some(CredGroup::Simple));
+        assert_eq!(flag_group_for("groq"), Some(CredGroup::Simple));
+        assert_eq!(flag_group_for("copilot"), Some(CredGroup::Simple));
+    }
+
+    #[test]
+    fn unknown_provider_maps_to_none() {
+        assert_eq!(flag_group_for("does-not-exist"), None);
+        assert_eq!(flag_group_for(""), None);
+    }
+
+    #[test]
+    fn only_copilot_is_non_scriptable() {
+        assert!(!is_scriptable("copilot"));
+        assert!(is_scriptable("anthropic"));
+        assert!(is_scriptable("openai"));
+        assert!(is_scriptable("amazon-bedrock"));
+        assert!(is_scriptable("other"));
+        assert!(is_scriptable("does-not-exist"));
+    }
+}

--- a/crates/ui/src/auth/mask.rs
+++ b/crates/ui/src/auth/mask.rs
@@ -1,1 +1,46 @@
-//! Placeholder for credential masking helpers.
+pub const SECRET_FIELDS: &[&str] = &["api_key", "aws_secret_access_key"];
+
+#[must_use]
+pub fn mask_secret(s: &str) -> String {
+    let count = s.chars().count();
+    if count <= 4 {
+        return "••••".to_string();
+    }
+    let tail: String = s.chars().skip(count - 4).collect();
+    format!("••••{tail}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{mask_secret, SECRET_FIELDS};
+
+    #[test]
+    fn masks_long_secret_to_last_four() {
+        assert_eq!(mask_secret("sk-ant-abc1234"), "••••1234");
+    }
+
+    #[test]
+    fn empty_and_short_secrets_fully_masked() {
+        assert_eq!(mask_secret(""), "••••");
+        assert_eq!(mask_secret("a"), "••••");
+        assert_eq!(mask_secret("abcd"), "••••");
+    }
+
+    #[test]
+    fn five_char_secret_shows_last_four() {
+        assert_eq!(mask_secret("abcde"), "••••bcde");
+    }
+
+    #[test]
+    fn never_reveals_more_than_four_chars() {
+        let masked = mask_secret("super-secret-value-9876");
+        assert!(masked.ends_with("9876"));
+        assert!(!masked.contains("value"));
+    }
+
+    #[test]
+    fn secret_fields_lists_known_secrets() {
+        assert!(SECRET_FIELDS.contains(&"api_key"));
+        assert!(SECRET_FIELDS.contains(&"aws_secret_access_key"));
+    }
+}

--- a/crates/ui/src/auth/mask.rs
+++ b/crates/ui/src/auth/mask.rs
@@ -1,0 +1,1 @@
+//! Placeholder for credential masking helpers.

--- a/crates/ui/src/auth/mod.rs
+++ b/crates/ui/src/auth/mod.rs
@@ -1,5 +1,8 @@
 pub mod anthropic;
+pub mod builder;
 pub mod custom;
+pub mod group;
+pub mod mask;
 pub mod openai;
 
 use std::io::{self, Read, Write};
@@ -8,6 +11,8 @@ use std::process::Command;
 use std::sync::mpsc;
 
 use api::oauth::{parse_oauth_callback_request_target, OAuthCallbackParams};
+
+use self::builder::{build_provider_config, CredGroup, CredInputs};
 
 use crate::app::Provider;
 
@@ -150,13 +155,15 @@ fn run_bedrock_auth() -> Result<(), Box<dyn std::error::Error>> {
 
     persist_preset_credentials(
         "amazon-bedrock",
-        api::StoredProviderConfig {
-            auth_method: "api_key".to_string(),
-            api_key: Some(access_key),
-            aws_secret_access_key: Some(secret_key),
-            region: Some(region),
-            ..Default::default()
-        },
+        build_provider_config(
+            CredGroup::Bedrock,
+            CredInputs {
+                access_key: Some(access_key),
+                secret_key: Some(secret_key),
+                region: Some(region),
+                ..CredInputs::default()
+            },
+        ),
     )
 }
 
@@ -191,13 +198,15 @@ fn run_azure_auth() -> Result<(), Box<dyn std::error::Error>> {
 
     persist_preset_credentials(
         "azure",
-        api::StoredProviderConfig {
-            auth_method: "api_key".to_string(),
-            api_key: Some(api_key),
-            resource_name: Some(resource_name),
-            deployment_name: Some(deployment_name),
-            ..Default::default()
-        },
+        build_provider_config(
+            CredGroup::Azure,
+            CredInputs {
+                api_key: Some(api_key),
+                resource_name: Some(resource_name),
+                deployment_name: Some(deployment_name),
+                ..CredInputs::default()
+            },
+        ),
     )
 }
 
@@ -225,12 +234,14 @@ pub fn run_preset_auth(preset: &api::ProviderPreset) -> Result<(), Box<dyn std::
     }
     persist_preset_credentials(
         preset.id,
-        api::StoredProviderConfig {
-            auth_method: "api_key".to_string(),
-            api_key: Some(key),
-            base_url: Some(preset.base_url.to_string()),
-            ..Default::default()
-        },
+        build_provider_config(
+            CredGroup::Simple,
+            CredInputs {
+                api_key: Some(key),
+                base_url: Some(preset.base_url.to_string()),
+                ..CredInputs::default()
+            },
+        ),
     )
 }
 

--- a/crates/ui/src/auth/mod.rs
+++ b/crates/ui/src/auth/mod.rs
@@ -5,6 +5,7 @@ pub mod custom;
 pub mod group;
 pub mod mask;
 pub mod openai;
+pub mod status;
 
 use std::io::{self, Read, Write};
 use std::net::TcpListener;

--- a/crates/ui/src/auth/mod.rs
+++ b/crates/ui/src/auth/mod.rs
@@ -1,5 +1,6 @@
 pub mod anthropic;
 pub mod builder;
+pub mod configure;
 pub mod custom;
 pub mod group;
 pub mod mask;

--- a/crates/ui/src/auth/openai.rs
+++ b/crates/ui/src/auth/openai.rs
@@ -4,8 +4,9 @@ use api::oauth::OAuthTokenExchangeRequest;
 use api::{AnthropicClient, AuthSource};
 
 use super::{
-    bind_oauth_listener, open_browser, persist_provider_credentials, wait_for_oauth_callback,
-    Provider,
+    bind_oauth_listener,
+    builder::{build_provider_config, CredGroup, CredInputs},
+    open_browser, persist_provider_credentials, wait_for_oauth_callback, Provider,
 };
 
 pub(super) fn run_auth() -> Result<(), Box<dyn std::error::Error>> {
@@ -29,11 +30,13 @@ pub(super) fn run_auth() -> Result<(), Box<dyn std::error::Error>> {
             }
             persist_provider_credentials(
                 Provider::OpenAi,
-                api::StoredProviderConfig {
-                    auth_method: "openai_key".to_string(),
-                    api_key: Some(key),
-                    ..Default::default()
-                },
+                build_provider_config(
+                    CredGroup::Simple,
+                    CredInputs {
+                        api_key: Some(key),
+                        ..CredInputs::default()
+                    },
+                ),
             )?;
         }
     }

--- a/crates/ui/src/auth/status.rs
+++ b/crates/ui/src/auth/status.rs
@@ -1,0 +1,425 @@
+use api::{CredentialStore, StoredProviderConfig};
+
+use super::mask::mask_secret;
+use super::{provider_label, resolve_provider_arg, ProviderChoice};
+
+/// Inspect configured credentials.
+///
+/// With `check: Some(provider)` this acts as a gate for agents: it returns
+/// exit code `0` when the resolved provider has usable credential material in
+/// the store and `3` otherwise. No table is printed under `--check` unless
+/// `json` is also set. Without `--check` it prints a deterministically-sorted
+/// table (human) or `{"active_provider":…,"providers":[…]}` (JSON).
+///
+/// All secret material is masked via [`mask_secret`]; raw secrets are never
+/// written to any stream.
+#[must_use]
+pub fn run_auth_status(check: Option<&str>, json: bool) -> i32 {
+    let store = match api::load_credentials() {
+        Ok(store) => store,
+        Err(error) => {
+            eprintln!("failed to load credentials: {error}");
+            return 1;
+        }
+    };
+
+    if let Some(provider) = check {
+        let code = check_exit_code(&store, provider);
+        if json {
+            println!("{}", render_status(&store, true));
+        }
+        return code;
+    }
+
+    println!("{}", render_status(&store, json));
+    0
+}
+
+/// List every built-in provider preset, sorted by display name.
+///
+/// Human format: `  <id>   <display_name>   env: <api_key_env_var or (none)>`.
+/// JSON format: an array of `{"id","display_name","env_var"}` objects. Always
+/// returns exit code `0`.
+#[must_use]
+pub fn run_auth_list(json: bool) -> i32 {
+    println!("{}", render_list(json));
+    0
+}
+
+fn check_exit_code(store: &CredentialStore, provider: &str) -> i32 {
+    let choice = match resolve_provider_arg(provider) {
+        Ok(choice) => choice,
+        Err(error) => {
+            eprintln!("{error}");
+            return 3;
+        }
+    };
+    let configured = store
+        .providers
+        .get(canonical_provider_id(&choice))
+        .is_some_and(has_usable_credential);
+    if configured {
+        0
+    } else {
+        3
+    }
+}
+
+fn canonical_provider_id(choice: &ProviderChoice) -> &str {
+    match choice {
+        ProviderChoice::Legacy(provider) => provider_label(*provider),
+        ProviderChoice::Preset(preset) => preset.id,
+    }
+}
+
+fn has_usable_credential(config: &StoredProviderConfig) -> bool {
+    let api_key_ok = config.api_key.as_deref().is_some_and(|key| !key.is_empty());
+    let aws_ok = config
+        .aws_secret_access_key
+        .as_deref()
+        .is_some_and(|secret| !secret.is_empty());
+    // `auth_method == "none"` is the custom no-key (local endpoint) case.
+    api_key_ok || aws_ok || has_oauth(config) || config.auth_method == "none"
+}
+
+fn has_oauth(config: &StoredProviderConfig) -> bool {
+    config
+        .oauth
+        .as_ref()
+        .is_some_and(|tokens| !tokens.access_token.is_empty())
+}
+
+fn masked_primary_secret(config: &StoredProviderConfig) -> Option<String> {
+    if let Some(key) = config.api_key.as_deref().filter(|value| !value.is_empty()) {
+        return Some(mask_secret(key));
+    }
+    if let Some(secret) = config
+        .aws_secret_access_key
+        .as_deref()
+        .filter(|value| !value.is_empty())
+    {
+        return Some(mask_secret(secret));
+    }
+    if let Some(tokens) = config.oauth.as_ref() {
+        if !tokens.access_token.is_empty() {
+            return Some(mask_secret(&tokens.access_token));
+        }
+    }
+    None
+}
+
+fn sorted_provider_keys(store: &CredentialStore) -> Vec<&str> {
+    let mut keys: Vec<&str> = store.providers.keys().map(String::as_str).collect();
+    keys.sort_unstable();
+    keys
+}
+
+fn sorted_presets() -> Vec<api::ProviderPreset> {
+    let mut presets = api::builtin_presets();
+    presets.sort_by_key(|preset| preset.display_name);
+    presets
+}
+
+fn render_status(store: &CredentialStore, json: bool) -> String {
+    if json {
+        to_pretty(&status_json(store))
+    } else {
+        render_status_human(store)
+    }
+}
+
+fn render_status_human(store: &CredentialStore) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    if let Some(active) = store.active_provider.as_deref() {
+        lines.push(format!("active provider: {active}"));
+    }
+    let keys = sorted_provider_keys(store);
+    if keys.is_empty() {
+        lines.push("  (no providers configured)".to_string());
+    } else {
+        for key in keys {
+            let config = &store.providers[key];
+            let masked = masked_primary_secret(config).unwrap_or_else(|| "(none)".to_string());
+            let model = config.default_model.as_deref().unwrap_or("(none)");
+            lines.push(format!(
+                "  {key}   {auth}   {masked}   model: {model}",
+                auth = config.auth_method
+            ));
+        }
+    }
+    lines.join("\n")
+}
+
+fn status_json(store: &CredentialStore) -> serde_json::Value {
+    let providers: Vec<serde_json::Value> = sorted_provider_keys(store)
+        .into_iter()
+        .map(|key| {
+            let config = &store.providers[key];
+            serde_json::json!({
+                "id": key,
+                "auth_method": config.auth_method,
+                "default_model": config.default_model,
+                "api_key_masked": masked_primary_secret(config).unwrap_or_default(),
+                "has_oauth": has_oauth(config),
+            })
+        })
+        .collect();
+    serde_json::json!({
+        "active_provider": store.active_provider,
+        "providers": providers,
+    })
+}
+
+fn render_list(json: bool) -> String {
+    if json {
+        return to_pretty(&list_json());
+    }
+    sorted_presets()
+        .into_iter()
+        .map(|preset| {
+            let env = preset.api_key_env_var.unwrap_or("(none)");
+            format!(
+                "  {id}   {name}   env: {env}",
+                id = preset.id,
+                name = preset.display_name
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn list_json() -> serde_json::Value {
+    let items: Vec<serde_json::Value> = sorted_presets()
+        .into_iter()
+        .map(|preset| {
+            serde_json::json!({
+                "id": preset.id,
+                "display_name": preset.display_name,
+                "env_var": preset.api_key_env_var,
+            })
+        })
+        .collect();
+    serde_json::Value::Array(items)
+}
+
+fn to_pretty(value: &serde_json::Value) -> String {
+    serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn cfg_with_api_key(key: &str) -> StoredProviderConfig {
+        StoredProviderConfig {
+            auth_method: "api_key".to_string(),
+            api_key: Some(key.to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn store_with(providers: Vec<(&str, StoredProviderConfig)>) -> CredentialStore {
+        let mut map = HashMap::new();
+        for (id, config) in providers {
+            map.insert(id.to_string(), config);
+        }
+        CredentialStore {
+            active_provider: None,
+            providers: map,
+        }
+    }
+
+    #[test]
+    fn check_returns_zero_for_configured_provider() {
+        let store = store_with(vec![("anthropic", cfg_with_api_key("sk-ant-xyz"))]);
+        assert_eq!(check_exit_code(&store, "anthropic"), 0);
+    }
+
+    #[test]
+    fn check_canonicalizes_alias_before_lookup() {
+        let store = store_with(vec![("anthropic", cfg_with_api_key("sk-ant-xyz"))]);
+        assert_eq!(check_exit_code(&store, "claude"), 0);
+    }
+
+    #[test]
+    fn check_returns_three_for_unconfigured_provider() {
+        let store = store_with(vec![]);
+        assert_eq!(check_exit_code(&store, "groq"), 3);
+        assert_eq!(check_exit_code(&store, "openai"), 3);
+    }
+
+    #[test]
+    fn check_returns_three_for_empty_api_key() {
+        let store = store_with(vec![(
+            "openai",
+            StoredProviderConfig {
+                auth_method: "openai_key".to_string(),
+                api_key: Some(String::new()),
+                ..Default::default()
+            },
+        )]);
+        assert_eq!(check_exit_code(&store, "openai"), 3);
+    }
+
+    #[test]
+    fn check_returns_three_for_unknown_provider() {
+        let store = store_with(vec![]);
+        assert_eq!(check_exit_code(&store, "does-not-exist"), 3);
+    }
+
+    #[test]
+    fn none_auth_method_counts_as_usable() {
+        let config = StoredProviderConfig {
+            auth_method: "none".to_string(),
+            ..Default::default()
+        };
+        assert!(has_usable_credential(&config));
+    }
+
+    #[test]
+    fn aws_secret_counts_as_usable() {
+        let config = StoredProviderConfig {
+            auth_method: "api_key".to_string(),
+            aws_secret_access_key: Some("secret".to_string()),
+            ..Default::default()
+        };
+        assert!(has_usable_credential(&config));
+    }
+
+    #[test]
+    fn oauth_token_counts_as_usable() {
+        let config = StoredProviderConfig {
+            auth_method: "oauth".to_string(),
+            oauth: Some(api::StoredOAuthTokens {
+                access_token: "tok".to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(has_usable_credential(&config));
+    }
+
+    #[test]
+    fn empty_oauth_token_not_usable() {
+        let config = StoredProviderConfig {
+            auth_method: "oauth".to_string(),
+            oauth: Some(api::StoredOAuthTokens::default()),
+            ..Default::default()
+        };
+        assert!(!has_usable_credential(&config));
+    }
+
+    #[test]
+    fn status_output_never_contains_raw_api_key() {
+        let secret = "sk-test-supersecret-body-1234";
+        let mut store = store_with(vec![(
+            "anthropic",
+            StoredProviderConfig {
+                auth_method: "api_key".to_string(),
+                api_key: Some(secret.to_string()),
+                default_model: Some("anthropic/claude-x".to_string()),
+                ..Default::default()
+            },
+        )]);
+        store.active_provider = Some("anthropic".to_string());
+
+        let human = render_status(&store, false);
+        let json = render_status(&store, true);
+
+        for output in [&human, &json] {
+            assert!(!output.contains(secret), "raw secret leaked: {output}");
+            assert!(
+                !output.contains("supersecret"),
+                "secret body leaked: {output}"
+            );
+            assert!(output.contains("••••1234"), "masked tail missing: {output}");
+        }
+    }
+
+    #[test]
+    fn status_output_never_contains_raw_oauth_token() {
+        let token = "oauth-access-token-secret-9999";
+        let store = store_with(vec![(
+            "copilot",
+            StoredProviderConfig {
+                auth_method: "oauth".to_string(),
+                oauth: Some(api::StoredOAuthTokens {
+                    access_token: token.to_string(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        )]);
+
+        let human = render_status(&store, false);
+        let json = render_status(&store, true);
+
+        assert!(!human.contains(token));
+        assert!(!json.contains(token));
+        assert!(human.contains("••••9999"));
+
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        assert_eq!(parsed["providers"][0]["has_oauth"], serde_json::json!(true));
+    }
+
+    #[test]
+    fn status_json_reports_active_provider_and_sorted_providers() {
+        let mut store = store_with(vec![
+            ("openai", cfg_with_api_key("key-two")),
+            ("anthropic", cfg_with_api_key("key-one")),
+        ]);
+        store.active_provider = Some("openai".to_string());
+
+        let json = render_status(&store, true);
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+
+        assert_eq!(parsed["active_provider"], serde_json::json!("openai"));
+        let providers = parsed["providers"].as_array().expect("array");
+        assert_eq!(providers.len(), 2);
+        assert_eq!(providers[0]["id"], serde_json::json!("anthropic"));
+        assert_eq!(providers[1]["id"], serde_json::json!("openai"));
+    }
+
+    #[test]
+    fn status_json_handles_empty_store() {
+        let store = CredentialStore::default();
+        let json = render_status(&store, true);
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        assert_eq!(parsed["active_provider"], serde_json::Value::Null);
+        assert_eq!(parsed["providers"].as_array().expect("array").len(), 0);
+    }
+
+    #[test]
+    fn auth_list_json_includes_all_presets() {
+        let json = render_list(true);
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        let arr = parsed.as_array().expect("array");
+
+        assert_eq!(arr.len(), api::builtin_presets().len());
+        assert_eq!(arr.len(), 25);
+
+        for entry in arr {
+            assert!(entry.get("id").is_some());
+            assert!(entry.get("display_name").is_some());
+            assert!(entry.get("env_var").is_some());
+        }
+    }
+
+    #[test]
+    fn auth_list_human_lists_every_preset() {
+        let human = render_list(false);
+        let lines: Vec<&str> = human.lines().collect();
+
+        assert_eq!(lines.len(), api::builtin_presets().len());
+        assert_eq!(lines.len(), 25);
+        assert!(human.contains("env: ANTHROPIC_API_KEY"));
+        assert!(human.contains("env: (none)"));
+    }
+
+    #[test]
+    fn run_auth_list_always_returns_zero() {
+        assert_eq!(run_auth_list(false), 0);
+        assert_eq!(run_auth_list(true), 0);
+    }
+}

--- a/crates/ui/src/config_runner.rs
+++ b/crates/ui/src/config_runner.rs
@@ -16,6 +16,7 @@ pub enum ConfigAction {
     Path,
 }
 
+#[must_use]
 pub fn run_config(action: ConfigAction, json: bool) -> i32 {
     match run_config_inner(action, json) {
         Ok(()) => 0,

--- a/crates/ui/src/config_runner.rs
+++ b/crates/ui/src/config_runner.rs
@@ -1,0 +1,74 @@
+use runtime::config_ops::{config_get, config_path, config_set, config_unset, ConfigError};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfigAction {
+    Get {
+        key: Option<String>,
+        effective: bool,
+    },
+    Set {
+        key: String,
+        value: String,
+    },
+    Unset {
+        key: String,
+    },
+    Path,
+}
+
+pub fn run_config(action: ConfigAction, json: bool) -> i32 {
+    match run_config_inner(action, json) {
+        Ok(()) => 0,
+        Err(err) => {
+            eprintln!("{err}");
+            match err {
+                ConfigError::UnknownKey(_) | ConfigError::BadValue { .. } => 2,
+                ConfigError::Io(_) => 1,
+            }
+        }
+    }
+}
+
+fn run_config_inner(action: ConfigAction, json: bool) -> Result<(), ConfigError> {
+    match action {
+        ConfigAction::Get { key, effective } => {
+            let output = config_get(key.as_deref().unwrap_or(""), effective)?;
+            if json || key.is_none() {
+                println!("{output}");
+            } else {
+                let parsed: serde_json::Value = serde_json::from_str(&output).map_err(|err| {
+                    ConfigError::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, err))
+                })?;
+                match parsed {
+                    serde_json::Value::String(value) => println!("{value}"),
+                    other => println!(
+                        "{}",
+                        serde_json::to_string(&other).map_err(|err| {
+                            ConfigError::Io(std::io::Error::new(
+                                std::io::ErrorKind::InvalidData,
+                                err,
+                            ))
+                        })?
+                    ),
+                }
+            }
+            Ok(())
+        }
+        ConfigAction::Set { key, value } => config_set(&key, &value),
+        ConfigAction::Unset { key } => config_unset(&key),
+        ConfigAction::Path => {
+            let path = config_path();
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string(&path.to_string_lossy().to_string()).map_err(|err| {
+                        ConfigError::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, err))
+                    })?
+                );
+            } else {
+                println!("{}", path.display());
+            }
+            Ok(())
+        }
+    }
+}

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -22,6 +22,7 @@ impl CliOutputFormat {
 
 pub mod app;
 pub mod auth;
+pub mod config_runner;
 pub mod display_width;
 pub mod error;
 pub mod events;

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -30,3 +30,4 @@ pub mod output_sink;
 pub mod session_mgr;
 
 pub use auth::configure::{run_auth_configure, AuthFlags};
+pub use auth::status::{run_auth_list, run_auth_status};

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -28,3 +28,5 @@ pub mod error;
 pub mod events;
 pub mod output_sink;
 pub mod session_mgr;
+
+pub use auth::configure::{run_auth_configure, AuthFlags};

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -31,3 +31,4 @@ pub mod session_mgr;
 
 pub use auth::configure::{run_auth_configure, AuthFlags};
 pub use auth::status::{run_auth_list, run_auth_status};
+pub use config_runner::{run_config, ConfigAction};


### PR DESCRIPTION
﻿## Summary

Makes every acrawl setup/configuration action scriptable in a single shell command, so agents and CI pipelines can configure acrawl without interactive prompts or TUI.

### Motivation

Today the *execution* path (`acrawl prompt`, `--resume`, env vars) is fully agent-friendly, but the *setup* path required interactive `stdin` (`dialoguer::FuzzySelect`, `io::stdin().read_line`). An agent couldn't configure credentials, set the model, or install MCP without a human at the terminal.

---

## New Commands

### `acrawl auth <provider> --api-key KEY [flags]`
Configure credentials non-interactively:
```bash
acrawl auth anthropic --api-key "sk-ant-..."
acrawl auth openai    --api-key "sk-..."
acrawl auth amazon-bedrock --access-key AKIA... --secret-key ... --region us-east-1
acrawl auth azure     --resource myres --deployment gpt-4o --api-key "..."
acrawl auth other     --base-url http://localhost:11434/v1        # Ollama, no key
acrawl auth vertex    --gcp-project my-proj --gcp-region us-central1 --api-key "..."
acrawl auth groq      --api-key "gsk_..."   # any of the 25 presets
```

### `acrawl auth status / list`
```bash
acrawl auth status                     # show all configured providers (secrets masked)
acrawl auth status --check anthropic   # exit 0 if configured, 3 if not (agent gate)
acrawl auth status --json              # machine-readable
acrawl auth list                       # all 25 available providers + env vars
```

### `acrawl config get|set|unset|path`
Schema-aware read/write of `settings.json` with dot-notation:
```bash
acrawl config set model anthropic/claude-sonnet-4-6
acrawl config set headless false
acrawl config set optimization.html_diff_mode true
acrawl config get model --effective    # resolved value the CLI would use
acrawl config get --json               # full settings dump
acrawl config unset max_steps          # revert to default (50)
```

### `acrawl mcp install/uninstall --client`
Non-interactive IDE MCP provisioning:
```bash
acrawl mcp install --client opencode
acrawl mcp install --client cursor,windsurf --scope project
acrawl mcp install --all --yes
acrawl mcp install --list-clients      # show all 17 supported clients
```

---

## One-Line Agent Bootstrap
```bash
acrawl auth anthropic --api-key "$KEY"
acrawl config set model anthropic/claude-sonnet-4-6
acrawl auth status --check anthropic   # gate: exit 0 if ready, 3 if not
acrawl prompt "scrape titles from example.com" --output-format json
```

---

## Exit Codes

| Code | Meaning |
|------|---------|
| `0` | Success |
| `1` | Runtime / IO error |
| `2` | Usage error (bad flag, unknown key, missing required field) |
| `3` | State-check failed (`--check` provider not configured; all MCP clients failed) |

---

## Implementation

### New files

| File | Purpose |
|------|---------|
| `crates/ui/src/auth/builder.rs` | Shared pure credential-builder — both interactive and non-interactive paths call `build_provider_config`, guaranteeing parity |
| `crates/ui/src/auth/group.rs` | Provider to flag-group mapping covering all 25 presets + 3 legacy aliases |
| `crates/ui/src/auth/mask.rs` | `mask_secret()` last-4-chars only; `SECRET_FIELDS` |
| `crates/ui/src/auth/configure.rs` | `run_auth_configure(provider, flags, json) -> i32` |
| `crates/ui/src/auth/status.rs` | `run_auth_status` + `run_auth_list` |
| `crates/runtime/src/config_ops.rs` | Schema-aware config engine (key to type registry, `config_set/get/unset/path`, `ConfigError`) |
| `crates/ui/src/config_runner.rs` | Thin `run_config(ConfigAction, json) -> i32` runner |

### Modified files

- **`crates/mcp-server/src/installer.rs`** — stable kebab client keys, `client_from_key`, `InstallReport`, `run_install_for`/`run_uninstall_for`/`list_clients`; interactive paths delegate to the new API unchanged
- **`crates/cli/src/main.rs`** — 10 new `CliAction` variants, extended `auth`/`config`/`mcp` sub-parsers, exit-code taxonomy (0/1/2/3), stdin TTY-guard (non-TTY + no flags → exit 2 immediately, never hangs)

### Backward compatibility

- All existing interactive paths (`acrawl auth`, bare `acrawl mcp install`, the REPL) **unchanged**
- `parse_args` signature unchanged; existing variants not mutated
- All 1,573 pre-existing tests pass

---

## Security

- `--api-key VALUE` is visible in process list / shell history — documented in `--help` and README
- `auth status` / `auth list` mask all secret fields to last-4 chars only (`....a1b2`)
- `active_provider` is never written by new code (provider is resolved from the model prefix)

---

## Testing

- 1,573 tests pass (`cargo test --workspace`)
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt --check` clean
- 7 E2E scenarios verified against the release binary with isolated `ACRAWL_CONFIG_HOME`: auth credential write, status gating (exit 0/3), config round-trip, TTY guard no-hang, secret-leak gate, unknown-key exit 2, idempotency
