### PR TITLE
feat(agent): SPA semantic introspection upgrade — regions, combobox engine, label-fill, scoped diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`page_map` — semantic region tree and active dialog detection**: emits a `regions` tree with ephemeral `@rN` handles and human-readable labels (`sidebar`, `main panel`, `admin modal`); `active_dialog` points to the topmost visible overlay; non-`<form>` controls (div-based modal inputs) surface with accessible names. `scope` now also accepts semantic tokens (`"dialog"`, `"main"`, `"sidebar"`) and `@rN` handles in addition to raw CSS selectors.
+- **`fill_form` — page-wide label resolution**: field keys resolve by visible label text page-wide without a `<form>` boundary, enabling fill in modal/admin UIs built from divs. Falls back to fuzzy matching via `crate::semantic::match_text`.
+- **`select_option` — portal-aware custom dropdown engine**: handles ARIA combobox/listbox and div-based dropdowns whose option list renders in a portal outside the trigger's DOM subtree. Detects open state via four signals (aria-expanded flip, new listbox/menu, new options, new floating panel), locates the option container via aria-controls/owns then document-wide search, and selects keyboard-first with a click fallback. Omitting `value`/`label`/`index` opens and enumerates available options without selecting (list-options mode).
+- **`click` — text + role + region activation**: new `text` parameter activates elements by visible label, including `<label for=id>` and wrapping `<label>` resolution. Optional `role` filter (supports semantic ARIA roles for native elements) and `region` filter (`@rN` handle or `"dialog"`/`"main"`/`"sidebar"` token). `selector` and `text` are mutually exclusive.
+
+### Changed
+
+- Post-action diffs auto-scope to the interacted container or active dialog by default; pass `widen: true` to any interaction tool to restore the full-page diff.
+- Diff computation consolidated to Rust (`feedback.rs`); the Chrome extension's JS-side `computePageMapDiff` / `pageMapCache` removed — both backends flow through a single diff path.
+- `@rN` region handles now resolve from the last full-page `page_map` snapshot rather than the most-recently-stored snapshot, so handles remain stable after container-scoped interactions.
+
 ## [0.12.1] - 2026-06-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Diff computation consolidated to Rust (`feedback.rs`); the Chrome extension's JS-side `computePageMapDiff` / `pageMapCache` removed — both backends flow through a single diff path.
 - `@rN` region handles now resolve from the last full-page `page_map` snapshot rather than the most-recently-stored snapshot, so handles remain stable after container-scoped interactions.
 
+### Fixed
+
+- **click**: `@rN` region handle not in snapshot now hard-fails instead of silently widening scope to full page
+- **click**: remove `|| document` JS fallback; scoped IIFE throws if the scope element is missing from the DOM
+- **click, fill_form**: `aria-labelledby` now correctly resolved as a whitespace-separated id list
+- **fill_form**: `submit` no longer reports success when no `<form>` matched the selector (`form_not_found` outcome now surfaces as an error)
+- **select_option**: popup closure alone no longer counts as verified selection; only trigger-text change or `aria-selected` qualify
+- **browser/playwright**: `isVisible` in DOM-snapshot extraction now uses `getBoundingClientRect()` matching the extension backend, fixing false-invisible on `position:fixed` portal overlays
+- **feedback**: post-action snapshots now enriched before caching, so `@rN` region handles remain valid after interactions; bare-tag diff-scope selectors (`section`, `article`, `form`) replaced with id-based or role-scoped selectors to prevent anchoring to the wrong container
+
 ## [0.12.1] - 2026-06-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,7 @@ dependencies = [
  "regex",
  "runtime",
  "script",
+ "serde",
  "serde_json",
  "sha2",
  "tempfile",

--- a/README.md
+++ b/README.md
@@ -252,10 +252,10 @@ If `fit_markdown` prunes all content (empty result), the tool automatically fall
 
 | Tool | Description |
 |------|-------------|
-| `click` | Click an element by CSS selector. Returns `page_state` after the click. |
+| `click` | Click an element by CSS selector, `@eN` ref, or visible label text. Use `text` (with optional `role`/`region`) to activate a button, tab, or link by its label — handy for SPA admin UIs and modals where CSS paths are fragile. Returns `page_state` after the click. |
 | `click_at` | Click at specific viewport coordinates (x, y). Use for canvas, maps, or SVGs. Returns `page_state`. |
-| `fill_form` | Fill form fields by selector or name, with optional auto-submit. Returns `page_state`. |
-| `select_option` | Select a dropdown option by value, label, or index. Returns `page_state`. |
+| `fill_form` | Fill form fields by selector, name, `@eN` ref, or visible label text — labels resolve page-wide, so fields in modals and div-based UIs without a `<form>` boundary work too. Optional auto-submit. Returns `page_state`. |
+| `select_option` | Select a dropdown option by value, label, or index. Works on native `<select>` and custom ARIA/portal dropdowns; omit value/label/index to list the available options without selecting. Returns `page_state`. |
 | `hover` | Hover over an element to reveal tooltips or menus. Returns `page_state`. |
 | `press_key` | Press a keyboard key (Enter, Escape, Tab, etc.), optionally targeting an element. Returns `page_state`. |
 | `set_device` | Switch browser device emulation (mobile/desktop). Supports 10 presets (iphone_15, pixel_7, ipad_pro, desktop, etc.) or custom viewport/UA/touch parameters. Returns differential `page_state` showing responsive layout changes. |
@@ -265,7 +265,7 @@ If `fit_markdown` prunes all content (empty result), the tool automatically fall
 
 | Tool | Description |
 |------|-------------|
-| `page_map` | Get the page's structural map: headings, landmarks, forms, links, and interactive elements (with selectors and state). Supports `scope` to query within a specific element (e.g. a modal). |
+| `page_map` | Get the page's structural map: headings, landmarks, forms, links, and interactive elements (with selectors and state), plus a `regions` hierarchy (sidebar/main/dialog), the `active_dialog`, and non-form `controls`. `scope` accepts a CSS selector, a semantic token (`dialog`/`main`/`sidebar`), or a region handle (`@r1`) to query within a specific element (e.g. a modal). |
 | `read_content` | Extract text by heading name or CSS selector, with offset/limit pagination for large pages. |
 | `list_resources` | List all links, images, and forms on the current page. |
 | `screenshot` | Capture a full-page screenshot (base64 PNG). |
@@ -323,11 +323,14 @@ Interaction tools (`click`, `click_at`, `fill_form`, `hover`, `press_key`, `go_b
     "headings": [{ "level": 1, "text": "...", "id": "...", "selector": "...", "char_count": 0, "preview": "..." }],
     "landmarks": [{ "tag": "nav", "role": "navigation", "id": "...", "selector": "...", "text_preview": "..." }],
     "links": [{ "text": "...", "href": "...", "selector": "..." }],
-    "interactive": { "counts": { "buttons": 0, "inputs": 0, "selects": 0, "textareas": 0, "total": 0 }, "elements": [] },
+    "regions": [{ "kind": "Main", "label": "main panel", "handle": "@r1", "selector": "main", "visible": true, "children": [] }],
+    "active_dialog": null,
     "meta": { "title": "...", "url": "...", "description": "..." },
     "truncated_links": false,
     "truncated_forms": false,
-    "truncated_landmarks": false
+    "truncated_landmarks": false,
+    "truncated_regions": false,
+    "truncated_controls": false
   }
 }
 ```
@@ -353,7 +356,7 @@ Interaction tools (`click`, `click_at`, `fill_form`, `hover`, `press_key`, `go_b
 }
 ```
 
-If nothing changed, `{ "url": "...", "title": "...", "changed": false }` is returned. On bridge failure, `{ "url": "unknown", "title": "unknown", "page_map": null }`. Caps: max 50 links, 20 landmarks per page_state.
+If nothing changed, `{ "url": "...", "title": "...", "changed": false }` is returned. On bridge failure, `{ "url": "unknown", "title": "unknown", "page_map": null }`. The embedded `page_map` preserves `regions` and `active_dialog` but omits the verbose `forms`, `interactive`, and `controls` arrays to keep interaction responses concise — call the `page_map` tool to retrieve those. Caps: max 50 links, 20 landmarks per page_state.
 
 
 ### Sub-Agent Parallelism

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -13,6 +13,7 @@ csv = "1"
 regex = "1"
 runtime = { path = "../runtime" }
 script = { path = "../script" }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 time = { version = "0.3", features = ["formatting"] }

--- a/crates/agent/src/implementation/lifecycle.rs
+++ b/crates/agent/src/implementation/lifecycle.rs
@@ -164,6 +164,7 @@ impl CrawlerAgent {
 mod tests {
     use std::sync::Arc;
 
+    use serde_json::Value;
     use tokio::sync::Mutex;
 
     use super::*;
@@ -175,6 +176,29 @@ mod tests {
                 .await
                 .expect("bridge should initialize for lifecycle test"),
         ) as Box<dyn BrowserBackend + Send>))
+    }
+
+    async fn respond_ok(
+        command_rx: &mut tokio::sync::mpsc::Receiver<(
+            crate::BridgeCommand,
+            tokio::sync::oneshot::Sender<crate::ws_server::BridgeResponse>,
+        )>,
+        expected_action: &str,
+        result: Option<Value>,
+    ) {
+        let (cmd, resp_tx) = command_rx
+            .recv()
+            .await
+            .unwrap_or_else(|| panic!("extension should receive {expected_action}"));
+        assert_eq!(cmd.action, expected_action);
+        resp_tx
+            .send(crate::ws_server::BridgeResponse {
+                id: cmd.id,
+                ok: true,
+                result,
+                error: None,
+            })
+            .unwrap();
     }
 
     #[tokio::test]
@@ -320,7 +344,6 @@ mod tests {
 
     #[tokio::test]
     async fn tool_execution_routes_commands_through_extension_bridge() {
-        use crate::ws_server::BridgeResponse;
         use acrawl_core::ToolExecutor;
         use serde_json::json;
 
@@ -344,86 +367,41 @@ mod tests {
             );
 
         // acquire_bridge() calls switch_tab first
-        let (cmd, resp_tx) = command_rx
-            .recv()
-            .await
-            .expect("extension should receive switch_tab");
-        assert_eq!(cmd.action, "switch_tab");
-        resp_tx
-            .send(BridgeResponse {
-                id: cmd.id,
-                ok: true,
-                result: Some(json!({"url": "about:blank", "title": ""})),
-                error: None,
-            })
-            .unwrap();
+        respond_ok(
+            &mut command_rx,
+            "switch_tab",
+            Some(json!({"url": "about:blank", "title": ""})),
+        )
+        .await;
 
         // Then click
-        let (cmd, resp_tx) = command_rx
-            .recv()
-            .await
-            .expect("extension should receive click");
-        assert_eq!(cmd.action, "click");
-        resp_tx
-            .send(BridgeResponse {
-                id: cmd.id,
-                ok: true,
-                result: None,
-                error: None,
-            })
-            .unwrap();
+        respond_ok(&mut command_rx, "click", None).await;
 
         // increment_seq pushes the current seq to the extension bridge so
         // buffered observations are tagged for temporal filtering.
-        let (cmd, resp_tx) = command_rx
-            .recv()
-            .await
-            .expect("extension should receive set_seq");
-        assert_eq!(cmd.action, "set_seq");
-        resp_tx
-            .send(BridgeResponse {
-                id: cmd.id,
-                ok: true,
-                result: None,
-                error: None,
-            })
-            .unwrap();
+        respond_ok(&mut command_rx, "set_seq", None).await;
 
         // post_action_page_state: acquire_bridge (switch_tab) + page_map
-        let (cmd, resp_tx) = command_rx
-            .recv()
-            .await
-            .expect("extension should receive second switch_tab");
-        assert_eq!(cmd.action, "switch_tab");
-        resp_tx
-            .send(BridgeResponse {
-                id: cmd.id,
-                ok: true,
-                result: Some(json!({"url": "about:blank", "title": ""})),
-                error: None,
-            })
-            .unwrap();
-
-        let (cmd, resp_tx) = command_rx
-            .recv()
-            .await
-            .expect("extension should receive page_map");
-        assert_eq!(cmd.action, "page_map");
-        resp_tx
-            .send(BridgeResponse {
-                id: cmd.id,
-                ok: true,
-                result: Some(json!({
-                    "headings": [],
-                    "landmarks": [],
-                    "forms": [],
-                    "links": [],
-                    "interactive": {},
-                    "meta": {"url": "https://test.com", "title": "Test Page", "description": ""}
-                })),
-                error: None,
-            })
-            .unwrap();
+        respond_ok(
+            &mut command_rx,
+            "switch_tab",
+            Some(json!({"url": "about:blank", "title": ""})),
+        )
+        .await;
+        respond_ok(&mut command_rx, "execute_js", Some(json!(null))).await;
+        respond_ok(
+            &mut command_rx,
+            "page_map",
+            Some(json!({
+                "headings": [],
+                "landmarks": [],
+                "forms": [],
+                "links": [],
+                "interactive": {},
+                "meta": {"url": "https://test.com", "title": "Test Page", "description": ""}
+            })),
+        )
+        .await;
 
         let result = handle.await.expect("task should complete");
         let output = result.expect("click should succeed through extension bridge");

--- a/crates/agent/src/implementation/mod.rs
+++ b/crates/agent/src/implementation/mod.rs
@@ -662,7 +662,7 @@ impl CrawlerAgent {
         }
 
         crate::tools::page_map::annotate_refs(&mut fresh_page_map, browser);
-        browser.set_page_snapshot(cache_key, fresh_page_map.clone());
+        browser.set_page_snapshot(&cache_key, None, fresh_page_map.clone());
 
         let Some(new_selector) = crate::self_healing::find_healed_selector(
             &old_ref,

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -236,19 +236,19 @@ fn fill_form_tool() -> ToolSpec {
 fn select_option_tool() -> ToolSpec {
     ToolSpec {
         name: "select_option",
-        description: "Select an option from a <select> dropdown element. Identify the target dropdown via CSS selector or @eN ref, then specify which option to select by its value attribute, visible label text, or zero-based index. Returns post-action page_state showing any page changes triggered by the selection (e.g. dependent dropdowns updating).",
+        description: "Select an option from a native <select> or custom ARIA/portal dropdown. Identify the target control via CSS selector or @eN ref, then specify which option to select by its value attribute, visible label text, or zero-based index. Omit value, label, and index to open the dropdown, enumerate the currently available options, and return them without selecting. Returns post-action page_state showing any page changes triggered by the selection (e.g. dependent dropdowns updating).",
         input_schema: json!({
             "type": "object",
             "properties": {
-                "selector": { "type": "string", "description": "CSS selector or @eN ref targeting the <select> element (e.g. \"@e4\", \"select#country\", \"select[name='size']\")." },
-                "value": { "type": "string", "description": "The value attribute of the <option> to select (e.g. \"us\", \"medium\"). Use when you know the option's value." },
-                "label": { "type": "string", "description": "The visible text of the <option> to select (e.g. \"United States\", \"Medium\"). Use when you know the display text." },
+                "selector": { "type": "string", "description": "CSS selector or @eN ref targeting the native select or custom dropdown trigger (e.g. \"@e4\", \"select#country\", \"button[role='combobox']\")." },
+                "value": { "type": "string", "description": "The value attribute of the option to select (e.g. \"us\", \"medium\"). For custom dropdowns without exposed values, this is matched against visible option text." },
+                "label": { "type": "string", "description": "The visible text of the option to select (e.g. \"United States\", \"Medium\"). Use when you know the display text." },
                 "index": { "type": "integer", "description": "Zero-based index of the <option> to select (0 = first option). Use when value/label are unknown." }
             },
             "required": ["selector"],
             "additionalProperties": false
         }),
-        instructions: Some("Provide `selector` for the <select> element, then one of `value`, `label`, or `index` to identify the option. Returns a `page_state` with the updated page structure after selection. The selector field accepts CSS selectors or @eN element refs from page_map output (e.g., \"@e4\")."),
+        instructions: Some("Works on native `<select>` elements and custom ARIA or portal-rendered dropdowns. Provide `selector`, then optionally set `value`, `label`, or `index` to choose an option. If all three are omitted, the tool opens the dropdown, lists the currently visible options, and returns them without selecting. Returns a `page_state` with the updated page structure after selection or list-mode open. The selector field accepts CSS selectors or @eN element refs from page_map output (e.g., \"@e4\")."),
     }
 }
 

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -218,7 +218,7 @@ fn click_at_tool() -> ToolSpec {
 fn fill_form_tool() -> ToolSpec {
     ToolSpec {
         name: "fill_form",
-        description: "Fill one or more form fields with values and optionally submit the form. Accepts field identifiers as CSS selectors, field names/IDs, or @eN references from page_map. Returns post-action page_state with the resulting URL and structural diff. Use form_selector to disambiguate when the page contains multiple forms.",
+        description: "Fill one or more form fields with values and optionally submit the form. Accepts field identifiers as CSS selectors, field names/IDs, or @eN references from page_map. Also resolves fields by visible label text page-wide — works in modals and div-based UIs without a <form> boundary. Returns post-action page_state with the resulting URL and structural diff. Use form_selector to disambiguate when the page contains multiple forms.",
         input_schema: json!({
             "type": "object",
             "properties": {
@@ -234,7 +234,7 @@ fn fill_form_tool() -> ToolSpec {
             "required": ["fields"],
             "additionalProperties": false
         }),
-        instructions: Some("Keys in `fields` accept CSS selectors, plain field names/IDs, or @eN element refs from page_map (e.g., {\"@e5\": \"value\"}). Set `submit` to true to submit after filling. Use `form_selector` when the page has multiple forms. The response includes post-action page state showing the resulting URL and page structure."),
+        instructions: Some("Keys in `fields` accept CSS selectors, plain field names/IDs, @eN element refs from page_map (e.g., {\"@e5\": \"value\"}), or a visible label text — labels are matched page-wide so fields inside modals or div-based UIs without a <form> boundary still resolve. Set `submit` to true to submit after filling. Use `form_selector` when the page has multiple forms. The response includes post-action page state showing the resulting URL and page structure."),
     }
 }
 
@@ -312,7 +312,7 @@ fn execute_js_tool() -> ToolSpec {
 fn page_map_tool() -> ToolSpec {
     ToolSpec {
         name: "page_map",
-        description: "Get a comprehensive structural map of the current page including headings (h1–h6 with section sizes), landmark regions, forms with field details, links (text + href, capped at 50), and interactive elements (buttons, inputs, selects with state and @eN refs). Use to discover page structure before interacting, or with scope to inspect a specific modal/dialog without background noise. Each interactive element returns a stable @eN reference for use in click, fill_form, hover, press_key, and select_option.",
+        description: "Get a comprehensive structural map of the current page including headings (h1–h6 with section sizes), landmark regions, forms with field details, links (text + href, capped at 50), and interactive elements (buttons, inputs, selects with state and @eN refs). Also returns a regions hierarchy (sidebar/main/dialog), the active_dialog, and non-form controls alongside headings/landmarks/links/interactive. Use to discover page structure before interacting, or with scope to inspect a specific modal/dialog without background noise. Scope accepts semantic tokens ('dialog', 'main', 'sidebar') or a region handle (@r1) in addition to a raw CSS selector. Each interactive element returns a stable @eN reference for use in click, fill_form, hover, press_key, and select_option.",
         input_schema: json!({
             "type": "object",
             "properties": {
@@ -323,7 +323,7 @@ fn page_map_tool() -> ToolSpec {
             },
             "additionalProperties": false
         }),
-        instructions: Some("Returns the full page anatomy: heading hierarchy (h1-h6 with section sizes), landmark regions, forms (with field details), links (text + href, capped at 50), interactive elements (buttons/inputs/selects with their text, selector, and state like disabled/aria-pressed/aria-expanded), and page metadata. Use scope to inspect only a modal/dialog/overlay without noise from the background page. Use links[].href with navigate instead of clicking when the URL is visible. Each interactive element includes a `ref` field (@e1, @e2, ...) — use these stable handles in click, fill_form, hover, press_key, and select_option instead of copying full CSS selectors."),
+        instructions: Some("Returns the full page anatomy: heading hierarchy (h1-h6 with section sizes), landmark regions, forms (with field details), links (text + href, capped at 50), interactive elements (buttons/inputs/selects with their text, selector, and state like disabled/aria-pressed/aria-expanded), a regions hierarchy (sidebar/main/dialog with @rN handles), the active_dialog, non-form controls, and page metadata. Use scope to inspect only a modal/dialog/overlay without noise from the background page — scope accepts a raw CSS selector, a semantic token ('dialog', 'main', 'sidebar'), or a region handle (@r1). Use links[].href with navigate instead of clicking when the URL is visible. Each interactive element includes a `ref` field (@e1, @e2, ...) — use these stable handles in click, fill_form, hover, press_key, and select_option instead of copying full CSS selectors."),
     }
 }
 

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -181,17 +181,19 @@ fn extraction_tools() -> Vec<ToolSpec> {
 fn click_tool() -> ToolSpec {
     ToolSpec {
         name: "click",
-        description: "Click on a page element identified by CSS selector or @eN reference from page_map. May trigger navigation, form submission, or dynamic content changes. Returns post-action page_state showing the resulting URL, title, and structural diff. Prefer navigate with a direct URL from page_map.links when available — use click only for buttons, toggles, and elements without direct links.",
+        description: "Click on a page element identified by CSS selector, @eN reference, or visible label text. May trigger navigation, form submission, or dynamic content changes. Returns post-action page_state. Use 'selector' for CSS/ref-based targeting; use 'text' (with optional 'role' and 'region') to activate a button, tab, checkbox, or link by its visible label — useful for SPA admin UIs and modals where CSS paths are fragile.",
         input_schema: json!({
             "type": "object",
             "properties": {
-                "selector": { "type": "string", "description": "CSS selector or @eN element reference from page_map (e.g. \"@e3\", \"button.submit\", \"#login-btn\"). Use @eN refs for stability." },
+                "selector": { "type": "string", "description": "CSS selector or @eN element reference from page_map (e.g. \"@e3\", \"button.submit\", \"#login-btn\"). Mutually exclusive with 'text'." },
+                "text": { "type": "string", "description": "Activate by visible label text instead of a selector. Finds the interactive element whose accessible name best matches this text. Mutually exclusive with 'selector'." },
+                "role": { "type": "string", "description": "Optional ARIA role filter when using 'text' (e.g. 'button', 'tab', 'checkbox', 'menuitem'). Narrows the match." },
+                "region": { "type": "string", "description": "Optional region handle (@r1, @r2…) or semantic token ('dialog', 'main', 'sidebar') to constrain the text search to a specific UI area." },
                 "widen": { "type": "boolean", "description": "When true, return the full-page diff instead of scoping to the interacted container. Default: false." }
             },
-            "required": ["selector"],
             "additionalProperties": false
         }),
-        instructions: Some("May trigger navigation or page changes. The response includes post-action page state (URL, title, page structure) so you can see what changed. Use navigate with a direct URL from page_map.links instead of click when possible — it's more reliable. The selector field accepts CSS selectors or @eN element refs from page_map output (e.g., \"@e3\")."),
+        instructions: Some("Two usage modes: (1) selector/ref mode: provide 'selector' with a CSS selector or @eN ref — reliable for elements with stable identifiers. (2) text mode: provide 'text' to find and click an element by its visible label (button text, aria-label, link text). Optionally add 'role' to narrow by ARIA role and 'region' to restrict search to a UI region. 'selector' and 'text' are mutually exclusive — provide exactly one."),
     }
 }
 

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -12,6 +12,7 @@ pub mod registry;
 pub mod script_executor;
 pub mod script_manager;
 pub mod self_healing;
+pub mod semantic;
 mod shared_client;
 pub mod state;
 pub mod tools;

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -185,7 +185,8 @@ fn click_tool() -> ToolSpec {
         input_schema: json!({
             "type": "object",
             "properties": {
-                "selector": { "type": "string", "description": "CSS selector or @eN element reference from page_map (e.g. \"@e3\", \"button.submit\", \"#login-btn\"). Use @eN refs for stability." }
+                "selector": { "type": "string", "description": "CSS selector or @eN element reference from page_map (e.g. \"@e3\", \"button.submit\", \"#login-btn\"). Use @eN refs for stability." },
+                "widen": { "type": "boolean", "description": "When true, return the full-page diff instead of scoping to the interacted container. Default: false." }
             },
             "required": ["selector"],
             "additionalProperties": false
@@ -202,7 +203,8 @@ fn click_at_tool() -> ToolSpec {
             "type": "object",
             "properties": {
                 "x": { "type": "number", "description": "X coordinate in viewport pixels (0 = left edge). Obtain via execute_js with getBoundingClientRect() on the target element." },
-                "y": { "type": "number", "description": "Y coordinate in viewport pixels (0 = top edge). Obtain via execute_js with getBoundingClientRect() on the target element." }
+                "y": { "type": "number", "description": "Y coordinate in viewport pixels (0 = top edge). Obtain via execute_js with getBoundingClientRect() on the target element." },
+                "widen": { "type": "boolean", "description": "When true, return the full-page diff instead of scoping to the interacted container. Default: false." }
             },
             "required": ["x", "y"],
             "additionalProperties": false
@@ -224,7 +226,8 @@ fn fill_form_tool() -> ToolSpec {
                     "description": "Map of field identifiers to values. Keys can be CSS selectors (\"input[name='email']\"), field name/ID attributes (\"email\"), or @eN refs from page_map (\"@e5\"). Values are the text to type into each field."
                 },
                 "submit": { "type": "boolean", "description": "If true, submit the form after filling all fields (triggers form submission event). Default: false." },
-                "form_selector": { "type": "string", "description": "CSS selector or @eN ref targeting a specific <form> element. Required when the page has multiple forms to disambiguate which form to fill." }
+                "form_selector": { "type": "string", "description": "CSS selector or @eN ref targeting a specific <form> element. Required when the page has multiple forms to disambiguate which form to fill." },
+                "widen": { "type": "boolean", "description": "When true, return the full-page diff instead of scoping to the interacted container. Default: false." }
             },
             "required": ["fields"],
             "additionalProperties": false
@@ -243,7 +246,8 @@ fn select_option_tool() -> ToolSpec {
                 "selector": { "type": "string", "description": "CSS selector or @eN ref targeting the native select or custom dropdown trigger (e.g. \"@e4\", \"select#country\", \"button[role='combobox']\")." },
                 "value": { "type": "string", "description": "The value attribute of the option to select (e.g. \"us\", \"medium\"). For custom dropdowns without exposed values, this is matched against visible option text." },
                 "label": { "type": "string", "description": "The visible text of the option to select (e.g. \"United States\", \"Medium\"). Use when you know the display text." },
-                "index": { "type": "integer", "description": "Zero-based index of the <option> to select (0 = first option). Use when value/label are unknown." }
+                "index": { "type": "integer", "description": "Zero-based index of the <option> to select (0 = first option). Use when value/label are unknown." },
+                "widen": { "type": "boolean", "description": "When true, return the full-page diff instead of scoping to the interacted container. Default: false." }
             },
             "required": ["selector"],
             "additionalProperties": false
@@ -259,7 +263,8 @@ fn hover_tool() -> ToolSpec {
         input_schema: json!({
             "type": "object",
             "properties": {
-                "selector": { "type": "string", "description": "CSS selector or @eN element reference from page_map targeting the element to hover over (e.g. \"@e2\", \".menu-trigger\", \"nav li\")." }
+                "selector": { "type": "string", "description": "CSS selector or @eN element reference from page_map targeting the element to hover over (e.g. \"@e2\", \".menu-trigger\", \"nav li\")." },
+                "widen": { "type": "boolean", "description": "When true, return the full-page diff instead of scoping to the interacted container. Default: false." }
             },
             "required": ["selector"],
             "additionalProperties": false
@@ -276,7 +281,8 @@ fn press_key_tool() -> ToolSpec {
             "type": "object",
             "properties": {
                 "key": { "type": "string", "description": "Key to press — use Playwright key names: \"Enter\", \"Escape\", \"Tab\", \"ArrowDown\", \"ArrowUp\", \"Backspace\", \"Space\", or single characters like \"a\". Modifier combos: \"Control+a\", \"Shift+Tab\"." },
-                "selector": { "type": "string", "description": "Optional CSS selector or @eN ref to focus before pressing the key. If omitted, the key is dispatched to the currently focused element or the page." }
+                "selector": { "type": "string", "description": "Optional CSS selector or @eN ref to focus before pressing the key. If omitted, the key is dispatched to the currently focused element or the page." },
+                "widen": { "type": "boolean", "description": "When true, return the full-page diff instead of scoping to the interacted container. Default: false." }
             },
             "required": ["key"],
             "additionalProperties": false

--- a/crates/agent/src/semantic/mod.rs
+++ b/crates/agent/src/semantic/mod.rs
@@ -1,0 +1,725 @@
+use std::collections::HashSet;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawElementFacts {
+    pub tag: String,
+    pub role: Option<String>,
+    pub aria_expanded: Option<String>,
+    pub aria_selected: Option<String>,
+    pub aria_pressed: Option<String>,
+    pub aria_controls: Option<String>,
+    pub aria_owns: Option<String>,
+    pub text: Option<String>,
+    pub aria_label: Option<String>,
+    pub aria_labelledby_text: Option<String>,
+    pub title: Option<String>,
+    pub placeholder: Option<String>,
+    pub name: Option<String>,
+    pub visible: bool,
+    pub floating: bool,
+    pub selector: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegionKind {
+    Sidebar,
+    Main,
+    Dialog,
+    Banner,
+    Nav,
+    Complementary,
+    Form,
+    Region,
+    Other,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegionCandidate {
+    pub tag: String,
+    pub role: Option<String>,
+    pub aria_label: Option<String>,
+    pub id: Option<String>,
+    pub depth: usize,
+    pub parent_idx: Option<usize>,
+    pub selector: String,
+    pub visible: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegionNode {
+    pub kind: RegionKind,
+    pub label: String,
+    pub handle: String,
+    pub selector: String,
+    pub visible: bool,
+    pub children: Vec<RegionNode>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OptionCandidate {
+    pub name: String,
+    pub selector: String,
+    pub role: Option<String>,
+    pub aria_selected: Option<String>,
+    pub disabled: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ControlInfo {
+    pub label: String,
+    pub role: String,
+    pub selector: String,
+    pub region_handle: Option<String>,
+    pub value: Option<String>,
+    pub required: bool,
+    pub disabled: bool,
+}
+
+#[must_use]
+pub fn compute_accessible_name(facts: &RawElementFacts) -> String {
+    trimmed_name(facts.aria_label.as_deref())
+        .or_else(|| trimmed_name(facts.aria_labelledby_text.as_deref()))
+        .or_else(|| trimmed_name(facts.text.as_deref()))
+        .or_else(|| raw_name(facts.placeholder.as_deref()))
+        .or_else(|| raw_name(facts.title.as_deref()))
+        .or_else(|| raw_name(facts.name.as_deref()))
+        .unwrap_or_default()
+}
+
+#[must_use]
+pub fn region_kind(tag: &str, role: Option<&str>) -> RegionKind {
+    if has_role(role, &["dialog", "alertdialog"]) {
+        RegionKind::Dialog
+    } else if has_role(role, &["navigation"]) || tag.eq_ignore_ascii_case("nav") {
+        RegionKind::Nav
+    } else if has_role(role, &["main"]) || tag.eq_ignore_ascii_case("main") {
+        RegionKind::Main
+    } else if has_role(role, &["complementary"]) || tag.eq_ignore_ascii_case("aside") {
+        RegionKind::Complementary
+    } else if has_role(role, &["banner"]) || tag.eq_ignore_ascii_case("header") {
+        RegionKind::Banner
+    } else if has_role(role, &["contentinfo"]) || tag.eq_ignore_ascii_case("footer") {
+        RegionKind::Complementary
+    } else if has_role(role, &["form"]) || tag.eq_ignore_ascii_case("form") {
+        RegionKind::Form
+    } else if has_role(role, &["region"]) || tag.eq_ignore_ascii_case("section") {
+        RegionKind::Region
+    } else {
+        RegionKind::Other
+    }
+}
+
+#[must_use]
+pub fn region_label(kind: &RegionKind, aria_label: Option<&str>, idx: usize) -> String {
+    if let Some(label) = aria_label.map(str::trim).filter(|label| !label.is_empty()) {
+        return label.to_string();
+    }
+
+    match kind {
+        RegionKind::Dialog => "modal dialog".to_string(),
+        RegionKind::Sidebar => "sidebar".to_string(),
+        RegionKind::Main => "main panel".to_string(),
+        RegionKind::Nav => "navigation".to_string(),
+        RegionKind::Banner => "banner".to_string(),
+        RegionKind::Complementary => "aside".to_string(),
+        RegionKind::Form => "form".to_string(),
+        RegionKind::Region => format!("region {}", idx + 1),
+        RegionKind::Other => format!("section {}", idx + 1),
+    }
+}
+
+#[must_use]
+pub fn assemble_region_tree(candidates: &[RegionCandidate]) -> Vec<RegionNode> {
+    let handles = candidates
+        .iter()
+        .enumerate()
+        .map(|(idx, _)| format!("@r{}", idx + 1))
+        .collect::<Vec<_>>();
+    let included = candidates
+        .iter()
+        .map(|candidate| candidate.depth <= 3)
+        .collect::<Vec<_>>();
+    let mut roots = Vec::new();
+    let mut children_by_parent = vec![Vec::new(); candidates.len()];
+
+    for (idx, candidate) in candidates.iter().enumerate() {
+        if !included[idx] {
+            continue;
+        }
+
+        if let Some(parent_idx) = candidate
+            .parent_idx
+            .filter(|&parent_idx| parent_idx < candidates.len() && included[parent_idx])
+        {
+            children_by_parent[parent_idx].push(idx);
+        } else {
+            roots.push(idx);
+        }
+    }
+
+    roots
+        .into_iter()
+        .map(|idx| build_region_node(idx, candidates, &handles, &children_by_parent))
+        .collect()
+}
+
+#[must_use]
+pub fn match_text(
+    query: &str,
+    candidates: &[(String, String)],
+    _role_filter: Option<&str>,
+) -> Option<(String, Vec<String>)> {
+    let trimmed_query = query.trim();
+    if trimmed_query.is_empty() {
+        return None;
+    }
+
+    match_same_tier(candidates, |name| name == query)
+        .or_else(|| match_same_tier(candidates, |name| name.eq_ignore_ascii_case(query)))
+        .or_else(|| match_same_tier(candidates, |name| name.trim() == trimmed_query))
+        .or_else(|| {
+            let lower_query = trimmed_query.to_lowercase();
+            match_same_tier(candidates, |name| {
+                name.to_lowercase().contains(&lower_query)
+            })
+        })
+        .or_else(|| match_token_overlap(trimmed_query, candidates))
+}
+
+#[must_use]
+pub fn select_active_dialog(regions: &[RegionNode]) -> Option<&RegionNode> {
+    let mut active_dialog = None;
+    collect_last_visible_dialog(regions, &mut active_dialog);
+    active_dialog
+}
+
+fn build_region_node(
+    idx: usize,
+    candidates: &[RegionCandidate],
+    handles: &[String],
+    children_by_parent: &[Vec<usize>],
+) -> RegionNode {
+    let candidate = &candidates[idx];
+    let kind = region_kind(&candidate.tag, candidate.role.as_deref());
+    let label = region_label(&kind, candidate.aria_label.as_deref(), idx);
+    let children = children_by_parent[idx]
+        .iter()
+        .copied()
+        .map(|child_idx| build_region_node(child_idx, candidates, handles, children_by_parent))
+        .collect();
+
+    RegionNode {
+        kind,
+        label,
+        handle: handles[idx].clone(),
+        selector: candidate.selector.clone(),
+        visible: candidate.visible,
+        children,
+    }
+}
+
+fn collect_last_visible_dialog<'a>(
+    regions: &'a [RegionNode],
+    active_dialog: &mut Option<&'a RegionNode>,
+) {
+    for region in regions {
+        if region.kind == RegionKind::Dialog && region.visible {
+            *active_dialog = Some(region);
+        }
+        collect_last_visible_dialog(&region.children, active_dialog);
+    }
+}
+
+fn has_role(role: Option<&str>, expected: &[&str]) -> bool {
+    role.is_some_and(|role| {
+        expected
+            .iter()
+            .any(|value| role.eq_ignore_ascii_case(value))
+    })
+}
+
+fn match_same_tier<F>(
+    candidates: &[(String, String)],
+    predicate: F,
+) -> Option<(String, Vec<String>)>
+where
+    F: Fn(&str) -> bool,
+{
+    let matches = candidates
+        .iter()
+        .filter(|(name, _)| predicate(name))
+        .map(|(_, selector)| selector.clone())
+        .collect::<Vec<_>>();
+    split_best_and_alternatives(matches)
+}
+
+fn match_token_overlap(
+    query: &str,
+    candidates: &[(String, String)],
+) -> Option<(String, Vec<String>)> {
+    let query_tokens = query
+        .split_whitespace()
+        .map(str::to_lowercase)
+        .collect::<HashSet<_>>();
+    let mut best_overlap = 0;
+    let mut matches = Vec::new();
+
+    for (name, selector) in candidates {
+        let overlap = name
+            .split_whitespace()
+            .map(str::to_lowercase)
+            .filter(|token| query_tokens.contains(token))
+            .collect::<HashSet<_>>()
+            .len();
+
+        if overlap == 0 {
+            continue;
+        }
+
+        if overlap > best_overlap {
+            best_overlap = overlap;
+            matches.clear();
+        }
+
+        if overlap == best_overlap {
+            matches.push(selector.clone());
+        }
+    }
+
+    split_best_and_alternatives(matches)
+}
+
+fn raw_name(value: Option<&str>) -> Option<String> {
+    value
+        .filter(|value| !value.is_empty())
+        .map(truncate_to_sixty_chars)
+}
+
+fn split_best_and_alternatives(mut matches: Vec<String>) -> Option<(String, Vec<String>)> {
+    if matches.is_empty() {
+        None
+    } else {
+        let best = matches.remove(0);
+        Some((best, matches))
+    }
+}
+
+fn trimmed_name(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(truncate_to_sixty_chars)
+}
+
+fn truncate_to_sixty_chars(value: &str) -> String {
+    value.chars().take(60).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn raw_facts() -> RawElementFacts {
+        RawElementFacts {
+            tag: "button".to_string(),
+            role: None,
+            aria_expanded: None,
+            aria_selected: None,
+            aria_pressed: None,
+            aria_controls: None,
+            aria_owns: None,
+            text: None,
+            aria_label: None,
+            aria_labelledby_text: None,
+            title: None,
+            placeholder: None,
+            name: None,
+            visible: true,
+            floating: false,
+            selector: "button.primary".to_string(),
+        }
+    }
+
+    fn region_candidate(
+        tag: &str,
+        role: Option<&str>,
+        aria_label: Option<&str>,
+        depth: usize,
+        parent_idx: Option<usize>,
+        selector: &str,
+        visible: bool,
+    ) -> RegionCandidate {
+        RegionCandidate {
+            tag: tag.to_string(),
+            role: role.map(str::to_string),
+            aria_label: aria_label.map(str::to_string),
+            id: None,
+            depth,
+            parent_idx,
+            selector: selector.to_string(),
+            visible,
+        }
+    }
+
+    fn region_node(
+        kind: RegionKind,
+        handle: &str,
+        selector: &str,
+        visible: bool,
+        children: Vec<RegionNode>,
+    ) -> RegionNode {
+        RegionNode {
+            kind,
+            label: handle.to_string(),
+            handle: handle.to_string(),
+            selector: selector.to_string(),
+            visible,
+            children,
+        }
+    }
+
+    #[test]
+    fn accessible_name_prefers_aria_label() {
+        let mut facts = raw_facts();
+        facts.aria_label = Some("Primary action".to_string());
+        facts.aria_labelledby_text = Some("Secondary action".to_string());
+        facts.text = Some("Click me".to_string());
+
+        assert_eq!(compute_accessible_name(&facts), "Primary action");
+    }
+
+    #[test]
+    fn accessible_name_uses_labelledby_when_label_missing() {
+        let mut facts = raw_facts();
+        facts.aria_labelledby_text = Some("  External label  ".to_string());
+
+        assert_eq!(compute_accessible_name(&facts), "External label");
+    }
+
+    #[test]
+    fn accessible_name_uses_text_when_aria_names_missing() {
+        let mut facts = raw_facts();
+        facts.text = Some("  Visible text  ".to_string());
+
+        assert_eq!(compute_accessible_name(&facts), "Visible text");
+    }
+
+    #[test]
+    fn accessible_name_uses_placeholder_when_text_missing() {
+        let mut facts = raw_facts();
+        facts.placeholder = Some("Search docs".to_string());
+
+        assert_eq!(compute_accessible_name(&facts), "Search docs");
+    }
+
+    #[test]
+    fn accessible_name_uses_title_when_placeholder_missing() {
+        let mut facts = raw_facts();
+        facts.title = Some("Tooltip name".to_string());
+
+        assert_eq!(compute_accessible_name(&facts), "Tooltip name");
+    }
+
+    #[test]
+    fn accessible_name_uses_name_attr_last() {
+        let mut facts = raw_facts();
+        facts.name = Some("email".to_string());
+
+        assert_eq!(compute_accessible_name(&facts), "email");
+    }
+
+    #[test]
+    fn accessible_name_returns_empty_when_all_inputs_missing() {
+        assert_eq!(compute_accessible_name(&raw_facts()), "");
+    }
+
+    #[test]
+    fn accessible_name_truncates_to_sixty_chars() {
+        let mut facts = raw_facts();
+        facts.aria_label = Some("x".repeat(75));
+
+        assert_eq!(compute_accessible_name(&facts), "x".repeat(60));
+    }
+
+    #[test]
+    fn region_kind_maps_dialog_roles() {
+        assert_eq!(region_kind("div", Some("dialog")), RegionKind::Dialog);
+        assert_eq!(region_kind("div", Some("alertdialog")), RegionKind::Dialog);
+    }
+
+    #[test]
+    fn region_kind_maps_navigation() {
+        assert_eq!(region_kind("nav", None), RegionKind::Nav);
+        assert_eq!(region_kind("div", Some("navigation")), RegionKind::Nav);
+    }
+
+    #[test]
+    fn region_kind_maps_main() {
+        assert_eq!(region_kind("main", None), RegionKind::Main);
+        assert_eq!(region_kind("div", Some("main")), RegionKind::Main);
+    }
+
+    #[test]
+    fn region_kind_maps_complementary_variants() {
+        assert_eq!(region_kind("aside", None), RegionKind::Complementary);
+        assert_eq!(
+            region_kind("div", Some("complementary")),
+            RegionKind::Complementary
+        );
+        assert_eq!(region_kind("footer", None), RegionKind::Complementary);
+        assert_eq!(
+            region_kind("div", Some("contentinfo")),
+            RegionKind::Complementary
+        );
+    }
+
+    #[test]
+    fn region_kind_maps_banner() {
+        assert_eq!(region_kind("header", None), RegionKind::Banner);
+        assert_eq!(region_kind("div", Some("banner")), RegionKind::Banner);
+    }
+
+    #[test]
+    fn region_kind_maps_form() {
+        assert_eq!(region_kind("form", None), RegionKind::Form);
+        assert_eq!(region_kind("div", Some("form")), RegionKind::Form);
+    }
+
+    #[test]
+    fn region_kind_maps_region_and_other() {
+        assert_eq!(region_kind("section", None), RegionKind::Region);
+        assert_eq!(region_kind("div", Some("region")), RegionKind::Region);
+        assert_eq!(region_kind("article", None), RegionKind::Other);
+    }
+
+    #[test]
+    fn region_label_prefers_aria_label() {
+        assert_eq!(
+            region_label(&RegionKind::Dialog, Some("Admin modal"), 0),
+            "Admin modal"
+        );
+    }
+
+    #[test]
+    fn region_label_uses_kind_defaults() {
+        assert_eq!(region_label(&RegionKind::Dialog, None, 0), "modal dialog");
+        assert_eq!(region_label(&RegionKind::Sidebar, None, 0), "sidebar");
+        assert_eq!(region_label(&RegionKind::Main, None, 0), "main panel");
+        assert_eq!(region_label(&RegionKind::Nav, None, 0), "navigation");
+        assert_eq!(region_label(&RegionKind::Banner, None, 0), "banner");
+        assert_eq!(region_label(&RegionKind::Complementary, None, 0), "aside");
+        assert_eq!(region_label(&RegionKind::Form, None, 0), "form");
+        assert_eq!(region_label(&RegionKind::Region, None, 1), "region 2");
+        assert_eq!(region_label(&RegionKind::Other, None, 2), "section 3");
+    }
+
+    #[test]
+    fn assemble_region_tree_builds_flat_roots() {
+        let candidates = vec![
+            region_candidate("main", None, None, 0, None, "main", true),
+            region_candidate("nav", None, None, 0, None, "nav", true),
+        ];
+
+        let regions = assemble_region_tree(&candidates);
+
+        assert_eq!(regions.len(), 2);
+        assert_eq!(regions[0].handle, "@r1");
+        assert_eq!(regions[1].handle, "@r2");
+        assert!(regions.iter().all(|region| region.children.is_empty()));
+    }
+
+    #[test]
+    fn assemble_region_tree_builds_nested_children() {
+        let candidates = vec![
+            region_candidate("main", None, Some("Workspace"), 0, None, "main", true),
+            region_candidate("aside", None, Some("Filters"), 1, Some(0), "aside", true),
+            region_candidate(
+                "section",
+                None,
+                Some("Subpanel"),
+                2,
+                Some(1),
+                "section",
+                true,
+            ),
+        ];
+
+        let regions = assemble_region_tree(&candidates);
+
+        assert_eq!(regions.len(), 1);
+        assert_eq!(regions[0].handle, "@r1");
+        assert_eq!(regions[0].children[0].handle, "@r2");
+        assert_eq!(regions[0].children[0].children[0].handle, "@r3");
+    }
+
+    #[test]
+    fn assemble_region_tree_caps_depth_at_three() {
+        let candidates = vec![
+            region_candidate("main", None, None, 0, None, "main", true),
+            region_candidate("section", None, None, 1, Some(0), "section.one", true),
+            region_candidate("section", None, None, 2, Some(1), "section.two", true),
+            region_candidate("section", None, None, 3, Some(2), "section.three", true),
+            region_candidate("section", None, None, 4, Some(3), "section.four", true),
+        ];
+
+        let regions = assemble_region_tree(&candidates);
+        let third_level = &regions[0].children[0].children[0].children[0];
+
+        assert_eq!(third_level.handle, "@r4");
+        assert!(third_level.children.is_empty());
+    }
+
+    #[test]
+    fn assemble_region_tree_preserves_document_order_handles() {
+        let candidates = vec![
+            region_candidate("main", None, None, 0, None, "main", true),
+            region_candidate("dialog", Some("dialog"), None, 0, None, "dialog", true),
+            region_candidate("section", None, None, 1, Some(0), "section", true),
+        ];
+
+        let regions = assemble_region_tree(&candidates);
+
+        assert_eq!(regions[0].handle, "@r1");
+        assert_eq!(regions[1].handle, "@r2");
+        assert_eq!(regions[0].children[0].handle, "@r3");
+    }
+
+    #[test]
+    fn match_text_prefers_exact_match() {
+        let candidates = vec![
+            ("Save draft".to_string(), "#save-draft".to_string()),
+            ("Save".to_string(), "#save".to_string()),
+        ];
+
+        assert_eq!(
+            match_text("Save", &candidates, None),
+            Some(("#save".to_string(), Vec::new()))
+        );
+    }
+
+    #[test]
+    fn match_text_falls_back_to_case_insensitive_match() {
+        let candidates = vec![("Save".to_string(), "#save".to_string())];
+
+        assert_eq!(
+            match_text("save", &candidates, None),
+            Some(("#save".to_string(), Vec::new()))
+        );
+    }
+
+    #[test]
+    fn match_text_falls_back_to_trimmed_match() {
+        let candidates = vec![("Save".to_string(), "#save".to_string())];
+
+        assert_eq!(
+            match_text("  Save  ", &candidates, None),
+            Some(("#save".to_string(), Vec::new()))
+        );
+    }
+
+    #[test]
+    fn match_text_falls_back_to_contains_match() {
+        let candidates = vec![("Save changes".to_string(), "#save".to_string())];
+
+        assert_eq!(
+            match_text("save", &candidates, None),
+            Some(("#save".to_string(), Vec::new()))
+        );
+    }
+
+    #[test]
+    fn match_text_uses_token_overlap_when_needed() {
+        let candidates = vec![
+            ("Export report csv".to_string(), "#csv".to_string()),
+            ("Export report pdf".to_string(), "#pdf".to_string()),
+        ];
+
+        assert_eq!(
+            match_text("report export", &candidates, None),
+            Some(("#csv".to_string(), vec!["#pdf".to_string()]))
+        );
+    }
+
+    #[test]
+    fn match_text_returns_none_when_no_match_exists() {
+        let candidates = vec![("Delete".to_string(), "#delete".to_string())];
+
+        assert_eq!(match_text("Archive", &candidates, None), None);
+    }
+
+    #[test]
+    fn match_text_returns_alternatives_for_same_tier_ties() {
+        let candidates = vec![
+            ("Save changes".to_string(), "#save-primary".to_string()),
+            (
+                "Save current state".to_string(),
+                "#save-secondary".to_string(),
+            ),
+        ];
+
+        assert_eq!(
+            match_text("save", &candidates, None),
+            Some((
+                "#save-primary".to_string(),
+                vec!["#save-secondary".to_string()]
+            ))
+        );
+    }
+
+    #[test]
+    fn select_active_dialog_returns_none_for_empty_regions() {
+        assert_eq!(select_active_dialog(&[]), None);
+    }
+
+    #[test]
+    fn select_active_dialog_returns_single_dialog() {
+        let regions = vec![region_node(
+            RegionKind::Dialog,
+            "@r1",
+            "dialog.one",
+            true,
+            Vec::new(),
+        )];
+
+        assert_eq!(
+            select_active_dialog(&regions).map(|region| region.handle.as_str()),
+            Some("@r1")
+        );
+    }
+
+    #[test]
+    fn select_active_dialog_returns_last_visible_dialog_in_document_order() {
+        let regions = vec![
+            region_node(RegionKind::Dialog, "@r1", "dialog.one", true, Vec::new()),
+            region_node(
+                RegionKind::Main,
+                "@r2",
+                "main",
+                true,
+                vec![region_node(
+                    RegionKind::Dialog,
+                    "@r3",
+                    "dialog.two",
+                    true,
+                    Vec::new(),
+                )],
+            ),
+            region_node(RegionKind::Dialog, "@r4", "dialog.three", false, Vec::new()),
+        ];
+
+        assert_eq!(
+            select_active_dialog(&regions).map(|region| region.handle.as_str()),
+            Some("@r3")
+        );
+    }
+
+    #[test]
+    fn select_active_dialog_returns_none_when_no_dialogs_are_visible() {
+        let regions = vec![
+            region_node(RegionKind::Main, "@r1", "main", true, Vec::new()),
+            region_node(RegionKind::Dialog, "@r2", "dialog", false, Vec::new()),
+        ];
+
+        assert_eq!(select_active_dialog(&regions), None);
+    }
+}

--- a/crates/agent/src/semantic/mod.rs
+++ b/crates/agent/src/semantic/mod.rs
@@ -1,6 +1,8 @@
 use std::collections::HashSet;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RawElementFacts {
     pub tag: String,
     pub role: Option<String>,
@@ -20,7 +22,7 @@ pub struct RawElementFacts {
     pub selector: String,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RegionKind {
     Sidebar,
     Main,
@@ -33,7 +35,7 @@ pub enum RegionKind {
     Other,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RegionCandidate {
     pub tag: String,
     pub role: Option<String>,
@@ -45,7 +47,7 @@ pub struct RegionCandidate {
     pub visible: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RegionNode {
     pub kind: RegionKind,
     pub label: String,
@@ -402,6 +404,42 @@ mod tests {
         facts.text = Some("  Visible text  ".to_string());
 
         assert_eq!(compute_accessible_name(&facts), "Visible text");
+    }
+
+    #[test]
+    fn raw_element_facts_deserializes_from_dom_snapshot_json() {
+        let json = serde_json::json!({
+            "elements": [{
+                "tag": "button",
+                "role": "combobox",
+                "aria_expanded": "false",
+                "aria_selected": null,
+                "aria_pressed": null,
+                "aria_controls": "menu-1",
+                "aria_owns": null,
+                "text": "Choose",
+                "aria_label": null,
+                "aria_labelledby_text": null,
+                "title": null,
+                "placeholder": null,
+                "name": null,
+                "visible": true,
+                "floating": false,
+                "selector": "button.cmb"
+            }]
+        });
+
+        let elements = json["elements"].as_array().unwrap();
+        let el = &elements[0];
+        assert_eq!(el["tag"].as_str().unwrap(), "button");
+        assert_eq!(el["role"].as_str().unwrap(), "combobox");
+        assert!(el["visible"].as_bool().unwrap());
+
+        let facts: Vec<RawElementFacts> = serde_json::from_value(json["elements"].clone()).unwrap();
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].tag, "button");
+        assert_eq!(facts[0].role.as_deref(), Some("combobox"));
+        assert!(facts[0].visible);
     }
 
     #[test]

--- a/crates/agent/src/tools/click.rs
+++ b/crates/agent/src/tools/click.rs
@@ -80,6 +80,20 @@ async fn resolve_by_text(
 
     let script = format!(
         r#"(() => {{
+        function selectorOf(el) {{
+            if (el.id) return '#' + CSS.escape(el.id);
+            const path = [];
+            let cur = el;
+            while (cur && cur.parentElement) {{
+                if (cur.id) {{ path.unshift('#' + CSS.escape(cur.id)); break; }}
+                const parent = cur.parentElement;
+                const tag = cur.tagName.toLowerCase();
+                const same = Array.from(parent.children).filter(c => c.tagName === cur.tagName);
+                path.unshift(same.length > 1 ? tag + ':nth-of-type(' + (same.indexOf(cur) + 1) + ')' : tag);
+                cur = parent;
+            }}
+            return path.join(' > ');
+        }}
         const root = {scope_init};
         const sels = [
             'button','a[href]','[role="button"]','[role="tab"]',
@@ -98,8 +112,7 @@ async fn resolve_by_text(
             if (!name) name = el.title || el.placeholder || '';
             if (!name) continue;
             const role = el.getAttribute('role') || el.tagName.toLowerCase();
-            const sel = el.id ? '#' + CSS.escape(el.id) : null;
-            if (sel) candidates.push([name.slice(0, 80), sel, role]);
+            candidates.push([name.slice(0, 80), selectorOf(el), role]);
         }}
         return candidates;
     }})()"#

--- a/crates/agent/src/tools/click.rs
+++ b/crates/agent/src/tools/click.rs
@@ -6,7 +6,10 @@ use crate::{CrawlError, ToolEffect, ToolExecutionError};
 
 #[derive(Debug)]
 struct ClickInput {
-    selector: String,
+    selector: Option<String>,
+    text: Option<String>,
+    role: Option<String>,
+    region: Option<String>,
     widen: bool,
 }
 
@@ -14,16 +17,124 @@ fn parse_input(input: &Value) -> Result<ClickInput, CrawlError> {
     let selector = input
         .get("selector")
         .and_then(Value::as_str)
-        .ok_or_else(|| CrawlError::new("missing required field: selector"))?;
+        .map(str::to_string);
+    let text = input
+        .get("text")
+        .and_then(Value::as_str)
+        .map(str::to_string);
 
-    if selector.is_empty() {
-        return Err(CrawlError::new("selector must not be empty"));
+    match (&selector, &text) {
+        (None, None) => return Err(CrawlError::new("either 'selector' or 'text' is required")),
+        (Some(_), Some(_)) => {
+            return Err(CrawlError::new(
+                "'selector' and 'text' are mutually exclusive",
+            ))
+        }
+        _ => {}
+    }
+
+    if let Some(ref s) = selector {
+        if s.is_empty() {
+            return Err(CrawlError::new("selector must not be empty"));
+        }
     }
 
     Ok(ClickInput {
-        selector: selector.to_string(),
+        selector,
+        text,
+        role: input
+            .get("role")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        region: input
+            .get("region")
+            .and_then(Value::as_str)
+            .map(str::to_string),
         widen: input.get("widen").and_then(Value::as_bool).unwrap_or(false),
     })
+}
+
+async fn resolve_by_text(
+    browser: &mut BrowserContext,
+    query: &str,
+    role_filter: Option<&str>,
+    region: Option<&str>,
+) -> Result<String, ToolExecutionError> {
+    let scope_sel: Option<String> = match region {
+        Some(r) if r.starts_with("@r") => {
+            browser.last_snapshot_region_selector(r).map(str::to_string)
+        }
+        Some("dialog") => {
+            Some("[role=\"dialog\"],[role=\"alertdialog\"],[aria-modal=\"true\"]".to_string())
+        }
+        Some("main") => Some("main,[role=\"main\"]".to_string()),
+        Some("sidebar") => Some("[role=\"complementary\"],aside".to_string()),
+        Some(other) => Some(other.to_string()),
+        None => None,
+    };
+
+    let scope_init = match &scope_sel {
+        Some(s) => format!("document.querySelector({s:?}) || document"),
+        None => "document".to_string(),
+    };
+
+    let script = format!(
+        r#"(() => {{
+        const root = {scope_init};
+        const sels = [
+            'button','a[href]','[role="button"]','[role="tab"]',
+            '[role="menuitem"]','[role="checkbox"]','[role="switch"]',
+            '[role="link"]','input[type="button"]','input[type="submit"]',
+            'input[type="checkbox"]','input[type="radio"]'
+        ];
+        const candidates = [];
+        for (const el of root.querySelectorAll(sels.join(','))) {{
+            let name = el.getAttribute('aria-label') || '';
+            if (!name) {{
+                const lby = el.getAttribute('aria-labelledby');
+                if (lby) name = document.getElementById(lby)?.innerText?.trim() || '';
+            }}
+            if (!name) name = (el.innerText || '').trim();
+            if (!name) name = el.title || el.placeholder || '';
+            if (!name) continue;
+            const role = el.getAttribute('role') || el.tagName.toLowerCase();
+            const sel = el.id ? '#' + CSS.escape(el.id) : null;
+            if (sel) candidates.push([name.slice(0, 80), sel, role]);
+        }}
+        return candidates;
+    }})()"#
+    );
+
+    let raw = browser
+        .acquire_bridge()
+        .await
+        .map_err(|e| ToolExecutionError::new(e.to_string()))?
+        .evaluate(&script)
+        .await
+        .map_err(|e| ToolExecutionError::new(e.to_string()))?;
+
+    let triples: Vec<[String; 3]> = raw
+        .get("value")
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .unwrap_or_default();
+
+    let pairs: Vec<(String, String)> = triples
+        .iter()
+        .filter(|[_, _, role]| {
+            role_filter.is_none_or(|rf| role.to_lowercase().contains(&rf.to_lowercase()))
+        })
+        .map(|[name, sel, _]| (name.clone(), sel.clone()))
+        .collect();
+
+    match crate::semantic::match_text(query, &pairs, None) {
+        Some((best, _alternatives)) => Ok(best),
+        None => Err(ToolExecutionError::new(format!(
+            "no element found with text '{query}'{}",
+            role_filter
+                .map(|r| format!(" and role '{r}'"))
+                .unwrap_or_default()
+        ))),
+    }
 }
 
 pub async fn execute(
@@ -32,8 +143,20 @@ pub async fn execute(
     crawl_state: &CrawlState,
 ) -> Result<ToolEffect, ToolExecutionError> {
     let params = parse_input(input)?;
-    let selector = super::ref_resolve::resolve_selector(&params.selector, browser.ref_map())
-        .map_err(ToolExecutionError::new)?;
+
+    let selector = if let Some(ref sel) = params.selector {
+        super::ref_resolve::resolve_selector(sel, browser.ref_map())
+            .map_err(ToolExecutionError::new)?
+    } else {
+        let text = params.text.as_deref().unwrap_or_default();
+        resolve_by_text(
+            browser,
+            text,
+            params.role.as_deref(),
+            params.region.as_deref(),
+        )
+        .await?
+    };
 
     browser
         .acquire_bridge()
@@ -47,10 +170,15 @@ pub async fn execute(
     let page_state =
         super::feedback::post_action_page_state(browser, Some(&selector), params.widen).await;
 
+    let display_target = params.text.as_deref().map_or_else(
+        || params.selector.clone().unwrap_or_default(),
+        |t| format!("text: {t}"),
+    );
+
     Ok(ToolEffect::reply_json(&serde_json::json!({
         "seq": seq,
         "success": true,
-        "message": format!("Clicked element: {}", params.selector),
+        "message": format!("Clicked element: {display_target}"),
         "page_state": page_state
     })))
 }
@@ -64,14 +192,46 @@ mod tests {
     fn parse_valid_selector() {
         let input = json!({"selector": ".btn-primary"});
         let result = parse_input(&input).unwrap();
-        assert_eq!(result.selector, ".btn-primary");
+        assert_eq!(result.selector, Some(".btn-primary".to_string()));
+        assert!(result.text.is_none());
+    }
+
+    #[test]
+    fn parse_valid_text() {
+        let input = json!({"text": "Submit"});
+        let result = parse_input(&input).unwrap();
+        assert_eq!(result.text, Some("Submit".to_string()));
+        assert!(result.selector.is_none());
+    }
+
+    #[test]
+    fn parse_text_with_role_and_region() {
+        let input = json!({"text": "Workers", "role": "tab", "region": "@r3"});
+        let result = parse_input(&input).unwrap();
+        assert_eq!(result.text, Some("Workers".to_string()));
+        assert_eq!(result.role, Some("tab".to_string()));
+        assert_eq!(result.region, Some("@r3".to_string()));
+    }
+
+    #[test]
+    fn parse_rejects_both_selector_and_text() {
+        let input = json!({"selector": "#btn", "text": "Submit"});
+        let err = parse_input(&input).unwrap_err();
+        assert!(err.to_string().contains("mutually exclusive"));
+    }
+
+    #[test]
+    fn parse_rejects_neither_selector_nor_text() {
+        let input = json!({});
+        let err = parse_input(&input).unwrap_err();
+        assert!(err.to_string().contains("required"));
     }
 
     #[test]
     fn parse_missing_selector_returns_error() {
         let input = json!({});
         let err = parse_input(&input).unwrap_err();
-        assert!(err.to_string().contains("selector"));
+        assert!(err.to_string().contains("required") || err.to_string().contains("selector"));
     }
 
     #[test]
@@ -91,7 +251,40 @@ mod tests {
     fn parse_complex_selector() {
         let input = json!({"selector": "div.container > ul > li:nth-child(2) a"});
         let result = parse_input(&input).unwrap();
-        assert_eq!(result.selector, "div.container > ul > li:nth-child(2) a");
+        assert_eq!(
+            result.selector,
+            Some("div.container > ul > li:nth-child(2) a".to_string())
+        );
+    }
+
+    #[test]
+    fn match_text_semantics_exact_wins() {
+        let candidates = vec![
+            ("Submit".to_string(), "#submit".to_string()),
+            ("Cancel".to_string(), "#cancel".to_string()),
+        ];
+        let (best, _) = crate::semantic::match_text("Submit", &candidates, None).unwrap();
+        assert_eq!(best, "#submit");
+    }
+
+    #[test]
+    fn match_text_semantics_case_insensitive() {
+        let candidates = vec![("Submit Form".to_string(), "#submit".to_string())];
+        let (best, _) = crate::semantic::match_text("submit form", &candidates, None).unwrap();
+        assert_eq!(best, "#submit");
+    }
+
+    #[test]
+    fn match_text_semantics_contains_fallback() {
+        let candidates = vec![("Email address".to_string(), "#email".to_string())];
+        let (best, _) = crate::semantic::match_text("email", &candidates, None).unwrap();
+        assert_eq!(best, "#email");
+    }
+
+    #[test]
+    fn match_text_semantics_no_match() {
+        let candidates = vec![("Email address".to_string(), "#email".to_string())];
+        assert!(crate::semantic::match_text("phone", &candidates, None).is_none());
     }
 
     #[test]
@@ -108,6 +301,5 @@ mod tests {
         });
         assert!(response["page_state"]["url"].is_string());
         assert!(response["page_state"]["title"].is_string());
-        assert!(!response["page_state"]["page_map"].is_null());
     }
 }

--- a/crates/agent/src/tools/click.rs
+++ b/crates/agent/src/tools/click.rs
@@ -61,9 +61,14 @@ async fn resolve_by_text(
     region: Option<&str>,
 ) -> Result<String, ToolExecutionError> {
     let scope_sel: Option<String> = match region {
-        Some(r) if r.starts_with("@r") => {
-            browser.last_snapshot_region_selector(r).map(str::to_string)
-        }
+        Some(r) if r.starts_with("@r") => match browser.last_snapshot_region_selector(r) {
+            Some(selector) => Some(selector.to_string()),
+            None => {
+                return Err(ToolExecutionError::new(format!(
+                    "unknown region handle '{r}'; call page_map first to get fresh handles"
+                )))
+            }
+        },
         Some("dialog") => {
             Some("[role=\"dialog\"],[role=\"alertdialog\"],[aria-modal=\"true\"]".to_string())
         }
@@ -74,63 +79,13 @@ async fn resolve_by_text(
     };
 
     let scope_init = match &scope_sel {
-        Some(s) => format!("document.querySelector({s:?}) || document"),
+        Some(s) => format!(
+            r"(() => {{ const __scope = document.querySelector({s:?}); if (!__scope) throw new Error('region scope element not found: {s}'); return __scope; }})()"
+        ),
         None => "document".to_string(),
     };
 
-    let script = format!(
-        r#"(() => {{
-        function selectorOf(el) {{
-            if (el.id) return '#' + CSS.escape(el.id);
-            const path = [];
-            let cur = el;
-            while (cur && cur.parentElement) {{
-                if (cur.id) {{ path.unshift('#' + CSS.escape(cur.id)); break; }}
-                const parent = cur.parentElement;
-                const tag = cur.tagName.toLowerCase();
-                const same = Array.from(parent.children).filter(c => c.tagName === cur.tagName);
-                path.unshift(same.length > 1 ? tag + ':nth-of-type(' + (same.indexOf(cur) + 1) + ')' : tag);
-                cur = parent;
-            }}
-            return path.join(' > ');
-        }}
-        const root = {scope_init};
-        const sels = [
-            'button','a[href]','[role="button"]','[role="tab"]',
-            '[role="menuitem"]','[role="checkbox"]','[role="switch"]',
-            '[role="link"]','input[type="button"]','input[type="submit"]',
-            'input[type="checkbox"]','input[type="radio"]'
-        ];
-        const candidates = [];
-        for (const el of root.querySelectorAll(sels.join(','))) {{
-            let name = el.getAttribute('aria-label') || '';
-            if (!name) {{
-                const lby = el.getAttribute('aria-labelledby');
-                if (lby) name = document.getElementById(lby)?.innerText?.trim() || '';
-            }}
-            if (!name && el.id) {{
-                const lbl = document.querySelector('label[for="' + CSS.escape(el.id) + '"]');
-                if (lbl) name = (lbl.innerText || '').trim();
-            }}
-            if (!name) {{
-                const wrapping = el.closest('label');
-                if (wrapping) name = (wrapping.innerText || '').replace((el.textContent || '').trim(), '').trim();
-            }}
-            if (!name) name = (el.innerText || '').trim();
-            if (!name) name = el.title || el.placeholder || '';
-            if (!name) continue;
-            const roleAttr = el.getAttribute('role');
-            const inputType = (el.type || '').toLowerCase();
-            const role = roleAttr ||
-                (el.tagName === 'INPUT' && inputType === 'checkbox' ? 'checkbox' :
-                 el.tagName === 'INPUT' && inputType === 'radio' ? 'radio' :
-                 el.tagName === 'INPUT' && ['button','submit','reset','image'].includes(inputType) ? 'button' :
-                 el.tagName === 'A' ? 'link' : el.tagName.toLowerCase());
-            candidates.push([name.slice(0, 80), selectorOf(el), role]);
-        }}
-        return candidates;
-    }})()"#
-    );
+    let script = build_resolve_by_text_script(&scope_init);
 
     let raw = browser
         .acquire_bridge()
@@ -162,6 +117,68 @@ async fn resolve_by_text(
                 .unwrap_or_default()
         ))),
     }
+}
+
+fn build_resolve_by_text_script(scope_init: &str) -> String {
+    format!(
+        r#"(() => {{
+        function selectorOf(el) {{
+            if (el.id) return '#' + CSS.escape(el.id);
+            const path = [];
+            let cur = el;
+            while (cur && cur.parentElement) {{
+                if (cur.id) {{ path.unshift('#' + CSS.escape(cur.id)); break; }}
+                const parent = cur.parentElement;
+                const tag = cur.tagName.toLowerCase();
+                const same = Array.from(parent.children).filter(c => c.tagName === cur.tagName);
+                path.unshift(same.length > 1 ? tag + ':nth-of-type(' + (same.indexOf(cur) + 1) + ')' : tag);
+                cur = parent;
+            }}
+            return path.join(' > ');
+        }}
+        const root = {scope_init};
+        const sels = [
+            'button','a[href]','[role="button"]','[role="tab"]',
+            '[role="menuitem"]','[role="checkbox"]','[role="switch"]',
+            '[role="link"]','input[type="button"]','input[type="submit"]',
+            'input[type="checkbox"]','input[type="radio"]'
+        ];
+        const candidates = [];
+        for (const el of root.querySelectorAll(sels.join(','))) {{
+            let name = el.getAttribute('aria-label') || '';
+            if (!name) {{
+                const lby = el.getAttribute('aria-labelledby');
+                if (lby) name = lby
+                    .split(/\s+/)
+                    .filter(Boolean)
+                    .map(id => document.getElementById(id)?.innerText?.trim() || '')
+                    .filter(Boolean)
+                    .join(' ')
+                    .trim();
+            }}
+            if (!name && el.id) {{
+                const lbl = document.querySelector('label[for="' + CSS.escape(el.id) + '"]');
+                if (lbl) name = (lbl.innerText || '').trim();
+            }}
+            if (!name) {{
+                const wrapping = el.closest('label');
+                if (wrapping) name = (wrapping.innerText || '').replace((el.textContent || '').trim(), '').trim();
+            }}
+            if (!name) name = (el.innerText || '').trim();
+            if (!name) name = el.title || el.placeholder || '';
+            if (!name) continue;
+            const roleAttr = el.getAttribute('role');
+            const inputType = (el.type || '').toLowerCase();
+            const role = roleAttr ||
+                (el.tagName === 'INPUT' && inputType === 'checkbox' ? 'checkbox' :
+                 el.tagName === 'INPUT' && inputType === 'radio' ? 'radio' :
+                 el.tagName === 'INPUT' && ['button','submit','reset','image'].includes(inputType) ? 'button' :
+                 el.tagName === 'A' ? 'link' : el.tagName.toLowerCase());
+            candidates.push([name.slice(0, 80), selectorOf(el), role]);
+        }}
+        return candidates;
+    }})()"#
+    )
 }
 
 pub async fn execute(

--- a/crates/agent/src/tools/click.rs
+++ b/crates/agent/src/tools/click.rs
@@ -108,6 +108,14 @@ async fn resolve_by_text(
                 const lby = el.getAttribute('aria-labelledby');
                 if (lby) name = document.getElementById(lby)?.innerText?.trim() || '';
             }}
+            if (!name && el.id) {{
+                const lbl = document.querySelector('label[for="' + CSS.escape(el.id) + '"]');
+                if (lbl) name = (lbl.innerText || '').trim();
+            }}
+            if (!name) {{
+                const wrapping = el.closest('label');
+                if (wrapping) name = (wrapping.innerText || '').replace((el.textContent || '').trim(), '').trim();
+            }}
             if (!name) name = (el.innerText || '').trim();
             if (!name) name = el.title || el.placeholder || '';
             if (!name) continue;

--- a/crates/agent/src/tools/click.rs
+++ b/crates/agent/src/tools/click.rs
@@ -7,6 +7,7 @@ use crate::{CrawlError, ToolEffect, ToolExecutionError};
 #[derive(Debug)]
 struct ClickInput {
     selector: String,
+    widen: bool,
 }
 
 fn parse_input(input: &Value) -> Result<ClickInput, CrawlError> {
@@ -21,6 +22,7 @@ fn parse_input(input: &Value) -> Result<ClickInput, CrawlError> {
 
     Ok(ClickInput {
         selector: selector.to_string(),
+        widen: input.get("widen").and_then(Value::as_bool).unwrap_or(false),
     })
 }
 
@@ -42,7 +44,8 @@ pub async fn execute(
         .map_err(|e| ToolExecutionError::new(e.to_string()))?;
 
     let seq = super::seq::increment_seq(crawl_state, browser).await;
-    let page_state = super::feedback::post_action_page_state(browser).await;
+    let page_state =
+        super::feedback::post_action_page_state(browser, Some(&selector), params.widen).await;
 
     Ok(ToolEffect::reply_json(&serde_json::json!({
         "seq": seq,

--- a/crates/agent/src/tools/click.rs
+++ b/crates/agent/src/tools/click.rs
@@ -119,7 +119,13 @@ async fn resolve_by_text(
             if (!name) name = (el.innerText || '').trim();
             if (!name) name = el.title || el.placeholder || '';
             if (!name) continue;
-            const role = el.getAttribute('role') || el.tagName.toLowerCase();
+            const roleAttr = el.getAttribute('role');
+            const inputType = (el.type || '').toLowerCase();
+            const role = roleAttr ||
+                (el.tagName === 'INPUT' && inputType === 'checkbox' ? 'checkbox' :
+                 el.tagName === 'INPUT' && inputType === 'radio' ? 'radio' :
+                 el.tagName === 'INPUT' && ['button','submit','reset','image'].includes(inputType) ? 'button' :
+                 el.tagName === 'A' ? 'link' : el.tagName.toLowerCase());
             candidates.push([name.slice(0, 80), selectorOf(el), role]);
         }}
         return candidates;

--- a/crates/agent/src/tools/click_at.rs
+++ b/crates/agent/src/tools/click_at.rs
@@ -8,6 +8,7 @@ use crate::{CrawlError, ToolEffect, ToolExecutionError};
 struct ClickAtInput {
     x: f64,
     y: f64,
+    widen: bool,
 }
 
 fn parse_input(input: &Value) -> Result<ClickAtInput, CrawlError> {
@@ -21,7 +22,11 @@ fn parse_input(input: &Value) -> Result<ClickAtInput, CrawlError> {
         .and_then(Value::as_f64)
         .ok_or_else(|| CrawlError::new("missing required field: y"))?;
 
-    Ok(ClickAtInput { x, y })
+    Ok(ClickAtInput {
+        x,
+        y,
+        widen: input.get("widen").and_then(Value::as_bool).unwrap_or(false),
+    })
 }
 
 pub async fn execute(
@@ -39,7 +44,7 @@ pub async fn execute(
         .map_err(|e| ToolExecutionError::new(e.to_string()))?;
 
     let seq = super::seq::increment_seq(crawl_state, browser).await;
-    let page_state = super::feedback::post_action_page_state(browser).await;
+    let page_state = super::feedback::post_action_page_state(browser, None, params.widen).await;
 
     Ok(ToolEffect::reply_json(&serde_json::json!({
         "seq": seq,

--- a/crates/agent/src/tools/feedback.rs
+++ b/crates/agent/src/tools/feedback.rs
@@ -435,7 +435,10 @@ async fn resolve_interacted_scope(
                     ['DIALOG', 'MAIN', 'ASIDE', 'NAV', 'FORM', 'SECTION', 'ARTICLE'].includes(cur.tagName)
                 ) {{
                     if (cur.id) return '#' + CSS.escape(cur.id);
-                    return cur.tagName.toLowerCase();
+                    if (role === 'dialog' || role === 'alertdialog') {{
+                        return '[role=' + role + ']';
+                    }}
+                    return null;
                 }}
                 cur = cur.parentElement;
             }}
@@ -455,6 +458,10 @@ fn page_state_from_feedback_map(
     scope: Option<&str>,
     mut pm: Value,
 ) -> Value {
+    // Enrich in place before caching so stored snapshots preserve regions and
+    // active_dialog for later scoped interactions.
+    super::page_map::enrich_semantic_sections(&mut pm);
+
     let full_url = extract_url(&pm).to_string();
     let cache_key = normalize_url(&full_url).to_string();
 

--- a/crates/agent/src/tools/feedback.rs
+++ b/crates/agent/src/tools/feedback.rs
@@ -18,6 +18,7 @@ const FEEDBACK_TIMEOUT: Duration = Duration::from_secs(3);
 /// `active_dialog`, and strips `forms`, `interactive`, and `controls` to keep
 /// interaction responses concise.
 pub fn build_page_state_from_map(mut pm: Value) -> Value {
+    super::page_map::enrich_semantic_sections(&mut pm);
     apply_page_map_caps(&mut pm);
 
     let url = pm

--- a/crates/agent/src/tools/feedback.rs
+++ b/crates/agent/src/tools/feedback.rs
@@ -383,12 +383,23 @@ fn fallback_value() -> Value {
     })
 }
 
+fn page_state_from_feedback_map(browser: &mut BrowserContext, mut pm: Value) -> Value {
+    let full_url = extract_url(&pm).to_string();
+    let cache_key = normalize_url(&full_url).to_string();
+
+    let response = match browser.page_snapshot_for_url(&cache_key, None) {
+        Some(prev) => build_diff_page_state(prev, &mut pm),
+        None => build_page_state_from_map(pm.clone()),
+    };
+
+    browser.set_page_snapshot(&cache_key, None, pm);
+    response
+}
+
 /// Best-effort post-action page state for interaction tool responses.
 ///
-/// Calls `page_map_feedback` on the bridge (which may return a pre-computed
-/// diff from the extension, or a full `page_map` from Playwright). If the
-/// response is already a diff, passes it through. Otherwise applies
-/// Rust-side differential comparison against the cached snapshot.
+/// Calls `page_map_feedback` on the bridge and applies Rust-side differential
+/// comparison against the cached snapshot.
 pub async fn post_action_page_state(browser: &mut BrowserContext) -> Value {
     let result = timeout(FEEDBACK_TIMEOUT, async {
         let mut bridge = browser.acquire_bridge().await?;
@@ -397,23 +408,7 @@ pub async fn post_action_page_state(browser: &mut BrowserContext) -> Value {
     .await;
 
     match result {
-        Ok(Ok(pm)) => {
-            if pm.get("changed").is_some() {
-                return pm;
-            }
-
-            let mut pm = pm;
-            let full_url = extract_url(&pm).to_string();
-            let cache_key = normalize_url(&full_url).to_string();
-
-            let response = match browser.page_snapshot_for_url(&cache_key) {
-                Some(prev) => build_diff_page_state(prev, &mut pm),
-                None => build_page_state_from_map(pm.clone()),
-            };
-
-            browser.set_page_snapshot(cache_key, pm);
-            response
-        }
+        Ok(Ok(pm)) => page_state_from_feedback_map(browser, pm),
         _ => fallback_value(),
     }
 }
@@ -431,9 +426,18 @@ pub fn record_page_fingerprint(url: &str, page_map: &Value, crawl_state: &mut Cr
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use tokio::sync::Mutex;
+
     use serde_json::json;
 
-    use super::{build_diff_page_state, build_page_state_from_map, fallback_value};
+    use super::{
+        build_diff_page_state, build_page_state_from_map, fallback_value,
+        page_state_from_feedback_map,
+    };
+    use crate::BrowserContext;
+    use browser::BrowserBackend;
 
     #[test]
     fn feedback_fallback_value_has_correct_shape() {
@@ -869,6 +873,54 @@ mod tests {
         let added = changes["added_interactive"].as_array().unwrap();
         assert_eq!(added.len(), 1);
         assert_eq!(added[0]["text"], "Delete");
+        assert_eq!(added[0]["selector"], "#del-btn");
+    }
+
+    #[test]
+    fn extension_style_raw_page_map_uses_same_diff_as_bridge_path() {
+        let prev = json!({
+            "headings": [],
+            "landmarks": [],
+            "links": [],
+            "forms": [],
+            "interactive": {
+                "counts": {"buttons": 1, "inputs": 0, "selects": 0, "textareas": 0, "total": 1},
+                "elements": [
+                    {"tag": "button", "text": "Add Element", "selector": "#add-btn", "type": "submit"}
+                ]
+            },
+            "meta": {"title": "Page", "url": "https://example.com/", "description": ""}
+        });
+        let mut current = json!({
+            "headings": [],
+            "landmarks": [],
+            "links": [],
+            "forms": [],
+            "interactive": {
+                "counts": {"buttons": 2, "inputs": 0, "selects": 0, "textareas": 0, "total": 2},
+                "elements": [
+                    {"tag": "button", "text": "Add Element", "selector": "#add-btn", "type": "submit"},
+                    {"tag": "button", "text": "Delete", "selector": "#del-btn", "type": "submit"}
+                ]
+            },
+            "meta": {"title": "Page", "url": "https://example.com/", "description": ""}
+        });
+
+        let bridge = Arc::new(Mutex::new(Box::new(
+            crate::tools::test_support::ObservationMockBackend::default(),
+        ) as Box<dyn BrowserBackend + Send>));
+        let mut browser = BrowserContext::new(bridge);
+        browser.set_page_snapshot("https://example.com/", None, prev.clone());
+
+        let extension_path = page_state_from_feedback_map(&mut browser, current.clone());
+        let bridge_path = build_diff_page_state(&prev, &mut current);
+
+        assert_eq!(extension_path, bridge_path);
+        assert_eq!(extension_path["changed"], true);
+        let added = extension_path["changes"]["added_interactive"]
+            .as_array()
+            .expect("added_interactive should be present");
+        assert_eq!(added.len(), 1);
         assert_eq!(added[0]["selector"], "#del-btn");
     }
 

--- a/crates/agent/src/tools/feedback.rs
+++ b/crates/agent/src/tools/feedback.rs
@@ -385,16 +385,84 @@ fn fallback_value() -> Value {
     })
 }
 
-fn page_state_from_feedback_map(browser: &mut BrowserContext, mut pm: Value) -> Value {
+fn evaluate_payload(value: &Value) -> &Value {
+    value.get("value").unwrap_or(value)
+}
+
+fn active_dialog_scope(snapshot: &Value) -> Option<String> {
+    let dialog = snapshot.get("active_dialog")?;
+    if dialog
+        .get("visible")
+        .and_then(Value::as_bool)
+        .is_some_and(|visible| !visible)
+    {
+        return None;
+    }
+
+    dialog
+        .get("selector")
+        .and_then(Value::as_str)
+        .filter(|selector| !selector.is_empty())
+        .map(str::to_string)
+}
+
+async fn resolve_interacted_scope(
+    dialog_scope: Option<String>,
+    interacted_selector: Option<&str>,
+    widen: bool,
+    bridge: &mut (dyn browser::BrowserBackend + Send),
+) -> Option<String> {
+    if widen {
+        return None;
+    }
+
+    if let Some(scope) = dialog_scope {
+        return Some(scope);
+    }
+
+    let selector = interacted_selector?;
+    let selector_json = serde_json::to_string(selector).ok()?;
+    let script = format!(
+        r"(() => {{
+            const el = document.querySelector({selector_json});
+            if (!el) return null;
+            let cur = el;
+            while (cur && cur !== document.body) {{
+                const role = cur.getAttribute('role');
+                if (
+                    ['dialog', 'alertdialog', 'region', 'main', 'complementary', 'navigation', 'form'].includes(role) ||
+                    ['DIALOG', 'MAIN', 'ASIDE', 'NAV', 'FORM', 'SECTION', 'ARTICLE'].includes(cur.tagName)
+                ) {{
+                    if (cur.id) return '#' + CSS.escape(cur.id);
+                    return cur.tagName.toLowerCase();
+                }}
+                cur = cur.parentElement;
+            }}
+            return null;
+        }})()"
+    );
+
+    bridge
+        .evaluate(&script)
+        .await
+        .ok()
+        .and_then(|value| evaluate_payload(&value).as_str().map(str::to_string))
+}
+
+fn page_state_from_feedback_map(
+    browser: &mut BrowserContext,
+    scope: Option<&str>,
+    mut pm: Value,
+) -> Value {
     let full_url = extract_url(&pm).to_string();
     let cache_key = normalize_url(&full_url).to_string();
 
-    let response = match browser.page_snapshot_for_url(&cache_key, None) {
+    let response = match browser.page_snapshot_for_url(&cache_key, scope) {
         Some(prev) => build_diff_page_state(prev, &mut pm),
         None => build_page_state_from_map(pm.clone()),
     };
 
-    browser.set_page_snapshot(&cache_key, None, pm);
+    browser.set_page_snapshot(&cache_key, scope, pm);
     response
 }
 
@@ -402,15 +470,28 @@ fn page_state_from_feedback_map(browser: &mut BrowserContext, mut pm: Value) -> 
 ///
 /// Calls `page_map_feedback` on the bridge and applies Rust-side differential
 /// comparison against the cached snapshot.
-pub async fn post_action_page_state(browser: &mut BrowserContext) -> Value {
+pub async fn post_action_page_state(
+    browser: &mut BrowserContext,
+    interacted_selector: Option<&str>,
+    widen: bool,
+) -> Value {
+    let dialog_scope = if widen {
+        None
+    } else {
+        browser.last_page_snapshot().and_then(active_dialog_scope)
+    };
+
     let result = timeout(FEEDBACK_TIMEOUT, async {
         let mut bridge = browser.acquire_bridge().await?;
-        bridge.page_map_feedback().await
+        let scope =
+            resolve_interacted_scope(dialog_scope, interacted_selector, widen, &mut **bridge).await;
+        let page_map = bridge.page_map_feedback(scope.as_deref()).await?;
+        Ok::<_, browser::BridgeError>((scope, page_map))
     })
     .await;
 
     match result {
-        Ok(Ok(pm)) => page_state_from_feedback_map(browser, pm),
+        Ok(Ok((scope, pm))) => page_state_from_feedback_map(browser, scope.as_deref(), pm),
         _ => fallback_value(),
     }
 }
@@ -428,18 +509,208 @@ pub fn record_page_fingerprint(url: &str, page_map: &Value, crawl_state: &mut Cr
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::sync::Arc;
+    use std::sync::Mutex as StdMutex;
 
+    use async_trait::async_trait;
+    use browser::{
+        BridgeError, BrowserState, PageInfo, ScreenshotOptions, StorageEntry, StorageType,
+    };
     use tokio::sync::Mutex;
 
-    use serde_json::json;
+    use serde_json::{json, Value};
 
     use super::{
         build_diff_page_state, build_page_state_from_map, fallback_value,
-        page_state_from_feedback_map,
+        page_state_from_feedback_map, post_action_page_state,
     };
     use crate::BrowserContext;
     use browser::BrowserBackend;
+
+    #[derive(Debug, Default)]
+    struct FeedbackMockState {
+        page_maps: HashMap<String, Value>,
+        requested_scopes: Vec<Option<String>>,
+        evaluate_result: Value,
+        evaluate_scripts: Vec<String>,
+    }
+
+    #[derive(Debug)]
+    struct FeedbackMockBackend {
+        state: Arc<StdMutex<FeedbackMockState>>,
+    }
+
+    #[async_trait]
+    impl BrowserBackend for FeedbackMockBackend {
+        async fn navigate(&mut self, _url: &str) -> Result<PageInfo, BridgeError> {
+            Ok(PageInfo {
+                title: "Test".to_string(),
+                html: String::new(),
+            })
+        }
+
+        async fn new_page(&mut self, _url: Option<&str>) -> Result<usize, BridgeError> {
+            Ok(0)
+        }
+
+        async fn close_page(&mut self, _page_index: usize) -> Result<(), BridgeError> {
+            Ok(())
+        }
+
+        async fn scroll(&mut self, _direction: &str, _pixels: i64) -> Result<(), BridgeError> {
+            Ok(())
+        }
+
+        async fn page_map(
+            &mut self,
+            scope: Option<&str>,
+            _compound_enrichment: bool,
+        ) -> Result<Value, BridgeError> {
+            let mut state = self.state.lock().expect("mock state poisoned");
+            state.requested_scopes.push(scope.map(str::to_string));
+            let key = scope.unwrap_or("").to_string();
+            state
+                .page_maps
+                .get(&key)
+                .cloned()
+                .ok_or_else(|| BridgeError::Protocol(format!("missing page_map for scope '{key}'")))
+        }
+
+        async fn read_content(
+            &mut self,
+            _heading: Option<&str>,
+            _selector: Option<&str>,
+            _offset: usize,
+            _max_chars: usize,
+        ) -> Result<Value, BridgeError> {
+            Ok(json!({}))
+        }
+
+        async fn wait_for_selector(
+            &mut self,
+            _selector: &str,
+            _timeout_ms: u64,
+            _state: Option<&str>,
+        ) -> Result<bool, BridgeError> {
+            Ok(true)
+        }
+
+        async fn select_option(
+            &mut self,
+            _selector: &str,
+            _value: &str,
+        ) -> Result<(), BridgeError> {
+            Ok(())
+        }
+
+        async fn evaluate(&mut self, script: &str) -> Result<Value, BridgeError> {
+            let mut state = self.state.lock().expect("mock state poisoned");
+            state.evaluate_scripts.push(script.to_string());
+            Ok(state.evaluate_result.clone())
+        }
+
+        async fn hover(&mut self, _selector: &str) -> Result<(), BridgeError> {
+            Ok(())
+        }
+
+        async fn press_key(
+            &mut self,
+            _key: &str,
+            _selector: Option<&str>,
+        ) -> Result<(), BridgeError> {
+            Ok(())
+        }
+
+        async fn switch_tab(&mut self, _index: i64) -> Result<Value, BridgeError> {
+            Ok(json!({ "ok": true }))
+        }
+
+        async fn export_cookies(&mut self) -> Result<BrowserState, BridgeError> {
+            Ok(BrowserState {
+                cookies: Value::Array(Vec::new()),
+                local_storage: Value::Object(serde_json::Map::new()),
+                url: String::new(),
+            })
+        }
+
+        async fn import_cookies(&mut self, _state: &BrowserState) -> Result<(), BridgeError> {
+            Ok(())
+        }
+
+        async fn import_cookies_only(&mut self, _state: &BrowserState) -> Result<(), BridgeError> {
+            Ok(())
+        }
+
+        async fn import_local_storage(&mut self, _state: &BrowserState) -> Result<(), BridgeError> {
+            Ok(())
+        }
+
+        async fn list_resources(&mut self) -> Result<Value, BridgeError> {
+            Ok(json!([]))
+        }
+
+        async fn save_file(&mut self, _url: &str, _path: &str) -> Result<String, BridgeError> {
+            Ok(String::new())
+        }
+
+        async fn click(&mut self, _selector: &str) -> Result<(), BridgeError> {
+            Ok(())
+        }
+
+        async fn click_at(&mut self, _x: f64, _y: f64) -> Result<(), BridgeError> {
+            Ok(())
+        }
+
+        async fn fill(&mut self, _selector: &str, _value: &str) -> Result<(), BridgeError> {
+            Ok(())
+        }
+
+        async fn screenshot(
+            &mut self,
+            _options: &ScreenshotOptions<'_>,
+        ) -> Result<(String, usize), BridgeError> {
+            Ok((String::new(), 0))
+        }
+
+        async fn go_back(&mut self) -> Result<String, BridgeError> {
+            Ok(String::new())
+        }
+
+        async fn set_device(&mut self, _options: &Value) -> Result<Value, BridgeError> {
+            Ok(json!({}))
+        }
+
+        async fn poll_observations(
+            &mut self,
+        ) -> Result<Vec<browser::ObservationEvent>, BridgeError> {
+            Ok(Vec::new())
+        }
+
+        async fn set_seq(&mut self, _seq: u64) -> Result<(), BridgeError> {
+            Ok(())
+        }
+
+        async fn get_storage(
+            &mut self,
+            _target: StorageType,
+        ) -> Result<(Vec<StorageEntry>, Vec<StorageEntry>), BridgeError> {
+            Ok((Vec::new(), Vec::new()))
+        }
+    }
+
+    fn browser_with_feedback_backend(
+        state: FeedbackMockState,
+        url: &str,
+    ) -> (BrowserContext, Arc<StdMutex<FeedbackMockState>>) {
+        let state = Arc::new(StdMutex::new(state));
+        let bridge = Arc::new(Mutex::new(Box::new(FeedbackMockBackend {
+            state: Arc::clone(&state),
+        }) as Box<dyn BrowserBackend + Send>));
+        let mut browser = BrowserContext::new(bridge);
+        browser.set_navigated_url(url, true);
+        (browser, state)
+    }
 
     #[test]
     fn feedback_fallback_value_has_correct_shape() {
@@ -945,7 +1216,7 @@ mod tests {
         let mut browser = BrowserContext::new(bridge);
         browser.set_page_snapshot("https://example.com/", None, prev.clone());
 
-        let extension_path = page_state_from_feedback_map(&mut browser, current.clone());
+        let extension_path = page_state_from_feedback_map(&mut browser, None, current.clone());
         let bridge_path = build_diff_page_state(&prev, &mut current);
 
         assert_eq!(extension_path, bridge_path);
@@ -1035,5 +1306,278 @@ mod tests {
         assert_eq!(modified.len(), 1);
         assert_eq!(modified[0]["selector"], "#dropdown");
         assert_eq!(modified[0]["state_changes"]["value"], "Option 1");
+    }
+
+    #[test]
+    fn scoped_diff_filters_to_container() {
+        let url = "https://example.com/settings";
+        let prev_full = json!({
+            "headings": [
+                {"level": 1, "text": "Settings", "selector": "#settings h1", "char_count": 20, "preview": "Settings"}
+            ],
+            "landmarks": [
+                {"tag": "main", "role": "main", "id": "content", "selector": "main", "text_preview": "Content"}
+            ],
+            "links": [
+                {"text": "Profile", "href": "https://example.com/profile", "selector": "header a.profile"},
+                {"text": "Save", "href": "https://example.com/save", "selector": "#settings a.save"}
+            ],
+            "forms": [],
+            "interactive": {},
+            "meta": {"title": "Settings", "url": url, "description": ""}
+        });
+        let mut current_full = json!({
+            "headings": [
+                {"level": 1, "text": "Settings", "selector": "#settings h1", "char_count": 20, "preview": "Settings"}
+            ],
+            "landmarks": [
+                {"tag": "main", "role": "main", "id": "content", "selector": "main", "text_preview": "Content"}
+            ],
+            "links": [
+                {"text": "Profile", "href": "https://example.com/profile", "selector": "header a.profile"},
+                {"text": "Billing", "href": "https://example.com/billing", "selector": "header a.billing"},
+                {"text": "Save", "href": "https://example.com/save", "selector": "#settings a.save"},
+                {"text": "Reset", "href": "https://example.com/reset", "selector": "#settings a.reset"}
+            ],
+            "forms": [],
+            "interactive": {},
+            "meta": {"title": "Settings", "url": url, "description": ""}
+        });
+        let prev_scoped = json!({
+            "headings": [
+                {"level": 1, "text": "Settings", "selector": "#settings h1", "char_count": 20, "preview": "Settings"}
+            ],
+            "landmarks": [],
+            "links": [
+                {"text": "Save", "href": "https://example.com/save", "selector": "#settings a.save"}
+            ],
+            "forms": [],
+            "interactive": {},
+            "meta": {"title": "Settings", "url": url, "description": ""}
+        });
+        let current_scoped = json!({
+            "headings": [
+                {"level": 1, "text": "Settings", "selector": "#settings h1", "char_count": 20, "preview": "Settings"}
+            ],
+            "landmarks": [],
+            "links": [
+                {"text": "Save", "href": "https://example.com/save", "selector": "#settings a.save"},
+                {"text": "Reset", "href": "https://example.com/reset", "selector": "#settings a.reset"}
+            ],
+            "forms": [],
+            "interactive": {},
+            "meta": {"title": "Settings", "url": url, "description": ""}
+        });
+
+        let full_diff = build_diff_page_state(&prev_full, &mut current_full);
+
+        let bridge = Arc::new(Mutex::new(Box::new(
+            crate::tools::test_support::ObservationMockBackend::default(),
+        ) as Box<dyn BrowserBackend + Send>));
+        let mut browser = BrowserContext::new(bridge);
+        browser.set_page_snapshot(url, Some("#settings"), prev_scoped);
+
+        let scoped_diff =
+            page_state_from_feedback_map(&mut browser, Some("#settings"), current_scoped);
+
+        assert_eq!(
+            full_diff["changes"]["added_links"]
+                .as_array()
+                .unwrap()
+                .len(),
+            2
+        );
+        assert_eq!(
+            scoped_diff["changes"]["added_links"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(scoped_diff["changes"]["added_links"][0]["text"], "Reset");
+    }
+
+    #[tokio::test]
+    async fn active_dialog_scope_uses_dialog_baseline() {
+        let url = "https://example.com/page";
+        let prev_dialog = json!({
+            "headings": [
+                {"level": 2, "text": "Confirm", "selector": "#confirm-dialog h2", "char_count": 10, "preview": "Confirm"}
+            ],
+            "landmarks": [
+                {"tag": "dialog", "role": "dialog", "id": "confirm-dialog", "selector": "#confirm-dialog", "text_preview": "Confirm dialog"}
+            ],
+            "links": [
+                {"text": "Cancel", "href": "https://example.com/cancel", "selector": "#confirm-dialog a.cancel"}
+            ],
+            "forms": [],
+            "interactive": {},
+            "meta": {"title": "Dialog", "url": url, "description": ""}
+        });
+        let current_dialog = json!({
+            "headings": [
+                {"level": 2, "text": "Confirm", "selector": "#confirm-dialog h2", "char_count": 10, "preview": "Confirm"}
+            ],
+            "landmarks": [
+                {"tag": "dialog", "role": "dialog", "id": "confirm-dialog", "selector": "#confirm-dialog", "text_preview": "Confirm dialog"}
+            ],
+            "links": [
+                {"text": "Cancel", "href": "https://example.com/cancel", "selector": "#confirm-dialog a.cancel"},
+                {"text": "Delete", "href": "https://example.com/delete", "selector": "#confirm-dialog a.delete"}
+            ],
+            "forms": [],
+            "interactive": {},
+            "meta": {"title": "Dialog", "url": url, "description": ""}
+        });
+
+        let (mut browser, state) = browser_with_feedback_backend(
+            FeedbackMockState {
+                page_maps: HashMap::from([("#confirm-dialog".to_string(), current_dialog)]),
+                evaluate_result: json!("section"),
+                ..FeedbackMockState::default()
+            },
+            url,
+        );
+        browser.set_page_snapshot(url, Some("#confirm-dialog"), prev_dialog);
+        browser.set_page_snapshot(
+            url,
+            None,
+            json!({
+                "headings": [],
+                "landmarks": [],
+                "links": [],
+                "forms": [],
+                "interactive": {},
+                "active_dialog": {"selector": "#confirm-dialog", "visible": true},
+                "meta": {"title": "Page", "url": url, "description": ""}
+            }),
+        );
+
+        let result = post_action_page_state(&mut browser, Some("#outside"), false).await;
+        let state = state.lock().expect("mock state poisoned");
+
+        assert_eq!(
+            state.requested_scopes,
+            vec![Some("#confirm-dialog".to_string())]
+        );
+        assert!(state.evaluate_scripts.is_empty());
+        assert_eq!(result["changes"]["added_links"][0]["text"], "Delete");
+    }
+
+    #[tokio::test]
+    async fn widen_true_returns_full_page_diff() {
+        let url = "https://example.com/page";
+        let prev_full = json!({
+            "headings": [],
+            "landmarks": [],
+            "links": [
+                {"text": "Account", "href": "https://example.com/account", "selector": "header a.account"},
+                {"text": "Save", "href": "https://example.com/save", "selector": "#panel a.save"}
+            ],
+            "forms": [],
+            "interactive": {},
+            "meta": {"title": "Page", "url": url, "description": ""}
+        });
+        let prev_scoped = json!({
+            "headings": [],
+            "landmarks": [],
+            "links": [
+                {"text": "Save", "href": "https://example.com/save", "selector": "#panel a.save"}
+            ],
+            "forms": [],
+            "interactive": {},
+            "meta": {"title": "Page", "url": url, "description": ""}
+        });
+        let current_full = json!({
+            "headings": [],
+            "landmarks": [],
+            "links": [
+                {"text": "Account", "href": "https://example.com/account", "selector": "header a.account"},
+                {"text": "Billing", "href": "https://example.com/billing", "selector": "header a.billing"},
+                {"text": "Save", "href": "https://example.com/save", "selector": "#panel a.save"},
+                {"text": "Reset", "href": "https://example.com/reset", "selector": "#panel a.reset"}
+            ],
+            "forms": [],
+            "interactive": {},
+            "meta": {"title": "Page", "url": url, "description": ""}
+        });
+        let current_scoped = json!({
+            "headings": [],
+            "landmarks": [],
+            "links": [
+                {"text": "Save", "href": "https://example.com/save", "selector": "#panel a.save"},
+                {"text": "Reset", "href": "https://example.com/reset", "selector": "#panel a.reset"}
+            ],
+            "forms": [],
+            "interactive": {},
+            "meta": {"title": "Page", "url": url, "description": ""}
+        });
+
+        let (mut browser, state) = browser_with_feedback_backend(
+            FeedbackMockState {
+                page_maps: HashMap::from([
+                    (String::new(), current_full),
+                    ("section".to_string(), current_scoped),
+                ]),
+                evaluate_result: json!("section"),
+                ..FeedbackMockState::default()
+            },
+            url,
+        );
+        browser.set_page_snapshot(url, None, prev_full);
+        browser.set_page_snapshot(url, Some("section"), prev_scoped);
+
+        let result = post_action_page_state(&mut browser, Some("#trigger"), true).await;
+        let state = state.lock().expect("mock state poisoned");
+
+        assert_eq!(state.requested_scopes, vec![None]);
+        assert!(state.evaluate_scripts.is_empty());
+        assert_eq!(
+            result["changes"]["added_links"].as_array().unwrap().len(),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn no_container_falls_back_to_full_page() {
+        let url = "https://example.com/page";
+        let prev_full = json!({
+            "headings": [],
+            "landmarks": [],
+            "links": [
+                {"text": "Account", "href": "https://example.com/account", "selector": "header a.account"}
+            ],
+            "forms": [],
+            "interactive": {},
+            "meta": {"title": "Page", "url": url, "description": ""}
+        });
+        let current_full = json!({
+            "headings": [],
+            "landmarks": [],
+            "links": [
+                {"text": "Account", "href": "https://example.com/account", "selector": "header a.account"},
+                {"text": "Billing", "href": "https://example.com/billing", "selector": "header a.billing"}
+            ],
+            "forms": [],
+            "interactive": {},
+            "meta": {"title": "Page", "url": url, "description": ""}
+        });
+
+        let (mut browser, state) = browser_with_feedback_backend(
+            FeedbackMockState {
+                page_maps: HashMap::from([(String::new(), current_full)]),
+                evaluate_result: Value::Null,
+                ..FeedbackMockState::default()
+            },
+            url,
+        );
+        browser.set_page_snapshot(url, None, prev_full);
+
+        let result = post_action_page_state(&mut browser, Some("#trigger"), false).await;
+        let state = state.lock().expect("mock state poisoned");
+
+        assert_eq!(state.requested_scopes, vec![None]);
+        assert_eq!(state.evaluate_scripts.len(), 1);
+        assert_eq!(result["changes"]["added_links"][0]["text"], "Billing");
     }
 }

--- a/crates/agent/src/tools/feedback.rs
+++ b/crates/agent/src/tools/feedback.rs
@@ -14,8 +14,9 @@ const FEEDBACK_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// Build structured page state from a raw `page_map` value (full, no diff).
 ///
-/// Applies caps, extracts url/title from meta, and strips `forms` and
-/// `interactive` fields to keep interaction responses concise.
+/// Applies caps, extracts url/title from meta, preserves `regions` and
+/// `active_dialog`, and strips `forms`, `interactive`, and `controls` to keep
+/// interaction responses concise.
 pub fn build_page_state_from_map(mut pm: Value) -> Value {
     apply_page_map_caps(&mut pm);
 
@@ -36,6 +37,7 @@ pub fn build_page_state_from_map(mut pm: Value) -> Value {
     if let Some(obj) = pm.as_object_mut() {
         obj.remove("forms");
         obj.remove("interactive");
+        obj.remove("controls");
     }
 
     json!({
@@ -492,6 +494,31 @@ mod tests {
                     "selector": "a.home"
                 }
             ],
+            "regions": [
+                {
+                    "kind": "Main",
+                    "label": "main panel",
+                    "handle": "@r1",
+                    "selector": "main",
+                    "visible": true,
+                    "children": []
+                }
+            ],
+            "active_dialog": {
+                "handle": "@r2",
+                "selector": "#confirm-dialog",
+                "label": "Confirm"
+            },
+            "controls": [
+                {
+                    "label": "Search",
+                    "role": "textbox",
+                    "selector": "#search",
+                    "value": null,
+                    "required": false,
+                    "disabled": false
+                }
+            ],
             "interactive": {
                 "buttons": 3,
                 "inputs": 2,
@@ -515,6 +542,8 @@ mod tests {
         assert!(pm["headings"].is_array());
         assert!(pm["landmarks"].is_array());
         assert!(pm["links"].is_array());
+        assert!(pm["regions"].is_array());
+        assert!(pm.get("active_dialog").is_some());
         assert!(pm["meta"].is_object());
 
         assert!(
@@ -524,6 +553,10 @@ mod tests {
         assert!(
             pm.get("interactive").is_none(),
             "interactive should be removed from page_map"
+        );
+        assert!(
+            pm.get("controls").is_none(),
+            "controls should be removed from page_map"
         );
 
         assert!(pm.get("truncated_links").is_some());

--- a/crates/agent/src/tools/fill_form.rs
+++ b/crates/agent/src/tools/fill_form.rs
@@ -193,6 +193,20 @@ async fn resolve_field_by_label(
     label_query: &str,
 ) -> Result<Option<String>, ToolExecutionError> {
     let script = r#"(() => {
+        function selectorOf(el) {
+            if (el.id) return '#' + CSS.escape(el.id);
+            const path = [];
+            let cur = el;
+            while (cur && cur.parentElement) {
+                if (cur.id) { path.unshift('#' + CSS.escape(cur.id)); break; }
+                const parent = cur.parentElement;
+                const tag = cur.tagName.toLowerCase();
+                const same = Array.from(parent.children).filter(c => c.tagName === cur.tagName);
+                path.unshift(same.length > 1 ? tag + ':nth-of-type(' + (same.indexOf(cur) + 1) + ')' : tag);
+                cur = parent;
+            }
+            return path.join(' > ');
+        }
         const results = [];
         const controls = document.querySelectorAll(
             'input:not([type="hidden"]), textarea, select, ' +
@@ -221,8 +235,7 @@ async fn resolve_field_by_label(
             if (!label) label = el.placeholder || el.title || el.name || '';
 
             if (label) {
-                const sel = el.id ? '#' + CSS.escape(el.id) : null;
-                if (sel) results.push([label.slice(0, 80), sel]);
+                results.push([label.slice(0, 80), selectorOf(el)]);
             }
         }
         return results;

--- a/crates/agent/src/tools/fill_form.rs
+++ b/crates/agent/src/tools/fill_form.rs
@@ -100,13 +100,24 @@ pub async fn execute(
             }})()"#,
             resolved_form_selector.replace('\'', "\\'")
         );
-        browser
+        let submit_result = browser
             .acquire_bridge()
             .await
             .map_err(|e| ToolExecutionError::new(e.to_string()))?
             .evaluate(&js)
             .await
             .map_err(|e| ToolExecutionError::new(format!("failed to submit form: {e}")))?;
+
+        let outcome = submit_result
+            .get("value")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+
+        if outcome == "form_not_found" {
+            return Err(ToolExecutionError::new(format!(
+                "no <form> matched selector '{resolved_form_selector}'; to submit a div-based SPA form, use click(text='Submit') instead"
+            )));
+        }
 
         if let Some(ref old_url) = pre_url {
             let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
@@ -226,10 +237,12 @@ async fn resolve_field_by_label(
             }
             // 3. aria-label
             if (!label) label = el.getAttribute('aria-label') || '';
-            // 4. aria-labelledby
+            // 4. aria-labelledby (space-separated list of ids per spec)
             if (!label) {
                 const lblById = el.getAttribute('aria-labelledby');
-                if (lblById) label = document.getElementById(lblById)?.innerText?.trim() || '';
+                if (lblById) label = lblById.split(/\s+/).filter(Boolean)
+                    .map(id => document.getElementById(id)?.innerText?.trim() || '')
+                    .filter(Boolean).join(' ').trim();
             }
             // 5. placeholder / title / name
             if (!label) label = el.placeholder || el.title || el.name || '';

--- a/crates/agent/src/tools/fill_form.rs
+++ b/crates/agent/src/tools/fill_form.rs
@@ -12,6 +12,7 @@ struct FillFormInput {
     fields: BTreeMap<String, String>,
     submit: bool,
     form_selector: String,
+    widen: bool,
 }
 
 fn parse_input(input: &Value) -> Result<FillFormInput, CrawlError> {
@@ -50,6 +51,7 @@ fn parse_input(input: &Value) -> Result<FillFormInput, CrawlError> {
         fields,
         submit,
         form_selector,
+        widen: input.get("widen").and_then(Value::as_bool).unwrap_or(false),
     })
 }
 
@@ -69,6 +71,10 @@ pub async fn execute(
             Ok::<_, ToolExecutionError>((resolved, val.clone()))
         })
         .collect::<Result<Vec<_>, _>>()?;
+
+    let resolved_form_selector =
+        super::ref_resolve::resolve_selector(&params.form_selector, browser.ref_map())
+            .map_err(ToolExecutionError::new)?;
 
     fill_fields(browser, &resolved_fields).await?;
 
@@ -92,7 +98,7 @@ pub async fn execute(
                 if (form.dispatchEvent(evt)) form.submit();
                 return 'dispatched';
             }})()"#,
-            params.form_selector.replace('\'', "\\'")
+            resolved_form_selector.replace('\'', "\\'")
         );
         browser
             .acquire_bridge()
@@ -123,7 +129,12 @@ pub async fn execute(
     }
 
     let seq = super::seq::increment_seq(crawl_state, browser).await;
-    let page_state = super::feedback::post_action_page_state(browser).await;
+    let page_state = super::feedback::post_action_page_state(
+        browser,
+        Some(&resolved_form_selector),
+        params.widen,
+    )
+    .await;
 
     let field_count = params.fields.len();
     Ok(ToolEffect::reply_json(&serde_json::json!({

--- a/crates/agent/src/tools/fill_form.rs
+++ b/crates/agent/src/tools/fill_form.rs
@@ -70,15 +70,7 @@ pub async fn execute(
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    for (selector, value) in &resolved_fields {
-        browser
-            .acquire_bridge()
-            .await
-            .map_err(|e| ToolExecutionError::new(e.to_string()))?
-            .fill(selector, value)
-            .await
-            .map_err(|e| ToolExecutionError::new(format!("failed to fill '{selector}': {e}")))?;
-    }
+    fill_fields(browser, &resolved_fields).await?;
 
     if params.submit {
         let pre_url = match browser.acquire_bridge().await {
@@ -143,6 +135,105 @@ pub async fn execute(
         ),
         "page_state": page_state
     })))
+}
+
+async fn fill_fields(
+    browser: &mut BrowserContext,
+    resolved_fields: &[(String, String)],
+) -> Result<(), ToolExecutionError> {
+    for (selector, value) in resolved_fields {
+        let fast_path = browser
+            .acquire_bridge()
+            .await
+            .map_err(|e| ToolExecutionError::new(e.to_string()))?
+            .fill(selector, value)
+            .await;
+
+        if let Err(fast_err) = fast_path {
+            // Fallback for controls outside any <form> (div-based admin UIs,
+            // modals, panels): fuzzy-match the field against page-wide labels.
+            match resolve_field_by_label(browser, selector).await? {
+                Some(fuzzy_selector) => {
+                    browser
+                        .acquire_bridge()
+                        .await
+                        .map_err(|e| ToolExecutionError::new(e.to_string()))?
+                        .fill(&fuzzy_selector, value)
+                        .await
+                        .map_err(|e| {
+                            ToolExecutionError::new(format!(
+                                "failed to fill '{selector}' (matched label to '{fuzzy_selector}'): {e}"
+                            ))
+                        })?;
+                }
+                None => {
+                    return Err(ToolExecutionError::new(format!(
+                        "failed to fill '{selector}': {fast_err}"
+                    )));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn resolve_field_by_label(
+    browser: &mut BrowserContext,
+    label_query: &str,
+) -> Result<Option<String>, ToolExecutionError> {
+    let script = r#"(() => {
+        const results = [];
+        const controls = document.querySelectorAll(
+            'input:not([type="hidden"]), textarea, select, ' +
+            '[role="checkbox"], [role="switch"], [role="combobox"], [role="textbox"]'
+        );
+        for (const el of controls) {
+            let label = '';
+            // 1. label[for=id]
+            if (el.id) {
+                const lbl = document.querySelector(`label[for="${CSS.escape(el.id)}"]`);
+                if (lbl) label = lbl.innerText.trim();
+            }
+            // 2. parent <label>
+            if (!label) {
+                const parent = el.closest('label');
+                if (parent) label = parent.innerText.replace(el.value || '', '').trim();
+            }
+            // 3. aria-label
+            if (!label) label = el.getAttribute('aria-label') || '';
+            // 4. aria-labelledby
+            if (!label) {
+                const lblById = el.getAttribute('aria-labelledby');
+                if (lblById) label = document.getElementById(lblById)?.innerText?.trim() || '';
+            }
+            // 5. placeholder / title / name
+            if (!label) label = el.placeholder || el.title || el.name || '';
+
+            if (label) {
+                const sel = el.id ? '#' + CSS.escape(el.id) : null;
+                if (sel) results.push([label.slice(0, 80), sel]);
+            }
+        }
+        return results;
+    })()"#;
+
+    let raw = browser
+        .acquire_bridge()
+        .await
+        .map_err(|e| ToolExecutionError::new(e.to_string()))?
+        .evaluate(script)
+        .await
+        .map_err(|e| ToolExecutionError::new(e.to_string()))?;
+
+    let pairs: Vec<(String, String)> = raw
+        .get("value")
+        .and_then(|v| serde_json::from_value::<Vec<[String; 2]>>(v.clone()).ok())
+        .unwrap_or_default()
+        .into_iter()
+        .map(|[name, sel]| (name, sel))
+        .collect();
+
+    Ok(crate::semantic::match_text(label_query, &pairs, None).map(|(best, _)| best))
 }
 
 #[cfg(test)]
@@ -227,5 +318,46 @@ mod tests {
         assert!(response["page_state"]["url"].is_string());
         assert!(response["page_state"]["title"].is_string());
         assert!(!response["page_state"]["page_map"].is_null());
+    }
+
+    #[test]
+    fn match_text_exact_wins_over_fuzzy() {
+        let candidates = vec![
+            ("Email address".to_string(), "#email".to_string()),
+            ("Password".to_string(), "#pw".to_string()),
+        ];
+        let (best, _) = crate::semantic::match_text("Email address", &candidates, None).unwrap();
+        assert_eq!(best, "#email");
+    }
+
+    #[test]
+    fn match_text_case_insensitive_fallback() {
+        let candidates = vec![("Email address".to_string(), "#email".to_string())];
+        let (best, _) = crate::semantic::match_text("email address", &candidates, None).unwrap();
+        assert_eq!(best, "#email");
+    }
+
+    #[test]
+    fn match_text_contains_fallback() {
+        let candidates = vec![("Email address".to_string(), "#email".to_string())];
+        let (best, _) = crate::semantic::match_text("email", &candidates, None).unwrap();
+        assert_eq!(best, "#email");
+    }
+
+    #[test]
+    fn match_text_no_match_returns_none() {
+        let candidates = vec![("Email address".to_string(), "#email".to_string())];
+        assert!(crate::semantic::match_text("phone", &candidates, None).is_none());
+    }
+
+    #[test]
+    fn match_text_ambiguous_returns_best_and_alternatives() {
+        let candidates = vec![
+            ("Name".to_string(), "#name-1".to_string()),
+            ("Name".to_string(), "#name-2".to_string()),
+        ];
+        let (best, alternatives) = crate::semantic::match_text("Name", &candidates, None).unwrap();
+        assert_eq!(best, "#name-1");
+        assert_eq!(alternatives, vec!["#name-2".to_string()]);
     }
 }

--- a/crates/agent/src/tools/go_back.rs
+++ b/crates/agent/src/tools/go_back.rs
@@ -22,7 +22,7 @@ pub async fn execute(
         .map_err(|e| ToolExecutionError::new(e.to_string()))?;
 
     let seq = super::seq::increment_seq(crawl_state, browser).await;
-    let page_state = super::feedback::post_action_page_state(browser).await;
+    let page_state = super::feedback::post_action_page_state(browser, None, false).await;
 
     Ok(ToolEffect::reply_json(&serde_json::json!({
         "seq": seq,

--- a/crates/agent/src/tools/hover.rs
+++ b/crates/agent/src/tools/hover.rs
@@ -4,12 +4,22 @@ use crate::state::CrawlState;
 use crate::BrowserContext;
 use crate::{CrawlError, ToolEffect, ToolExecutionError};
 
-pub fn parse_input(input: &Value) -> Result<String, CrawlError> {
-    input
+pub struct HoverInput {
+    selector: String,
+    widen: bool,
+}
+
+pub fn parse_input(input: &Value) -> Result<HoverInput, CrawlError> {
+    let selector = input
         .get("selector")
         .and_then(|v| v.as_str())
         .map(String::from)
-        .ok_or_else(|| CrawlError::new("hover requires 'selector' field"))
+        .ok_or_else(|| CrawlError::new("hover requires 'selector' field"))?;
+
+    Ok(HoverInput {
+        selector,
+        widen: input.get("widen").and_then(Value::as_bool).unwrap_or(false),
+    })
 }
 
 pub async fn execute(
@@ -17,8 +27,8 @@ pub async fn execute(
     browser: &mut BrowserContext,
     crawl_state: &CrawlState,
 ) -> Result<ToolEffect, ToolExecutionError> {
-    let selector = parse_input(input)?;
-    let resolved = super::ref_resolve::resolve_selector(&selector, browser.ref_map())
+    let params = parse_input(input)?;
+    let resolved = super::ref_resolve::resolve_selector(&params.selector, browser.ref_map())
         .map_err(ToolExecutionError::new)?;
 
     browser
@@ -30,12 +40,13 @@ pub async fn execute(
         .map_err(|e| ToolExecutionError::new(e.to_string()))?;
 
     let seq = super::seq::increment_seq(crawl_state, browser).await;
-    let page_state = super::feedback::post_action_page_state(browser).await;
+    let page_state =
+        super::feedback::post_action_page_state(browser, Some(&resolved), params.widen).await;
 
     Ok(ToolEffect::reply_json(&json!({
         "seq": seq,
         "success": true,
-        "message": format!("Hovered over: {selector}"),
+        "message": format!("Hovered over: {}", params.selector),
         "page_state": page_state
     })))
 }
@@ -49,8 +60,9 @@ mod tests {
     #[test]
     fn parses_selector() {
         let input = json!({"selector": ".menu-item"});
-        let selector = parse_input(&input).unwrap();
-        assert_eq!(selector, ".menu-item");
+        let parsed = parse_input(&input).unwrap();
+        assert_eq!(parsed.selector, ".menu-item");
+        assert!(!parsed.widen);
     }
 
     #[test]

--- a/crates/agent/src/tools/navigate.rs
+++ b/crates/agent/src/tools/navigate.rs
@@ -450,7 +450,7 @@ fn cache_page_map_snapshot(
         .and_then(Value::as_str)
         .unwrap_or("unknown");
     let cache_key = normalize_url(pm_url).to_string();
-    browser.set_page_snapshot(cache_key, page_map.clone());
+    browser.set_page_snapshot(&cache_key, None, page_map.clone());
 
     let fp_settings = runtime::load_settings();
     if runtime::settings_get_page_fingerprinting(&fp_settings) {

--- a/crates/agent/src/tools/navigate.rs
+++ b/crates/agent/src/tools/navigate.rs
@@ -4,7 +4,7 @@ use crate::markdown::{extract_main_html, html_to_markdown, DEFAULT_MAX_MARKDOWN_
 use crate::prune::{prune_html_with_profile, select_profile, CleaningProfile};
 use crate::state::CrawlState;
 use crate::tools::html_diff::HtmlDiffTracker;
-use crate::tools::page_map::{annotate_refs, apply_page_map_caps, normalize_url};
+use crate::tools::page_map::{annotate_refs, apply_page_map_caps, enrich_semantic_sections, normalize_url};
 use crate::BrowserContext;
 use crate::FetchRouter;
 use crate::{CrawlError, ToolEffect, ToolExecutionError};
@@ -409,6 +409,7 @@ async fn build_page_map(
         match browser.acquire_bridge().await {
             Ok(mut bridge) => match bridge.page_map(None, compound_enrichment).await {
                 Ok(mut value) => {
+                    enrich_semantic_sections(&mut value);
                     apply_page_map_caps(&mut value);
                     value
                 }

--- a/crates/agent/src/tools/navigate.rs
+++ b/crates/agent/src/tools/navigate.rs
@@ -4,7 +4,9 @@ use crate::markdown::{extract_main_html, html_to_markdown, DEFAULT_MAX_MARKDOWN_
 use crate::prune::{prune_html_with_profile, select_profile, CleaningProfile};
 use crate::state::CrawlState;
 use crate::tools::html_diff::HtmlDiffTracker;
-use crate::tools::page_map::{annotate_refs, apply_page_map_caps, enrich_semantic_sections, normalize_url};
+use crate::tools::page_map::{
+    annotate_refs, apply_page_map_caps, enrich_semantic_sections, normalize_url,
+};
 use crate::BrowserContext;
 use crate::FetchRouter;
 use crate::{CrawlError, ToolEffect, ToolExecutionError};

--- a/crates/agent/src/tools/page_map.rs
+++ b/crates/agent/src/tools/page_map.rs
@@ -1,11 +1,17 @@
-use serde_json::Value;
+use serde_json::{json, Value};
 
+use crate::semantic::{
+    assemble_region_tree, compute_accessible_name, select_active_dialog, RawElementFacts,
+    RegionCandidate,
+};
 use crate::BrowserContext;
 use crate::{ToolEffect, ToolExecutionError};
 
 const MAX_PAGE_MAP_LINKS: usize = 50;
 const MAX_PAGE_MAP_FORMS: usize = 10;
 const MAX_PAGE_MAP_LANDMARKS: usize = 20;
+const MAX_PAGE_MAP_REGIONS: usize = 16;
+const MAX_PAGE_MAP_CONTROLS: usize = 30;
 
 /// Normalize a URL for page-map caching and ref lifecycle comparison.
 /// Strips fragment unless it looks like a hash-based route (`#/…` or `#!/…`).
@@ -54,6 +60,8 @@ pub fn apply_page_map_caps(value: &mut Value) {
     let truncated_links = truncate_array_field(value, "links", MAX_PAGE_MAP_LINKS);
     let truncated_forms = truncate_array_field(value, "forms", MAX_PAGE_MAP_FORMS);
     let truncated_landmarks = truncate_array_field(value, "landmarks", MAX_PAGE_MAP_LANDMARKS);
+    let truncated_regions = truncate_array_field(value, "regions", MAX_PAGE_MAP_REGIONS);
+    let truncated_controls = truncate_array_field(value, "controls", MAX_PAGE_MAP_CONTROLS);
 
     if let Some(object) = value.as_object_mut() {
         object.insert("truncated_links".to_string(), Value::Bool(truncated_links));
@@ -61,6 +69,14 @@ pub fn apply_page_map_caps(value: &mut Value) {
         object.insert(
             "truncated_landmarks".to_string(),
             Value::Bool(truncated_landmarks),
+        );
+        object.insert(
+            "truncated_regions".to_string(),
+            Value::Bool(truncated_regions),
+        );
+        object.insert(
+            "truncated_controls".to_string(),
+            Value::Bool(truncated_controls),
         );
     }
 }
@@ -78,12 +94,151 @@ fn truncate_array_field(value: &mut Value, key: &str, max_len: usize) -> bool {
         })
 }
 
+fn resolve_scope(scope: Option<&str>, browser: &BrowserContext) -> Option<String> {
+    match scope {
+        Some("dialog") => Some(
+            "[role=\"dialog\"], [role=\"alertdialog\"], [aria-modal=\"true\"], [popover]"
+                .to_string(),
+        ),
+        Some("main") => Some("main, [role=\"main\"]".to_string()),
+        Some("sidebar") => Some("[role=\"complementary\"], aside, nav".to_string()),
+        Some(handle) if handle.starts_with("@r") => browser
+            .last_snapshot_region_selector(handle)
+            .map(str::to_string),
+        Some(other) => Some(other.to_string()),
+        None => None,
+    }
+}
+
+fn infer_control_role(tag: &str, role: Option<&str>) -> String {
+    role.map_or_else(
+        || {
+            match tag {
+                "button" => "button",
+                "select" => "combobox",
+                "textarea" | "input" => "textbox",
+                _ => "",
+            }
+            .to_string()
+        },
+        str::to_string,
+    )
+}
+
+fn control_facts_from_value(value: &Value) -> RawElementFacts {
+    RawElementFacts {
+        tag: value
+            .get("tag")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+        role: value
+            .get("role")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        aria_expanded: None,
+        aria_selected: None,
+        aria_pressed: None,
+        aria_controls: None,
+        aria_owns: None,
+        text: value
+            .get("text")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        aria_label: value
+            .get("aria_label")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        aria_labelledby_text: value
+            .get("aria_labelledby_text")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        title: value
+            .get("title")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        placeholder: value
+            .get("placeholder")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        name: value
+            .get("name")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        visible: true,
+        floating: false,
+        selector: value
+            .get("selector")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+    }
+}
+
+fn enrich_semantic_sections(result: &mut Value) {
+    let regions = result
+        .get("regionCandidates")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| serde_json::from_value::<RegionCandidate>(item.clone()).ok())
+                .collect::<Vec<_>>()
+        })
+        .map(|candidates| assemble_region_tree(&candidates))
+        .unwrap_or_default();
+
+    let active_dialog = select_active_dialog(&regions).map(|region| {
+        json!({
+            "handle": region.handle,
+            "selector": region.selector,
+            "label": region.label,
+        })
+    });
+
+    let controls = result
+        .get("nonFormControls")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .map(|item| {
+                    let facts = control_facts_from_value(item);
+                    json!({
+                        "label": compute_accessible_name(&facts),
+                        "role": infer_control_role(&facts.tag, facts.role.as_deref()),
+                        "selector": facts.selector,
+                        "value": item.get("value").cloned().unwrap_or(Value::Null),
+                        "required": item.get("required").and_then(Value::as_bool).unwrap_or(false),
+                        "disabled": item.get("disabled").and_then(Value::as_bool).unwrap_or(false),
+                    })
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    if let Some(object) = result.as_object_mut() {
+        object.insert(
+            "regions".to_string(),
+            serde_json::to_value(regions).unwrap_or_else(|_| Value::Array(Vec::new())),
+        );
+        object.insert(
+            "active_dialog".to_string(),
+            active_dialog.unwrap_or(Value::Null),
+        );
+        object.insert("controls".to_string(), Value::Array(controls));
+        object.remove("regionCandidates");
+        object.remove("nonFormControls");
+    }
+}
+
 pub async fn execute(
     input: &Value,
     browser: &mut BrowserContext,
     crawl_state: &mut crate::state::CrawlState,
 ) -> Result<ToolEffect, ToolExecutionError> {
     let scope = input.get("scope").and_then(Value::as_str);
+    let resolved_scope = resolve_scope(scope, browser);
 
     let settings = runtime::load_settings();
     let compound_enrichment = runtime::settings_get_compound_enrichment(&settings);
@@ -92,9 +247,11 @@ pub async fn execute(
         .acquire_bridge()
         .await
         .map_err(|e| ToolExecutionError::new(e.to_string()))?
-        .page_map(scope, compound_enrichment)
+        .page_map(resolved_scope.as_deref(), compound_enrichment)
         .await
         .map_err(|e| ToolExecutionError::new(e.to_string()))?;
+
+    enrich_semantic_sections(&mut result);
 
     apply_page_map_caps(&mut result);
 
@@ -135,9 +292,13 @@ pub async fn execute(
 
 #[cfg(test)]
 mod tests {
-    use serde_json::{json, Value};
+    use std::sync::Arc;
 
-    use super::apply_page_map_caps;
+    use serde_json::{json, Value};
+    use tokio::sync::Mutex;
+
+    use super::{apply_page_map_caps, enrich_semantic_sections, resolve_scope};
+    use browser::BrowserContext;
 
     #[test]
     fn page_map_response_structure_has_all_sections() {
@@ -340,6 +501,149 @@ mod tests {
 
         assert_eq!(value["links"].as_array().map(Vec::len), Some(5));
         assert_eq!(value["truncated_links"], json!(false));
+    }
+
+    #[test]
+    fn page_map_caps_regions_and_controls() {
+        let mut value = json!({
+            "headings": [],
+            "landmarks": [],
+            "forms": [],
+            "links": [],
+            "regions": (0..20)
+                .map(|index| json!({
+                    "kind": "Region",
+                    "label": format!("region {index}"),
+                    "handle": format!("@r{}", index + 1),
+                    "selector": format!("#region-{index}"),
+                    "visible": true,
+                    "children": []
+                }))
+                .collect::<Vec<_>>(),
+            "controls": (0..40)
+                .map(|index| json!({
+                    "label": format!("Control {index}"),
+                    "role": "textbox",
+                    "selector": format!("#control-{index}"),
+                    "value": null,
+                    "required": false,
+                    "disabled": false
+                }))
+                .collect::<Vec<_>>(),
+            "interactive": {},
+            "meta": {}
+        });
+
+        apply_page_map_caps(&mut value);
+
+        assert_eq!(value["regions"].as_array().map(Vec::len), Some(16));
+        assert_eq!(value["controls"].as_array().map(Vec::len), Some(30));
+        assert_eq!(value["truncated_regions"], json!(true));
+        assert_eq!(value["truncated_controls"], json!(true));
+    }
+
+    #[test]
+    fn page_map_assembles_regions_from_raw_candidates() {
+        let mut value = json!({
+            "regionCandidates": [
+                {
+                    "tag": "main",
+                    "role": null,
+                    "aria_label": null,
+                    "id": null,
+                    "depth": 1,
+                    "parent_idx": null,
+                    "selector": "main",
+                    "visible": true
+                },
+                {
+                    "tag": "div",
+                    "role": "dialog",
+                    "aria_label": "Confirm",
+                    "id": "modal",
+                    "depth": 2,
+                    "parent_idx": 0,
+                    "selector": "div#modal",
+                    "visible": true
+                }
+            ],
+            "nonFormControls": [
+                {
+                    "tag": "input",
+                    "role": null,
+                    "text": "",
+                    "aria_label": "Search",
+                    "aria_labelledby_text": null,
+                    "title": null,
+                    "placeholder": null,
+                    "name": null,
+                    "value": null,
+                    "required": false,
+                    "disabled": false,
+                    "selector": "input#search"
+                }
+            ],
+            "headings": [],
+            "landmarks": [],
+            "forms": [],
+            "links": [],
+            "interactive": {"counts": {"total": 0, "buttons": 0, "inputs": 0, "selects": 0, "textareas": 0}, "elements": []},
+            "meta": {"title": "Test", "url": "https://example.com", "description": ""},
+            "total_landmarks": 0,
+            "total_forms": 0,
+            "total_links": 0
+        });
+
+        enrich_semantic_sections(&mut value);
+
+        assert_eq!(value["regions"].as_array().map(Vec::len), Some(1));
+        assert_eq!(value["regions"][0]["label"], json!("main panel"));
+        assert_eq!(
+            value["regions"][0]["children"][0]["label"],
+            json!("Confirm")
+        );
+        assert_eq!(value["active_dialog"]["handle"], json!("@r2"));
+        assert_eq!(value["active_dialog"]["selector"], json!("div#modal"));
+        assert_eq!(value["controls"][0]["label"], json!("Search"));
+        assert_eq!(value["controls"][0]["role"], json!("textbox"));
+        assert!(value.get("regionCandidates").is_none());
+        assert!(value.get("nonFormControls").is_none());
+    }
+
+    #[test]
+    fn semantic_scope_tokens_resolve_from_snapshot() {
+        let bridge: Arc<Mutex<Box<dyn browser::BrowserBackend + Send>>> =
+            Arc::new(Mutex::new(Box::new(browser::NopBridge)));
+        let mut ctx = BrowserContext::new(bridge);
+        ctx.set_page_snapshot(
+            "https://example.com",
+            None,
+            json!({
+                "regions": [{
+                    "handle": "@r1",
+                    "selector": "main",
+                    "children": [{
+                        "handle": "@r2",
+                        "selector": "#modal",
+                        "children": []
+                    }]
+                }]
+            }),
+        );
+
+        assert_eq!(
+            resolve_scope(Some("main"), &ctx),
+            Some("main, [role=\"main\"]".to_string())
+        );
+        assert_eq!(
+            resolve_scope(Some("dialog"), &ctx),
+            Some(
+                "[role=\"dialog\"], [role=\"alertdialog\"], [aria-modal=\"true\"], [popover]"
+                    .to_string(),
+            )
+        );
+        assert_eq!(resolve_scope(Some("@r2"), &ctx), Some("#modal".to_string()));
+        assert_eq!(resolve_scope(Some("@r9"), &ctx), None);
     }
 
     #[test]

--- a/crates/agent/src/tools/page_map.rs
+++ b/crates/agent/src/tools/page_map.rs
@@ -94,20 +94,30 @@ fn truncate_array_field(value: &mut Value, key: &str, max_len: usize) -> bool {
         })
 }
 
-fn resolve_scope(scope: Option<&str>, browser: &BrowserContext) -> Option<String> {
-    match scope {
+fn resolve_scope(
+    scope: Option<&str>,
+    browser: &BrowserContext,
+) -> Result<Option<String>, ToolExecutionError> {
+    Ok(match scope {
         Some("dialog") => Some(
             "[role=\"dialog\"], [role=\"alertdialog\"], [aria-modal=\"true\"], [popover]"
                 .to_string(),
         ),
         Some("main") => Some("main, [role=\"main\"]".to_string()),
         Some("sidebar") => Some("[role=\"complementary\"], aside, nav".to_string()),
-        Some(handle) if handle.starts_with("@r") => browser
-            .last_snapshot_region_selector(handle)
-            .map(str::to_string),
+        Some(handle) if handle.starts_with("@r") => {
+            match browser.last_snapshot_region_selector(handle) {
+                Some(selector) => Some(selector.to_string()),
+                None => {
+                    return Err(ToolExecutionError::new(format!(
+                        "unknown region handle '{handle}'; call page_map first to get fresh handles"
+                    )))
+                }
+            }
+        }
         Some(other) => Some(other.to_string()),
         None => None,
-    }
+    })
 }
 
 fn infer_control_role(tag: &str, role: Option<&str>) -> String {
@@ -238,7 +248,7 @@ pub async fn execute(
     crawl_state: &mut crate::state::CrawlState,
 ) -> Result<ToolEffect, ToolExecutionError> {
     let scope = input.get("scope").and_then(Value::as_str);
-    let resolved_scope = resolve_scope(scope, browser);
+    let resolved_scope = resolve_scope(scope, browser)?;
 
     let settings = runtime::load_settings();
     let compound_enrichment = runtime::settings_get_compound_enrichment(&settings);
@@ -632,18 +642,24 @@ mod tests {
         );
 
         assert_eq!(
-            resolve_scope(Some("main"), &ctx),
+            resolve_scope(Some("main"), &ctx).unwrap(),
             Some("main, [role=\"main\"]".to_string())
         );
         assert_eq!(
-            resolve_scope(Some("dialog"), &ctx),
+            resolve_scope(Some("dialog"), &ctx).unwrap(),
             Some(
                 "[role=\"dialog\"], [role=\"alertdialog\"], [aria-modal=\"true\"], [popover]"
                     .to_string(),
             )
         );
-        assert_eq!(resolve_scope(Some("@r2"), &ctx), Some("#modal".to_string()));
-        assert_eq!(resolve_scope(Some("@r9"), &ctx), None);
+        assert_eq!(
+            resolve_scope(Some("@r2"), &ctx).unwrap(),
+            Some("#modal".to_string())
+        );
+        assert_eq!(
+            resolve_scope(Some("@r9"), &ctx).unwrap_err().to_string(),
+            "unknown region handle '@r9'; call page_map first to get fresh handles"
+        );
     }
 
     #[test]

--- a/crates/agent/src/tools/page_map.rs
+++ b/crates/agent/src/tools/page_map.rs
@@ -175,7 +175,7 @@ fn control_facts_from_value(value: &Value) -> RawElementFacts {
     }
 }
 
-fn enrich_semantic_sections(result: &mut Value) {
+pub(super) fn enrich_semantic_sections(result: &mut Value) {
     let regions = result
         .get("regionCandidates")
         .and_then(Value::as_array)

--- a/crates/agent/src/tools/page_map.rs
+++ b/crates/agent/src/tools/page_map.rs
@@ -114,7 +114,7 @@ pub async fn execute(
         }
 
         annotate_refs(&mut result, browser);
-        browser.set_page_snapshot(cache_key, result.clone());
+        browser.set_page_snapshot(&cache_key, None, result.clone());
     } else {
         annotate_refs(&mut result, browser);
     }

--- a/crates/agent/src/tools/press_key.rs
+++ b/crates/agent/src/tools/press_key.rs
@@ -7,6 +7,7 @@ use crate::{CrawlError, ToolEffect, ToolExecutionError};
 pub struct PressKeyInput {
     pub key: String,
     pub selector: Option<String>,
+    pub widen: bool,
 }
 
 pub fn parse_input(input: &Value) -> Result<PressKeyInput, CrawlError> {
@@ -21,7 +22,11 @@ pub fn parse_input(input: &Value) -> Result<PressKeyInput, CrawlError> {
         .and_then(|v| v.as_str())
         .map(String::from);
 
-    Ok(PressKeyInput { key, selector })
+    Ok(PressKeyInput {
+        key,
+        selector,
+        widen: input.get("widen").and_then(Value::as_bool).unwrap_or(false),
+    })
 }
 
 pub async fn execute(
@@ -48,7 +53,12 @@ pub async fn execute(
         .map_err(|e| ToolExecutionError::new(e.to_string()))?;
 
     let seq = super::seq::increment_seq(crawl_state, browser).await;
-    let page_state = super::feedback::post_action_page_state(browser).await;
+    let page_state = super::feedback::post_action_page_state(
+        browser,
+        resolved_selector.as_deref(),
+        parsed.widen,
+    )
+    .await;
 
     Ok(ToolEffect::reply_json(&json!({
         "seq": seq,

--- a/crates/agent/src/tools/refresh.rs
+++ b/crates/agent/src/tools/refresh.rs
@@ -21,7 +21,7 @@ pub async fn execute(
         .map_err(|e| ToolExecutionError::new(e.to_string()))?;
 
     let seq = super::seq::increment_seq(crawl_state, browser).await;
-    let page_state = super::feedback::post_action_page_state(browser).await;
+    let page_state = super::feedback::post_action_page_state(browser, None, false).await;
 
     Ok(ToolEffect::reply_json(&serde_json::json!({
         "seq": seq,

--- a/crates/agent/src/tools/scroll.rs
+++ b/crates/agent/src/tools/scroll.rs
@@ -42,7 +42,7 @@ pub async fn execute(
         .map_err(|e| ToolExecutionError::new(e.to_string()))?;
 
     let seq = super::seq::increment_seq(crawl_state, browser).await;
-    let page_state = super::feedback::post_action_page_state(browser).await;
+    let page_state = super::feedback::post_action_page_state(browser, None, false).await;
 
     Ok(ToolEffect::reply_json(&json!({
         "seq": seq,

--- a/crates/agent/src/tools/select_option.rs
+++ b/crates/agent/src/tools/select_option.rs
@@ -816,19 +816,6 @@ async fn verify_custom_selection(
 
             if (target && target.getAttribute('aria-selected') === 'true') return true;
 
-            const controlledIds = [trigger.getAttribute('aria-controls'), trigger.getAttribute('aria-owns')]
-                .filter(Boolean)
-                .flatMap((value) => value.split(/\s+/).filter(Boolean));
-            if (controlledIds.length > 0) {{
-                const stillVisible = controlledIds.some((id) => {{
-                    const node = document.getElementById(id);
-                    if (!node) return false;
-                    const style = getComputedStyle(node);
-                    return node.offsetParent !== null && !node.hidden && style.visibility !== 'hidden';
-                }});
-                if (!stillVisible) return true;
-            }}
-
             return false;
         }})()"
     );

--- a/crates/agent/src/tools/select_option.rs
+++ b/crates/agent/src/tools/select_option.rs
@@ -1,29 +1,61 @@
+use std::collections::HashSet;
+use std::time::Duration;
+
 use serde_json::{json, Value};
 
+use crate::semantic::{compute_accessible_name, OptionCandidate, RawElementFacts};
 use crate::state::CrawlState;
 use crate::BrowserContext;
 use crate::{CrawlError, ToolEffect, ToolExecutionError};
 
+const OPEN_WAIT: Duration = Duration::from_millis(300);
+const VERIFY_WAIT: Duration = Duration::from_millis(200);
+const MAX_OPTION_ATTEMPTS: usize = 5;
+const OPEN_KEYS: [&str; 3] = ["Enter", "Space", "ArrowDown"];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SelectOptionInput {
     pub selector: String,
-    pub value: String,
+    pub value: Option<String>,
+    pub label: Option<String>,
+    pub index: Option<usize>,
 }
 
 pub fn parse_input(input: &Value) -> Result<SelectOptionInput, CrawlError> {
     let selector = input
         .get("selector")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| CrawlError::new("select_option requires 'selector' field"))?
-        .to_string();
+        .and_then(Value::as_str)
+        .ok_or_else(|| CrawlError::new("missing required field: selector"))?;
 
-    let value = input
-        .get("value")
-        .or_else(|| input.get("label"))
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| CrawlError::new("select_option requires 'value' or 'label' field"))?
-        .to_string();
+    if selector.trim().is_empty() {
+        return Err(CrawlError::new("selector must not be empty"));
+    }
 
-    Ok(SelectOptionInput { selector, value })
+    let index = match input.get("index") {
+        Some(value) => {
+            let raw = value
+                .as_u64()
+                .ok_or_else(|| CrawlError::new("index must be a non-negative integer"))?;
+            Some(
+                usize::try_from(raw)
+                    .map_err(|_| CrawlError::new("index is too large for this platform"))?,
+            )
+        }
+        None => None,
+    };
+
+    Ok(SelectOptionInput {
+        selector: selector.to_string(),
+        value: input
+            .get("value")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        label: input
+            .get("label")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        index,
+    })
 }
 
 pub async fn execute(
@@ -31,17 +63,57 @@ pub async fn execute(
     browser: &mut BrowserContext,
     crawl_state: &CrawlState,
 ) -> Result<ToolEffect, ToolExecutionError> {
-    let parsed = parse_input(input)?;
-    let resolved = super::ref_resolve::resolve_selector(&parsed.selector, browser.ref_map())
+    let params = parse_input(input)?;
+    let selector = super::ref_resolve::resolve_selector(&params.selector, browser.ref_map())
         .map_err(ToolExecutionError::new)?;
 
-    browser
-        .acquire_bridge()
-        .await
-        .map_err(|e| ToolExecutionError::new(e.to_string()))?
-        .select_option(&resolved, &parsed.value)
-        .await
-        .map_err(|e| ToolExecutionError::new(e.to_string()))?;
+    if check_is_native_select(browser, &selector).await? {
+        return execute_native(&params, &selector, browser, crawl_state).await;
+    }
+
+    execute_custom(&params, &selector, browser, crawl_state).await
+}
+
+async fn execute_native(
+    params: &SelectOptionInput,
+    selector: &str,
+    browser: &mut BrowserContext,
+    crawl_state: &CrawlState,
+) -> Result<ToolEffect, ToolExecutionError> {
+    let options = get_native_options(browser, selector).await?;
+
+    let selected = if let Some(value) = params.value.as_deref() {
+        browser
+            .acquire_bridge()
+            .await
+            .map_err(|e| ToolExecutionError::new(e.to_string()))?
+            .select_option(selector, value)
+            .await
+            .map_err(|e| ToolExecutionError::new(e.to_string()))?;
+        Some(value.to_string())
+    } else if let Some(label) = params.label.as_deref() {
+        select_native_by_label(browser, selector, label).await?;
+        Some(label.to_string())
+    } else if let Some(index) = params.index {
+        let option = options.get(index).ok_or_else(|| {
+            ToolExecutionError::new(format!(
+                "option index {index} is out of range; available indices: 0..{}",
+                options.len().saturating_sub(1)
+            ))
+        })?;
+        select_native_by_index(browser, selector, index).await?;
+        Some(option.name.clone())
+    } else {
+        let seq = super::seq::increment_seq(crawl_state, browser).await;
+        let page_state = super::feedback::post_action_page_state(browser).await;
+        return Ok(ToolEffect::reply_json(&json!({
+            "seq": seq,
+            "success": true,
+            "mode": "list",
+            "options": option_candidates_json(&options),
+            "page_state": page_state,
+        })));
+    };
 
     let seq = super::seq::increment_seq(crawl_state, browser).await;
     let page_state = super::feedback::post_action_page_state(browser).await;
@@ -49,41 +121,1114 @@ pub async fn execute(
     Ok(ToolEffect::reply_json(&json!({
         "seq": seq,
         "success": true,
-        "message": format!("Selected '{}' in {}", parsed.value, parsed.selector),
-        "page_state": page_state
+        "selected": selected,
+        "options": option_candidates_json(&options),
+        "page_state": page_state,
     })))
+}
+
+async fn execute_custom(
+    params: &SelectOptionInput,
+    selector: &str,
+    browser: &mut BrowserContext,
+    crawl_state: &CrawlState,
+) -> Result<ToolEffect, ToolExecutionError> {
+    let before_snapshot = extract_dom_snapshot(browser).await?;
+    let before = snapshot_elements(&before_snapshot)?;
+
+    open_custom_dropdown(browser, selector, &before).await?;
+    let options = locate_and_enumerate_options(browser, selector, &before).await?;
+
+    if options.is_empty() {
+        return Err(ToolExecutionError::new(
+            "dropdown opened, but no visible options were found",
+        ));
+    }
+
+    if params.value.is_none() && params.label.is_none() && params.index.is_none() {
+        let seq = super::seq::increment_seq(crawl_state, browser).await;
+        let page_state = super::feedback::post_action_page_state(browser).await;
+        return Ok(ToolEffect::reply_json(&json!({
+            "seq": seq,
+            "success": true,
+            "mode": "list",
+            "options": option_candidates_json(&options),
+            "page_state": page_state,
+        })));
+    }
+
+    let (target_option, target_text, target_index) = select_target_option(params, &options)?;
+    let keyboard_selected =
+        try_keyboard_select(browser, selector, &target_option.selector, target_index).await?;
+
+    if !keyboard_selected {
+        browser
+            .acquire_bridge()
+            .await
+            .map_err(|e| ToolExecutionError::new(e.to_string()))?
+            .click(&target_option.selector)
+            .await
+            .map_err(|e| ToolExecutionError::new(e.to_string()))?;
+    }
+
+    tokio::time::sleep(VERIFY_WAIT).await;
+    let verified =
+        verify_custom_selection(browser, selector, &target_option.selector, &target_text).await?;
+
+    let seq = super::seq::increment_seq(crawl_state, browser).await;
+    let page_state = super::feedback::post_action_page_state(browser).await;
+
+    if verified {
+        return Ok(ToolEffect::reply_json(&json!({
+            "seq": seq,
+            "success": true,
+            "selected": target_text,
+            "options": option_candidates_json(&options),
+            "page_state": page_state,
+        })));
+    }
+
+    Ok(ToolEffect::reply_json(&json!({
+        "seq": seq,
+        "success": false,
+        "selected": target_text,
+        "message": "Selection could not be verified; returning visible options for retry.",
+        "options": option_candidates_json(&options),
+        "page_state": page_state,
+    })))
+}
+
+async fn check_is_native_select(
+    browser: &mut BrowserContext,
+    selector: &str,
+) -> Result<bool, ToolExecutionError> {
+    let selector_json = js_string(selector)?;
+    let script = format!(
+        r"(() => {{
+            const el = document.querySelector({selector_json});
+            return el ? el.tagName : null;
+        }})()"
+    );
+
+    let result = browser
+        .acquire_bridge()
+        .await
+        .map_err(|e| ToolExecutionError::new(e.to_string()))?
+        .evaluate(&script)
+        .await
+        .map_err(|e| ToolExecutionError::new(e.to_string()))?;
+
+    Ok(evaluate_payload(&result)
+        .as_str()
+        .is_some_and(|tag| tag.eq_ignore_ascii_case("select")))
+}
+
+async fn select_native_by_label(
+    browser: &mut BrowserContext,
+    selector: &str,
+    label: &str,
+) -> Result<(), ToolExecutionError> {
+    let selector_json = js_string(selector)?;
+    let label_json = js_string(label)?;
+    let script = format!(
+        r"(() => {{
+            const select = document.querySelector({selector_json});
+            if (!select) return {{ ok: false, error: 'select_not_found' }};
+            if (select.tagName !== 'SELECT') return {{ ok: false, error: 'not_select' }};
+
+            const normalizedTarget = {label_json}.trim().toLowerCase();
+            const index = Array.from(select.options).findIndex((option) =>
+                (option.textContent || '').trim().toLowerCase() === normalizedTarget
+            );
+
+            if (index < 0) return {{ ok: false, error: 'label_not_found' }};
+
+            select.selectedIndex = index;
+            select.dispatchEvent(new Event('input', {{ bubbles: true }}));
+            select.dispatchEvent(new Event('change', {{ bubbles: true }}));
+            return {{ ok: true }};
+        }})()"
+    );
+
+    let result = browser
+        .acquire_bridge()
+        .await
+        .map_err(|e| ToolExecutionError::new(e.to_string()))?
+        .evaluate(&script)
+        .await
+        .map_err(|e| ToolExecutionError::new(e.to_string()))?;
+
+    if evaluate_payload(&result)
+        .get("ok")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return Ok(());
+    }
+
+    let error = evaluate_payload(&result)
+        .get("error")
+        .and_then(Value::as_str)
+        .unwrap_or("label_not_found");
+    Err(ToolExecutionError::new(format!(
+        "native select option with label '{label}' not found ({error})"
+    )))
+}
+
+async fn select_native_by_index(
+    browser: &mut BrowserContext,
+    selector: &str,
+    index: usize,
+) -> Result<(), ToolExecutionError> {
+    let selector_json = js_string(selector)?;
+    let script = format!(
+        r"(() => {{
+            const select = document.querySelector({selector_json});
+            if (!select) return {{ ok: false, error: 'select_not_found' }};
+            if (select.tagName !== 'SELECT') return {{ ok: false, error: 'not_select' }};
+            const index = {index};
+            if (index < 0 || index >= select.options.length) {{
+                return {{ ok: false, error: 'index_out_of_range' }};
+            }}
+
+            select.selectedIndex = index;
+            select.dispatchEvent(new Event('input', {{ bubbles: true }}));
+            select.dispatchEvent(new Event('change', {{ bubbles: true }}));
+            return {{ ok: true }};
+        }})()"
+    );
+
+    let result = browser
+        .acquire_bridge()
+        .await
+        .map_err(|e| ToolExecutionError::new(e.to_string()))?
+        .evaluate(&script)
+        .await
+        .map_err(|e| ToolExecutionError::new(e.to_string()))?;
+
+    if evaluate_payload(&result)
+        .get("ok")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return Ok(());
+    }
+
+    let error = evaluate_payload(&result)
+        .get("error")
+        .and_then(Value::as_str)
+        .unwrap_or("index_out_of_range");
+    Err(ToolExecutionError::new(format!(
+        "native select option index {index} could not be selected ({error})"
+    )))
+}
+
+async fn get_native_options(
+    browser: &mut BrowserContext,
+    selector: &str,
+) -> Result<Vec<OptionCandidate>, ToolExecutionError> {
+    let selector_json = js_string(selector)?;
+    let script = format!(
+        r"(() => {{
+            const select = document.querySelector({selector_json});
+            if (!select || select.tagName !== 'SELECT') return [];
+
+            return Array.from(select.options).map((option, index) => {{
+                const optionSelector = option.id
+                    ? '#' + CSS.escape(option.id)
+                    : {selector_json} + ' > option:nth-of-type(' + (index + 1) + ')';
+                return {{
+                    name: (option.textContent || '').trim(),
+                    selector: optionSelector,
+                    role: 'option',
+                    aria_selected: option.selected ? 'true' : null,
+                    disabled: option.disabled,
+                }};
+            }});
+        }})()"
+    );
+
+    let result = browser
+        .acquire_bridge()
+        .await
+        .map_err(|e| ToolExecutionError::new(e.to_string()))?
+        .evaluate(&script)
+        .await
+        .map_err(|e| ToolExecutionError::new(e.to_string()))?;
+
+    Ok(parse_option_candidates(&result))
+}
+
+async fn open_custom_dropdown(
+    browser: &mut BrowserContext,
+    selector: &str,
+    before: &[RawElementFacts],
+) -> Result<(), ToolExecutionError> {
+    let already_open = trigger_facts_for_selector(selector, before)
+        .and_then(|facts| facts.aria_expanded.as_deref())
+        .is_some_and(|value| value == "true");
+    if already_open {
+        return Ok(());
+    }
+
+    browser
+        .acquire_bridge()
+        .await
+        .map_err(|e| ToolExecutionError::new(e.to_string()))?
+        .click(selector)
+        .await
+        .map_err(|e| ToolExecutionError::new(e.to_string()))?;
+
+    tokio::time::sleep(OPEN_WAIT).await;
+    let after = snapshot_elements(&extract_dom_snapshot(browser).await?)?;
+    if detect_dropdown_opened_from_snapshots(before, &after) {
+        return Ok(());
+    }
+
+    for key in OPEN_KEYS {
+        browser
+            .acquire_bridge()
+            .await
+            .map_err(|e| ToolExecutionError::new(e.to_string()))?
+            .press_key(key, Some(selector))
+            .await
+            .map_err(|e| ToolExecutionError::new(e.to_string()))?;
+
+        tokio::time::sleep(OPEN_WAIT).await;
+        let after = snapshot_elements(&extract_dom_snapshot(browser).await?)?;
+        if detect_dropdown_opened_from_snapshots(before, &after) {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+fn detect_dropdown_opened_from_snapshots(
+    before: &[RawElementFacts],
+    after: &[RawElementFacts],
+) -> bool {
+    let before_selectors = before
+        .iter()
+        .map(|facts| facts.selector.as_str())
+        .collect::<HashSet<_>>();
+
+    let expanded_flip = after.iter().any(|facts| {
+        if facts.aria_expanded.as_deref() != Some("true") {
+            return false;
+        }
+
+        before
+            .iter()
+            .find(|prior| prior.selector == facts.selector)
+            .and_then(|prior| prior.aria_expanded.as_deref())
+            != Some("true")
+    });
+    if expanded_flip {
+        return true;
+    }
+
+    let new_container = after.iter().any(|facts| {
+        is_visible_container(facts) && !before_selectors.contains(facts.selector.as_str())
+    });
+    if new_container {
+        return true;
+    }
+
+    let new_option = after.iter().any(|facts| {
+        is_visible_option(facts) && !before_selectors.contains(facts.selector.as_str())
+    });
+    if new_option {
+        return true;
+    }
+
+    after.iter().any(|facts| {
+        facts.visible && facts.floating && !before_selectors.contains(facts.selector.as_str())
+    })
+}
+
+async fn locate_and_enumerate_options(
+    browser: &mut BrowserContext,
+    selector: &str,
+    before: &[RawElementFacts],
+) -> Result<Vec<OptionCandidate>, ToolExecutionError> {
+    let mut last_options = Vec::new();
+
+    for attempt in 0..MAX_OPTION_ATTEMPTS {
+        let after_snapshot = extract_dom_snapshot(browser).await?;
+        let after = snapshot_elements(&after_snapshot)?;
+
+        let scopes = option_search_scopes(selector, before, &after);
+        for scope in scopes {
+            let mut options = enumerate_options_in_scope(browser, scope.as_deref()).await?;
+            if options.is_empty() {
+                if let Some(scope_selector) = scope.as_deref() {
+                    if scroll_scope_once(browser, scope_selector).await? {
+                        tokio::time::sleep(OPEN_WAIT).await;
+                        options = enumerate_options_in_scope(browser, Some(scope_selector)).await?;
+                    }
+                } else {
+                    options = snapshot_option_candidates(&after);
+                }
+            }
+
+            if !options.is_empty() {
+                return Ok(options);
+            }
+            last_options = options;
+        }
+
+        if attempt + 1 < MAX_OPTION_ATTEMPTS {
+            tokio::time::sleep(OPEN_WAIT).await;
+        }
+    }
+
+    Ok(last_options)
+}
+
+fn option_search_scopes(
+    selector: &str,
+    before: &[RawElementFacts],
+    after: &[RawElementFacts],
+) -> Vec<Option<String>> {
+    let mut scopes = Vec::new();
+    let mut seen = HashSet::new();
+    let mut has_document_scope = false;
+    let before_visible = before
+        .iter()
+        .filter(|facts| facts.visible)
+        .map(|facts| facts.selector.as_str())
+        .collect::<HashSet<_>>();
+
+    let trigger = trigger_facts_for_selector(selector, after)
+        .or_else(|| trigger_facts_for_selector(selector, before));
+
+    if let Some(trigger) = trigger {
+        for id in controlled_ids(trigger) {
+            add_scope(
+                &mut scopes,
+                &mut seen,
+                &mut has_document_scope,
+                Some(format!("#{id}")),
+            );
+        }
+    }
+
+    for facts in after.iter().filter(|facts| is_visible_container(facts)) {
+        add_scope(
+            &mut scopes,
+            &mut seen,
+            &mut has_document_scope,
+            Some(facts.selector.clone()),
+        );
+    }
+
+    for facts in after.iter().filter(|facts| {
+        facts.visible && facts.floating && !before_visible.contains(facts.selector.as_str())
+    }) {
+        add_scope(
+            &mut scopes,
+            &mut seen,
+            &mut has_document_scope,
+            Some(facts.selector.clone()),
+        );
+    }
+
+    add_scope(&mut scopes, &mut seen, &mut has_document_scope, None);
+    scopes
+}
+
+fn add_scope(
+    scopes: &mut Vec<Option<String>>,
+    seen: &mut HashSet<String>,
+    has_document_scope: &mut bool,
+    scope: Option<String>,
+) {
+    match scope {
+        Some(selector) if seen.insert(selector.clone()) => scopes.push(Some(selector)),
+        None if !*has_document_scope => {
+            *has_document_scope = true;
+            scopes.push(None);
+        }
+        Some(_) | None => {}
+    }
+}
+
+async fn enumerate_options_in_scope(
+    browser: &mut BrowserContext,
+    scope: Option<&str>,
+) -> Result<Vec<OptionCandidate>, ToolExecutionError> {
+    let scope_json = match scope {
+        Some(value) => js_string(value)?,
+        None => "null".to_string(),
+    };
+    let script = format!(
+        r#"(() => {{
+            const scopeSelector = {scope_json};
+            const root = scopeSelector ? document.querySelector(scopeSelector) : document;
+            if (!root) return [];
+
+            function cssPath(el) {{
+                if (el.id) return '#' + CSS.escape(el.id);
+                const parts = [];
+                let cur = el;
+                while (cur && cur !== document.body && cur !== document.documentElement) {{
+                    let seg = cur.tagName.toLowerCase();
+                    const parent = cur.parentElement;
+                    if (parent) {{
+                        const sibs = Array.from(parent.children).filter((child) => child.tagName === cur.tagName);
+                        if (sibs.length > 1) seg += ':nth-of-type(' + (sibs.indexOf(cur) + 1) + ')';
+                    }}
+                    parts.unshift(seg);
+                    cur = cur.parentElement;
+                }}
+                return parts.join(' > ');
+            }}
+
+            function isVisible(el) {{
+                const style = getComputedStyle(el);
+                return el.offsetParent !== null && !el.hidden && style.visibility !== 'hidden';
+            }}
+
+            function labelledByText(el) {{
+                const labelledBy = el.getAttribute('aria-labelledby');
+                if (!labelledBy) return '';
+                return labelledBy
+                    .split(/\s+/)
+                    .filter(Boolean)
+                    .map((id) => document.getElementById(id)?.innerText?.trim() || '')
+                    .filter(Boolean)
+                    .join(' ')
+                    .trim();
+            }}
+
+            return Array.from(root.querySelectorAll('[role="option"], [role="menuitem"], [role="treeitem"], li'))
+                .filter((el) => isVisible(el))
+                .map((el) => {{
+                    const name = (
+                        (el.innerText || '').trim() ||
+                        el.getAttribute('aria-label') ||
+                        labelledByText(el) ||
+                        el.getAttribute('title') ||
+                        ''
+                    ).trim().slice(0, 120);
+                    return {{
+                        name,
+                        selector: cssPath(el),
+                        role: el.getAttribute('role'),
+                        aria_selected: el.getAttribute('aria-selected'),
+                        disabled: el.matches('[disabled], [aria-disabled="true"]'),
+                    }};
+                }})
+                .filter((option) => option.name && option.selector);
+        }})()"#
+    );
+
+    let result = browser
+        .acquire_bridge()
+        .await
+        .map_err(|e| ToolExecutionError::new(e.to_string()))?
+        .evaluate(&script)
+        .await
+        .map_err(|e| ToolExecutionError::new(e.to_string()))?;
+
+    Ok(parse_option_candidates(&result))
+}
+
+async fn scroll_scope_once(
+    browser: &mut BrowserContext,
+    scope: &str,
+) -> Result<bool, ToolExecutionError> {
+    let scope_json = js_string(scope)?;
+    let script = format!(
+        r"(() => {{
+            const root = document.querySelector({scope_json});
+            if (!root) return false;
+            root.scrollTop = root.scrollHeight;
+            return true;
+        }})()"
+    );
+
+    let result = browser
+        .acquire_bridge()
+        .await
+        .map_err(|e| ToolExecutionError::new(e.to_string()))?
+        .evaluate(&script)
+        .await
+        .map_err(|e| ToolExecutionError::new(e.to_string()))?;
+
+    Ok(evaluate_payload(&result).as_bool().unwrap_or(false))
+}
+
+fn select_target_option<'a>(
+    params: &'a SelectOptionInput,
+    options: &'a [OptionCandidate],
+) -> Result<(&'a OptionCandidate, String, usize), ToolExecutionError> {
+    if let Some(index) = params.index {
+        let option = options.get(index).ok_or_else(|| {
+            ToolExecutionError::new(format!(
+                "option index {index} is out of range; available indices: 0..{}",
+                options.len().saturating_sub(1)
+            ))
+        })?;
+        return Ok((option, option.name.clone(), index));
+    }
+
+    let target_text = params
+        .label
+        .as_deref()
+        .or(params.value.as_deref())
+        .unwrap_or_default()
+        .to_string();
+
+    let pairs = options
+        .iter()
+        .map(|option| (option.name.clone(), option.selector.clone()))
+        .collect::<Vec<_>>();
+    let (best_selector, _) =
+        crate::semantic::match_text(&target_text, &pairs, None).ok_or_else(|| {
+            ToolExecutionError::new(format!(
+                "option '{target_text}' not found. Available: {:?}",
+                options
+                    .iter()
+                    .map(|option| option.name.as_str())
+                    .collect::<Vec<_>>()
+            ))
+        })?;
+
+    let index = options
+        .iter()
+        .position(|option| option.selector == best_selector)
+        .ok_or_else(|| {
+            ToolExecutionError::new("matched option selector disappeared before selection")
+        })?;
+
+    Ok((&options[index], target_text, index))
+}
+
+async fn try_keyboard_select(
+    browser: &mut BrowserContext,
+    trigger_selector: &str,
+    target_selector: &str,
+    target_index: usize,
+) -> Result<bool, ToolExecutionError> {
+    if is_target_active(browser, trigger_selector, target_selector).await? {
+        browser
+            .acquire_bridge()
+            .await
+            .map_err(|e| ToolExecutionError::new(e.to_string()))?
+            .press_key("Enter", Some(trigger_selector))
+            .await
+            .map_err(|e| ToolExecutionError::new(e.to_string()))?;
+        return Ok(true);
+    }
+
+    for _ in 0..=target_index {
+        browser
+            .acquire_bridge()
+            .await
+            .map_err(|e| ToolExecutionError::new(e.to_string()))?
+            .press_key("ArrowDown", Some(trigger_selector))
+            .await
+            .map_err(|e| ToolExecutionError::new(e.to_string()))?;
+        tokio::time::sleep(VERIFY_WAIT).await;
+
+        if is_target_active(browser, trigger_selector, target_selector).await? {
+            browser
+                .acquire_bridge()
+                .await
+                .map_err(|e| ToolExecutionError::new(e.to_string()))?
+                .press_key("Enter", Some(trigger_selector))
+                .await
+                .map_err(|e| ToolExecutionError::new(e.to_string()))?;
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+async fn is_target_active(
+    browser: &mut BrowserContext,
+    trigger_selector: &str,
+    target_selector: &str,
+) -> Result<bool, ToolExecutionError> {
+    let trigger_json = js_string(trigger_selector)?;
+    let target_json = js_string(target_selector)?;
+    let script = format!(
+        r"(() => {{
+            const trigger = document.querySelector({trigger_json});
+            const target = document.querySelector({target_json});
+            if (!trigger || !target) return false;
+
+            const activeId = trigger.getAttribute('aria-activedescendant');
+            if (activeId && target.id && activeId === target.id) return true;
+            if (target.getAttribute('aria-selected') === 'true') return true;
+            return document.activeElement === target;
+        }})()"
+    );
+
+    let result = browser
+        .acquire_bridge()
+        .await
+        .map_err(|e| ToolExecutionError::new(e.to_string()))?
+        .evaluate(&script)
+        .await
+        .map_err(|e| ToolExecutionError::new(e.to_string()))?;
+
+    Ok(evaluate_payload(&result).as_bool().unwrap_or(false))
+}
+
+async fn verify_custom_selection(
+    browser: &mut BrowserContext,
+    trigger_selector: &str,
+    target_selector: &str,
+    target_text: &str,
+) -> Result<bool, ToolExecutionError> {
+    let trigger_json = js_string(trigger_selector)?;
+    let target_json = js_string(target_selector)?;
+    let target_text_json = js_string(target_text)?;
+    let script = format!(
+        r"(() => {{
+            const trigger = document.querySelector({trigger_json});
+            const target = document.querySelector({target_json});
+            const targetText = {target_text_json}.trim().toLowerCase();
+            if (!trigger) return false;
+
+            const triggerTexts = [
+                trigger.innerText || '',
+                trigger.textContent || '',
+                trigger.getAttribute('aria-label') || '',
+                'value' in trigger ? String(trigger.value || '') : ''
+            ]
+                .map((value) => value.trim().toLowerCase())
+                .filter(Boolean);
+            if (triggerTexts.some((value) => value.includes(targetText))) return true;
+
+            if (target && target.getAttribute('aria-selected') === 'true') return true;
+
+            const controlledIds = [trigger.getAttribute('aria-controls'), trigger.getAttribute('aria-owns')]
+                .filter(Boolean)
+                .flatMap((value) => value.split(/\s+/).filter(Boolean));
+            if (controlledIds.length > 0) {{
+                const stillVisible = controlledIds.some((id) => {{
+                    const node = document.getElementById(id);
+                    if (!node) return false;
+                    const style = getComputedStyle(node);
+                    return node.offsetParent !== null && !node.hidden && style.visibility !== 'hidden';
+                }});
+                if (!stillVisible) return true;
+            }}
+
+            return false;
+        }})()"
+    );
+
+    let result = browser
+        .acquire_bridge()
+        .await
+        .map_err(|e| ToolExecutionError::new(e.to_string()))?
+        .evaluate(&script)
+        .await
+        .map_err(|e| ToolExecutionError::new(e.to_string()))?;
+
+    Ok(evaluate_payload(&result).as_bool().unwrap_or(false))
+}
+
+async fn extract_dom_snapshot(browser: &mut BrowserContext) -> Result<Value, ToolExecutionError> {
+    browser
+        .acquire_bridge()
+        .await
+        .map_err(|e| ToolExecutionError::new(e.to_string()))?
+        .extract_dom_snapshot(None)
+        .await
+        .map_err(|e| ToolExecutionError::new(e.to_string()))
+}
+
+fn snapshot_elements(snapshot: &Value) -> Result<Vec<RawElementFacts>, ToolExecutionError> {
+    serde_json::from_value(
+        snapshot
+            .get("elements")
+            .cloned()
+            .unwrap_or_else(|| json!([])),
+    )
+    .map_err(|e| ToolExecutionError::new(format!("failed to parse DOM snapshot: {e}")))
+}
+
+fn trigger_facts_for_selector<'a>(
+    selector: &str,
+    facts: &'a [RawElementFacts],
+) -> Option<&'a RawElementFacts> {
+    facts.iter().find(|facts| facts.selector == selector)
+}
+
+fn controlled_ids(trigger: &RawElementFacts) -> Vec<String> {
+    [
+        trigger.aria_controls.as_deref(),
+        trigger.aria_owns.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    .flat_map(|value| value.split_whitespace())
+    .filter(|value| !value.is_empty())
+    .map(str::to_string)
+    .collect()
+}
+
+fn snapshot_option_candidates(facts: &[RawElementFacts]) -> Vec<OptionCandidate> {
+    facts
+        .iter()
+        .filter(|facts| is_visible_option(facts))
+        .map(|facts| OptionCandidate {
+            name: compute_accessible_name(facts),
+            selector: facts.selector.clone(),
+            role: facts.role.clone(),
+            aria_selected: facts.aria_selected.clone(),
+            disabled: false,
+        })
+        .filter(|option| !option.name.is_empty())
+        .collect()
+}
+
+fn parse_option_candidates(raw: &Value) -> Vec<OptionCandidate> {
+    evaluate_payload(raw)
+        .as_array()
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| {
+                    let name = item.get("name").and_then(Value::as_str)?.trim().to_string();
+                    let selector = item
+                        .get("selector")
+                        .and_then(Value::as_str)?
+                        .trim()
+                        .to_string();
+                    if name.is_empty() || selector.is_empty() {
+                        return None;
+                    }
+
+                    Some(OptionCandidate {
+                        name,
+                        selector,
+                        role: item.get("role").and_then(Value::as_str).map(str::to_string),
+                        aria_selected: item
+                            .get("aria_selected")
+                            .and_then(Value::as_str)
+                            .map(str::to_string),
+                        disabled: item
+                            .get("disabled")
+                            .and_then(Value::as_bool)
+                            .unwrap_or(false),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn option_candidates_json(options: &[OptionCandidate]) -> Value {
+    Value::Array(
+        options
+            .iter()
+            .map(|option| {
+                json!({
+                    "name": option.name,
+                    "selector": option.selector,
+                    "role": option.role,
+                    "aria_selected": option.aria_selected,
+                    "disabled": option.disabled,
+                })
+            })
+            .collect(),
+    )
+}
+
+fn evaluate_payload(value: &Value) -> &Value {
+    value.get("value").unwrap_or(value)
+}
+
+fn js_string(value: &str) -> Result<String, ToolExecutionError> {
+    serde_json::to_string(value).map_err(|e| ToolExecutionError::new(e.to_string()))
+}
+
+fn is_visible_container(facts: &RawElementFacts) -> bool {
+    facts.visible && matches!(facts.role.as_deref(), Some("listbox" | "menu" | "menubar"))
+}
+
+fn is_visible_option(facts: &RawElementFacts) -> bool {
+    facts.visible
+        && matches!(
+            facts.role.as_deref(),
+            Some("option" | "menuitem" | "treeitem")
+        )
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+    use std::sync::{Arc, Mutex};
+
+    use async_trait::async_trait;
+    use browser::{
+        BridgeError, BrowserBackend, BrowserState, ObservationEvent, PageInfo, ScreenshotOptions,
+        SharedBridge, StorageEntry, StorageType,
+    };
     use serde_json::json;
+    use tokio::sync::Mutex as AsyncMutex;
 
     use super::*;
+
+    #[derive(Debug, Default)]
+    struct MockState {
+        evaluate_results: VecDeque<Value>,
+        snapshot_results: VecDeque<Value>,
+        clicks: Vec<String>,
+        keypresses: Vec<(String, Option<String>)>,
+        native_selects: Vec<(String, String)>,
+        evaluate_scripts: Vec<String>,
+    }
+
+    #[derive(Debug, Clone)]
+    struct MockBackend {
+        state: Arc<Mutex<MockState>>,
+    }
+
+    impl MockBackend {
+        fn new(state: Arc<Mutex<MockState>>) -> Self {
+            Self { state }
+        }
+    }
+
+    #[async_trait]
+    impl BrowserBackend for MockBackend {
+        async fn navigate(&mut self, _url: &str) -> Result<PageInfo, BridgeError> {
+            Ok(PageInfo {
+                title: "Test".to_string(),
+                html: String::new(),
+            })
+        }
+
+        async fn new_page(&mut self, _url: Option<&str>) -> Result<usize, BridgeError> {
+            Ok(0)
+        }
+
+        async fn close_page(&mut self, _page_index: usize) -> Result<(), BridgeError> {
+            Ok(())
+        }
+
+        async fn scroll(&mut self, _direction: &str, _pixels: i64) -> Result<(), BridgeError> {
+            Ok(())
+        }
+
+        async fn page_map(
+            &mut self,
+            _scope: Option<&str>,
+            _compound_enrichment: bool,
+        ) -> Result<Value, BridgeError> {
+            Ok(json!({
+                "headings": [],
+                "landmarks": [],
+                "forms": [],
+                "links": [],
+                "interactive": {},
+                "meta": {"title": "Test", "url": "https://example.com", "description": ""}
+            }))
+        }
+
+        async fn read_content(
+            &mut self,
+            _heading: Option<&str>,
+            _selector: Option<&str>,
+            _offset: usize,
+            _max_chars: usize,
+        ) -> Result<Value, BridgeError> {
+            Ok(json!({}))
+        }
+
+        async fn wait_for_selector(
+            &mut self,
+            _selector: &str,
+            _timeout_ms: u64,
+            _state: Option<&str>,
+        ) -> Result<bool, BridgeError> {
+            Ok(true)
+        }
+
+        async fn select_option(&mut self, selector: &str, value: &str) -> Result<(), BridgeError> {
+            self.state
+                .lock()
+                .unwrap()
+                .native_selects
+                .push((selector.to_string(), value.to_string()));
+            Ok(())
+        }
+
+        async fn evaluate(&mut self, script: &str) -> Result<Value, BridgeError> {
+            let mut state = self.state.lock().unwrap();
+            state.evaluate_scripts.push(script.to_string());
+            Ok(state.evaluate_results.pop_front().unwrap_or(Value::Null))
+        }
+
+        async fn hover(&mut self, _selector: &str) -> Result<(), BridgeError> {
+            Ok(())
+        }
+
+        async fn press_key(
+            &mut self,
+            key: &str,
+            selector: Option<&str>,
+        ) -> Result<(), BridgeError> {
+            self.state
+                .lock()
+                .unwrap()
+                .keypresses
+                .push((key.to_string(), selector.map(str::to_string)));
+            Ok(())
+        }
+
+        async fn switch_tab(&mut self, _index: i64) -> Result<Value, BridgeError> {
+            Ok(json!({"ok": true}))
+        }
+
+        async fn export_cookies(&mut self) -> Result<BrowserState, BridgeError> {
+            Ok(BrowserState {
+                cookies: Value::Array(Vec::new()),
+                local_storage: Value::Object(serde_json::Map::new()),
+                url: String::new(),
+            })
+        }
+
+        async fn import_cookies(&mut self, _state: &BrowserState) -> Result<(), BridgeError> {
+            Ok(())
+        }
+
+        async fn import_cookies_only(&mut self, _state: &BrowserState) -> Result<(), BridgeError> {
+            Ok(())
+        }
+
+        async fn import_local_storage(&mut self, _state: &BrowserState) -> Result<(), BridgeError> {
+            Ok(())
+        }
+
+        async fn list_resources(&mut self) -> Result<Value, BridgeError> {
+            Ok(json!([]))
+        }
+
+        async fn save_file(&mut self, _url: &str, _path: &str) -> Result<String, BridgeError> {
+            Ok(String::new())
+        }
+
+        async fn click(&mut self, selector: &str) -> Result<(), BridgeError> {
+            self.state.lock().unwrap().clicks.push(selector.to_string());
+            Ok(())
+        }
+
+        async fn click_at(&mut self, _x: f64, _y: f64) -> Result<(), BridgeError> {
+            Ok(())
+        }
+
+        async fn fill(&mut self, _selector: &str, _value: &str) -> Result<(), BridgeError> {
+            Ok(())
+        }
+
+        async fn screenshot(
+            &mut self,
+            _options: &ScreenshotOptions<'_>,
+        ) -> Result<(String, usize), BridgeError> {
+            Ok((String::new(), 0))
+        }
+
+        async fn go_back(&mut self) -> Result<String, BridgeError> {
+            Ok(String::new())
+        }
+
+        async fn set_device(&mut self, _options: &Value) -> Result<Value, BridgeError> {
+            Ok(json!({}))
+        }
+
+        async fn extract_dom_snapshot(
+            &mut self,
+            _scope: Option<&str>,
+        ) -> Result<Value, BridgeError> {
+            Ok(self
+                .state
+                .lock()
+                .unwrap()
+                .snapshot_results
+                .pop_front()
+                .unwrap_or_else(|| json!({"elements": []})))
+        }
+
+        async fn poll_observations(&mut self) -> Result<Vec<ObservationEvent>, BridgeError> {
+            Ok(Vec::new())
+        }
+
+        async fn set_seq(&mut self, _seq: u64) -> Result<(), BridgeError> {
+            Ok(())
+        }
+
+        async fn get_storage(
+            &mut self,
+            _storage_type: StorageType,
+        ) -> Result<(Vec<StorageEntry>, Vec<StorageEntry>), BridgeError> {
+            Ok((Vec::new(), Vec::new()))
+        }
+    }
+
+    fn make_browser(state: Arc<Mutex<MockState>>) -> BrowserContext {
+        let bridge: SharedBridge = Arc::new(AsyncMutex::new(
+            Box::new(MockBackend::new(state)) as Box<dyn BrowserBackend + Send>
+        ));
+        BrowserContext::new(bridge)
+    }
+
+    fn effect_json(effect: ToolEffect) -> Value {
+        match effect {
+            ToolEffect::Reply(body) => serde_json::from_str(&body).unwrap(),
+            other => panic!("expected reply effect, got {other:?}"),
+        }
+    }
+
+    fn snapshot(elements: Vec<Value>) -> Value {
+        Value::Object(
+            [("elements".to_string(), Value::Array(elements))]
+                .into_iter()
+                .collect(),
+        )
+    }
 
     #[test]
     fn parses_selector_and_value() {
         let input = json!({"selector": "#country", "value": "US"});
         let parsed = parse_input(&input).unwrap();
         assert_eq!(parsed.selector, "#country");
-        assert_eq!(parsed.value, "US");
+        assert_eq!(parsed.value.as_deref(), Some("US"));
+        assert_eq!(parsed.label, None);
+        assert_eq!(parsed.index, None);
     }
 
     #[test]
     fn accepts_label_as_value() {
         let input = json!({"selector": "select.lang", "label": "English"});
         let parsed = parse_input(&input).unwrap();
-        assert_eq!(parsed.value, "English");
+        assert_eq!(parsed.value, None);
+        assert_eq!(parsed.label.as_deref(), Some("English"));
+    }
+
+    #[test]
+    fn accepts_index_and_list_mode() {
+        let with_index = parse_input(&json!({"selector": "#country", "index": 2})).unwrap();
+        assert_eq!(with_index.index, Some(2));
+
+        let list_mode = parse_input(&json!({"selector": "#country"})).unwrap();
+        assert_eq!(list_mode.value, None);
+        assert_eq!(list_mode.label, None);
+        assert_eq!(list_mode.index, None);
     }
 
     #[test]
     fn fails_without_selector() {
         let input = json!({"value": "US"});
-        assert!(parse_input(&input).is_err());
-    }
-
-    #[test]
-    fn fails_without_value() {
-        let input = json!({"selector": "#country"});
         assert!(parse_input(&input).is_err());
     }
 
@@ -102,5 +1247,528 @@ mod tests {
         assert!(response["page_state"]["url"].is_string());
         assert!(response["page_state"]["title"].is_string());
         assert!(!response["page_state"]["page_map"].is_null());
+    }
+
+    #[tokio::test]
+    async fn check_is_native_select_recognizes_select_tag() {
+        let state = Arc::new(Mutex::new(MockState {
+            evaluate_results: VecDeque::from(vec![json!({"value": "SELECT"})]),
+            ..MockState::default()
+        }));
+        let mut browser = make_browser(state);
+
+        assert!(check_is_native_select(&mut browser, "#country")
+            .await
+            .unwrap());
+    }
+
+    #[tokio::test]
+    async fn check_is_native_select_rejects_non_select_tag() {
+        let state = Arc::new(Mutex::new(MockState {
+            evaluate_results: VecDeque::from(vec![json!({"value": "DIV"})]),
+            ..MockState::default()
+        }));
+        let mut browser = make_browser(state);
+
+        assert!(!check_is_native_select(&mut browser, "#country")
+            .await
+            .unwrap());
+    }
+
+    #[test]
+    fn detect_dropdown_opened_on_all_supported_signals() {
+        let before = vec![RawElementFacts {
+            tag: "button".to_string(),
+            role: Some("combobox".to_string()),
+            aria_expanded: Some("false".to_string()),
+            aria_selected: None,
+            aria_pressed: None,
+            aria_controls: Some("city-list".to_string()),
+            aria_owns: None,
+            text: Some("Choose city".to_string()),
+            aria_label: None,
+            aria_labelledby_text: None,
+            title: None,
+            placeholder: None,
+            name: None,
+            visible: true,
+            floating: false,
+            selector: "#city-trigger".to_string(),
+        }];
+
+        let after_aria = vec![RawElementFacts {
+            aria_expanded: Some("true".to_string()),
+            ..before[0].clone()
+        }];
+        assert!(detect_dropdown_opened_from_snapshots(&before, &after_aria));
+
+        let after_listbox = vec![
+            before[0].clone(),
+            RawElementFacts {
+                tag: "div".to_string(),
+                role: Some("listbox".to_string()),
+                aria_expanded: None,
+                aria_selected: None,
+                aria_pressed: None,
+                aria_controls: None,
+                aria_owns: None,
+                text: None,
+                aria_label: None,
+                aria_labelledby_text: None,
+                title: None,
+                placeholder: None,
+                name: None,
+                visible: true,
+                floating: false,
+                selector: "#city-list".to_string(),
+            },
+        ];
+        assert!(detect_dropdown_opened_from_snapshots(
+            &before,
+            &after_listbox
+        ));
+
+        let after_option = vec![
+            before[0].clone(),
+            RawElementFacts {
+                tag: "div".to_string(),
+                role: Some("option".to_string()),
+                aria_expanded: None,
+                aria_selected: None,
+                aria_pressed: None,
+                aria_controls: None,
+                aria_owns: None,
+                text: Some("Paris".to_string()),
+                aria_label: None,
+                aria_labelledby_text: None,
+                title: None,
+                placeholder: None,
+                name: None,
+                visible: true,
+                floating: false,
+                selector: "#city-list-option-1".to_string(),
+            },
+        ];
+        assert!(detect_dropdown_opened_from_snapshots(
+            &before,
+            &after_option
+        ));
+
+        let after_floating = vec![
+            before[0].clone(),
+            RawElementFacts {
+                tag: "div".to_string(),
+                role: None,
+                aria_expanded: None,
+                aria_selected: None,
+                aria_pressed: None,
+                aria_controls: None,
+                aria_owns: None,
+                text: None,
+                aria_label: None,
+                aria_labelledby_text: None,
+                title: None,
+                placeholder: None,
+                name: None,
+                visible: true,
+                floating: true,
+                selector: "#overlay".to_string(),
+            },
+        ];
+        assert!(detect_dropdown_opened_from_snapshots(
+            &before,
+            &after_floating
+        ));
+    }
+
+    #[test]
+    fn parses_option_candidates_from_evaluate_json() {
+        let raw = json!({
+            "value": [
+                {"name": "English", "selector": "#opt-en", "role": "option", "aria_selected": "true", "disabled": false},
+                {"name": "French", "selector": "#opt-fr", "role": "option", "aria_selected": null, "disabled": true}
+            ]
+        });
+
+        let options = parse_option_candidates(&raw);
+        assert_eq!(options.len(), 2);
+        assert_eq!(options[0].name, "English");
+        assert_eq!(options[0].selector, "#opt-en");
+        assert_eq!(options[0].aria_selected.as_deref(), Some("true"));
+        assert!(options[1].disabled);
+    }
+
+    #[test]
+    fn option_search_scopes_prefers_aria_controls_and_keeps_document_fallback() {
+        let before = vec![RawElementFacts {
+            tag: "button".to_string(),
+            role: Some("combobox".to_string()),
+            aria_expanded: Some("false".to_string()),
+            aria_selected: None,
+            aria_pressed: None,
+            aria_controls: Some("portal-list".to_string()),
+            aria_owns: None,
+            text: Some("Language".to_string()),
+            aria_label: None,
+            aria_labelledby_text: None,
+            title: None,
+            placeholder: None,
+            name: None,
+            visible: true,
+            floating: false,
+            selector: "#lang-trigger".to_string(),
+        }];
+        let after = vec![
+            RawElementFacts {
+                aria_expanded: Some("true".to_string()),
+                ..before[0].clone()
+            },
+            RawElementFacts {
+                tag: "div".to_string(),
+                role: Some("listbox".to_string()),
+                aria_expanded: None,
+                aria_selected: None,
+                aria_pressed: None,
+                aria_controls: None,
+                aria_owns: None,
+                text: None,
+                aria_label: None,
+                aria_labelledby_text: None,
+                title: None,
+                placeholder: None,
+                name: None,
+                visible: true,
+                floating: true,
+                selector: "#portal-list".to_string(),
+            },
+        ];
+
+        let scopes = option_search_scopes("#lang-trigger", &before, &after);
+        assert_eq!(scopes.first(), Some(&Some("#portal-list".to_string())));
+        assert_eq!(scopes.last(), Some(&None));
+    }
+
+    #[test]
+    fn match_text_returns_best_option_selector() {
+        let options = [
+            OptionCandidate {
+                name: "United States".to_string(),
+                selector: "#opt-us".to_string(),
+                role: Some("option".to_string()),
+                aria_selected: None,
+                disabled: false,
+            },
+            OptionCandidate {
+                name: "United Kingdom".to_string(),
+                selector: "#opt-uk".to_string(),
+                role: Some("option".to_string()),
+                aria_selected: None,
+                disabled: false,
+            },
+        ];
+
+        let pairs: Vec<(String, String)> = options
+            .iter()
+            .map(|option| (option.name.clone(), option.selector.clone()))
+            .collect();
+        let (best, _) = crate::semantic::match_text("united kingdom", &pairs, None).unwrap();
+        assert_eq!(best, "#opt-uk");
+    }
+
+    #[tokio::test]
+    async fn list_options_mode_returns_options_without_selecting() {
+        let state = Arc::new(Mutex::new(MockState {
+            evaluate_results: VecDeque::from(vec![
+                json!({"value": "DIV"}),
+                json!({"value": [
+                    {"name": "English", "selector": "#opt-en", "role": "option", "aria_selected": null, "disabled": false},
+                    {"name": "French", "selector": "#opt-fr", "role": "option", "aria_selected": null, "disabled": false}
+                ]}),
+            ]),
+            snapshot_results: VecDeque::from(vec![
+                snapshot(vec![json!({
+                    "tag": "button",
+                    "role": "combobox",
+                    "aria_expanded": "false",
+                    "aria_selected": null,
+                    "aria_pressed": null,
+                    "aria_controls": "lang-list",
+                    "aria_owns": null,
+                    "text": "Language",
+                    "aria_label": null,
+                    "aria_labelledby_text": null,
+                    "title": null,
+                    "placeholder": null,
+                    "name": null,
+                    "visible": true,
+                    "floating": false,
+                    "selector": "#lang-trigger"
+                })]),
+                snapshot(vec![
+                    json!({
+                        "tag": "button",
+                        "role": "combobox",
+                        "aria_expanded": "true",
+                        "aria_selected": null,
+                        "aria_pressed": null,
+                        "aria_controls": "lang-list",
+                        "aria_owns": null,
+                        "text": "Language",
+                        "aria_label": null,
+                        "aria_labelledby_text": null,
+                        "title": null,
+                        "placeholder": null,
+                        "name": null,
+                        "visible": true,
+                        "floating": false,
+                        "selector": "#lang-trigger"
+                    }),
+                    json!({
+                        "tag": "div",
+                        "role": "listbox",
+                        "aria_expanded": null,
+                        "aria_selected": null,
+                        "aria_pressed": null,
+                        "aria_controls": null,
+                        "aria_owns": null,
+                        "text": null,
+                        "aria_label": null,
+                        "aria_labelledby_text": null,
+                        "title": null,
+                        "placeholder": null,
+                        "name": null,
+                        "visible": true,
+                        "floating": true,
+                        "selector": "#lang-list"
+                    }),
+                ]),
+            ]),
+            ..MockState::default()
+        }));
+        let mut browser = make_browser(state.clone());
+
+        let effect = execute(
+            &json!({"selector": "#lang-trigger"}),
+            &mut browser,
+            &CrawlState::default(),
+        )
+        .await
+        .unwrap();
+        let response = effect_json(effect);
+
+        assert_eq!(response["mode"], "list");
+        assert_eq!(response["options"].as_array().unwrap().len(), 2);
+        assert_eq!(state.lock().unwrap().native_selects.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn try_keyboard_select_presses_enter_when_target_becomes_active() {
+        let state = Arc::new(Mutex::new(MockState {
+            evaluate_results: VecDeque::from(vec![json!({"value": false}), json!({"value": true})]),
+            ..MockState::default()
+        }));
+        let mut browser = make_browser(state.clone());
+
+        let selected = try_keyboard_select(&mut browser, "#combo", "#opt-uk", 0)
+            .await
+            .unwrap();
+
+        assert!(selected);
+        assert_eq!(
+            state.lock().unwrap().keypresses,
+            vec![
+                ("ArrowDown".to_string(), Some("#combo".to_string())),
+                ("Enter".to_string(), Some("#combo".to_string())),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn custom_selection_falls_back_to_click_when_keyboard_path_fails() {
+        let state = Arc::new(Mutex::new(MockState {
+            evaluate_results: VecDeque::from(vec![
+                json!({"value": "DIV"}),
+                json!({"value": [
+                    {"name": "English", "selector": "#opt-en", "role": "option", "aria_selected": null, "disabled": false},
+                    {"name": "French", "selector": "#opt-fr", "role": "option", "aria_selected": null, "disabled": false}
+                ]}),
+                json!({"value": false}),
+                json!({"value": false}),
+                json!({"value": false}),
+                json!({"value": true}),
+            ]),
+            snapshot_results: VecDeque::from(vec![
+                snapshot(vec![json!({
+                    "tag": "button",
+                    "role": "combobox",
+                    "aria_expanded": "false",
+                    "aria_selected": null,
+                    "aria_pressed": null,
+                    "aria_controls": "lang-list",
+                    "aria_owns": null,
+                    "text": "Language",
+                    "aria_label": null,
+                    "aria_labelledby_text": null,
+                    "title": null,
+                    "placeholder": null,
+                    "name": null,
+                    "visible": true,
+                    "floating": false,
+                    "selector": "#lang-trigger"
+                })]),
+                snapshot(vec![
+                    json!({
+                        "tag": "button",
+                        "role": "combobox",
+                        "aria_expanded": "true",
+                        "aria_selected": null,
+                        "aria_pressed": null,
+                        "aria_controls": "lang-list",
+                        "aria_owns": null,
+                        "text": "Language",
+                        "aria_label": null,
+                        "aria_labelledby_text": null,
+                        "title": null,
+                        "placeholder": null,
+                        "name": null,
+                        "visible": true,
+                        "floating": false,
+                        "selector": "#lang-trigger"
+                    }),
+                    json!({
+                        "tag": "div",
+                        "role": "listbox",
+                        "aria_expanded": null,
+                        "aria_selected": null,
+                        "aria_pressed": null,
+                        "aria_controls": null,
+                        "aria_owns": null,
+                        "text": null,
+                        "aria_label": null,
+                        "aria_labelledby_text": null,
+                        "title": null,
+                        "placeholder": null,
+                        "name": null,
+                        "visible": true,
+                        "floating": true,
+                        "selector": "#lang-list"
+                    }),
+                ]),
+            ]),
+            ..MockState::default()
+        }));
+        let mut browser = make_browser(state.clone());
+
+        let effect = execute(
+            &json!({"selector": "#lang-trigger", "label": "French"}),
+            &mut browser,
+            &CrawlState::default(),
+        )
+        .await
+        .unwrap();
+        let response = effect_json(effect);
+
+        assert_eq!(response["success"], true);
+        assert!(state
+            .lock()
+            .unwrap()
+            .clicks
+            .iter()
+            .any(|sel| sel == "#opt-fr"));
+    }
+
+    #[tokio::test]
+    async fn custom_selection_returns_options_when_verification_fails() {
+        let state = Arc::new(Mutex::new(MockState {
+            evaluate_results: VecDeque::from(vec![
+                json!({"value": "DIV"}),
+                json!({"value": [
+                    {"name": "English", "selector": "#opt-en", "role": "option", "aria_selected": null, "disabled": false},
+                    {"name": "French", "selector": "#opt-fr", "role": "option", "aria_selected": null, "disabled": false}
+                ]}),
+                json!({"value": false}),
+                json!({"value": false}),
+                json!({"value": false}),
+                json!({"value": false}),
+            ]),
+            snapshot_results: VecDeque::from(vec![
+                snapshot(vec![json!({
+                    "tag": "button",
+                    "role": "combobox",
+                    "aria_expanded": "false",
+                    "aria_selected": null,
+                    "aria_pressed": null,
+                    "aria_controls": "lang-list",
+                    "aria_owns": null,
+                    "text": "Language",
+                    "aria_label": null,
+                    "aria_labelledby_text": null,
+                    "title": null,
+                    "placeholder": null,
+                    "name": null,
+                    "visible": true,
+                    "floating": false,
+                    "selector": "#lang-trigger"
+                })]),
+                snapshot(vec![
+                    json!({
+                        "tag": "button",
+                        "role": "combobox",
+                        "aria_expanded": "true",
+                        "aria_selected": null,
+                        "aria_pressed": null,
+                        "aria_controls": "lang-list",
+                        "aria_owns": null,
+                        "text": "Language",
+                        "aria_label": null,
+                        "aria_labelledby_text": null,
+                        "title": null,
+                        "placeholder": null,
+                        "name": null,
+                        "visible": true,
+                        "floating": false,
+                        "selector": "#lang-trigger"
+                    }),
+                    json!({
+                        "tag": "div",
+                        "role": "listbox",
+                        "aria_expanded": null,
+                        "aria_selected": null,
+                        "aria_pressed": null,
+                        "aria_controls": null,
+                        "aria_owns": null,
+                        "text": null,
+                        "aria_label": null,
+                        "aria_labelledby_text": null,
+                        "title": null,
+                        "placeholder": null,
+                        "name": null,
+                        "visible": true,
+                        "floating": true,
+                        "selector": "#lang-list"
+                    }),
+                ]),
+            ]),
+            ..MockState::default()
+        }));
+        let mut browser = make_browser(state.clone());
+
+        let effect = execute(
+            &json!({"selector": "#lang-trigger", "label": "French"}),
+            &mut browser,
+            &CrawlState::default(),
+        )
+        .await
+        .unwrap();
+        let response = effect_json(effect);
+
+        assert_eq!(response["success"], false);
+        assert_eq!(response["options"].as_array().unwrap().len(), 2);
+        assert!(state
+            .lock()
+            .unwrap()
+            .clicks
+            .iter()
+            .any(|sel| sel == "#opt-fr"));
     }
 }

--- a/crates/agent/src/tools/select_option.rs
+++ b/crates/agent/src/tools/select_option.rs
@@ -19,6 +19,7 @@ pub struct SelectOptionInput {
     pub value: Option<String>,
     pub label: Option<String>,
     pub index: Option<usize>,
+    pub widen: bool,
 }
 
 pub fn parse_input(input: &Value) -> Result<SelectOptionInput, CrawlError> {
@@ -55,6 +56,7 @@ pub fn parse_input(input: &Value) -> Result<SelectOptionInput, CrawlError> {
             .and_then(Value::as_str)
             .map(str::to_string),
         index,
+        widen: input.get("widen").and_then(Value::as_bool).unwrap_or(false),
     })
 }
 
@@ -105,7 +107,8 @@ async fn execute_native(
         Some(option.name.clone())
     } else {
         let seq = super::seq::increment_seq(crawl_state, browser).await;
-        let page_state = super::feedback::post_action_page_state(browser).await;
+        let page_state =
+            super::feedback::post_action_page_state(browser, Some(selector), params.widen).await;
         return Ok(ToolEffect::reply_json(&json!({
             "seq": seq,
             "success": true,
@@ -116,7 +119,8 @@ async fn execute_native(
     };
 
     let seq = super::seq::increment_seq(crawl_state, browser).await;
-    let page_state = super::feedback::post_action_page_state(browser).await;
+    let page_state =
+        super::feedback::post_action_page_state(browser, Some(selector), params.widen).await;
 
     Ok(ToolEffect::reply_json(&json!({
         "seq": seq,
@@ -147,7 +151,8 @@ async fn execute_custom(
 
     if params.value.is_none() && params.label.is_none() && params.index.is_none() {
         let seq = super::seq::increment_seq(crawl_state, browser).await;
-        let page_state = super::feedback::post_action_page_state(browser).await;
+        let page_state =
+            super::feedback::post_action_page_state(browser, Some(selector), params.widen).await;
         return Ok(ToolEffect::reply_json(&json!({
             "seq": seq,
             "success": true,
@@ -176,7 +181,8 @@ async fn execute_custom(
         verify_custom_selection(browser, selector, &target_option.selector, &target_text).await?;
 
     let seq = super::seq::increment_seq(crawl_state, browser).await;
-    let page_state = super::feedback::post_action_page_state(browser).await;
+    let page_state =
+        super::feedback::post_action_page_state(browser, Some(selector), params.widen).await;
 
     if verified {
         return Ok(ToolEffect::reply_json(&json!({

--- a/crates/agent/src/tools/select_option.rs
+++ b/crates/agent/src/tools/select_option.rs
@@ -592,8 +592,11 @@ async fn enumerate_options_in_scope(
             }}
 
             function isVisible(el) {{
+                if (el.hidden) return false;
                 const style = getComputedStyle(el);
-                return el.offsetParent !== null && !el.hidden && style.visibility !== 'hidden';
+                if (style.display === 'none' || style.visibility === 'hidden') return false;
+                const rect = el.getBoundingClientRect();
+                return rect.width > 0 || rect.height > 0;
             }}
 
             function labelledByText(el) {{

--- a/crates/agent/src/tools/set_device.rs
+++ b/crates/agent/src/tools/set_device.rs
@@ -343,7 +343,7 @@ pub async fn execute(
     crawl_state.action_cache = None;
     crawl_state.current_device = Some(device_name.clone());
 
-    let page_state = super::feedback::post_action_page_state(browser).await;
+    let page_state = super::feedback::post_action_page_state(browser, None, false).await;
 
     Ok(ToolEffect::reply_json(&serde_json::json!({
         "success": true,

--- a/crates/agent/src/tools/switch_tab.rs
+++ b/crates/agent/src/tools/switch_tab.rs
@@ -40,7 +40,7 @@ pub async fn execute(
         .and_then(serde_json::Value::as_i64)
         .unwrap_or(0);
 
-    let page_state = super::feedback::post_action_page_state(browser).await;
+    let page_state = super::feedback::post_action_page_state(browser, None, false).await;
 
     Ok(ToolEffect::reply_json(&json!({
         "success": true,

--- a/crates/agent/src/tools/wait.rs
+++ b/crates/agent/src/tools/wait.rs
@@ -106,7 +106,7 @@ pub async fn execute(
             .await
             .map_err(|e| ToolExecutionError::new(e.to_string()))?;
 
-        let page_state = super::feedback::post_action_page_state(browser).await;
+        let page_state = super::feedback::post_action_page_state(browser, None, false).await;
 
         Ok(ToolEffect::reply_json(&json!({
             "success": true,
@@ -118,7 +118,7 @@ pub async fn execute(
     } else {
         tokio::time::sleep(Duration::from_millis(parsed.timeout_ms)).await;
 
-        let page_state = super::feedback::post_action_page_state(browser).await;
+        let page_state = super::feedback::post_action_page_state(browser, None, false).await;
 
         Ok(ToolEffect::reply_json(&json!({
             "success": true,

--- a/crates/agent/tests/extension_e2e_test.rs
+++ b/crates/agent/tests/extension_e2e_test.rs
@@ -87,8 +87,9 @@ async fn extension_bridge_e2e_tool_routes_through_websocket() {
     respond_to_command(&mut ws, "click", None).await;
     // increment_seq pushes the current seq to the extension bridge
     respond_to_command(&mut ws, "set_seq", None).await;
-    // post_action_page_state: switch_tab + page_map
+    // post_action_page_state: switch_tab + execute_js scope probe + page_map
     respond_to_command(&mut ws, "switch_tab", Some(json!({"url": "", "title": ""}))).await;
+    respond_to_command(&mut ws, "execute_js", Some(json!(null))).await;
     respond_to_command(
         &mut ws,
         "page_map",

--- a/crates/browser/src/browser_backend.rs
+++ b/crates/browser/src/browser_backend.rs
@@ -136,7 +136,9 @@ pub trait BrowserBackend: Debug {
         scope: Option<&str>,
     ) -> Result<serde_json::Value, BridgeError> {
         let _ = scope;
-        Ok(serde_json::json!({ "elements": [] }))
+        Err(BridgeError::Unsupported(
+            "extract_dom_snapshot not implemented for this backend".into(),
+        ))
     }
 
     /// Drains buffered observation events. Required for every backend — no

--- a/crates/browser/src/browser_backend.rs
+++ b/crates/browser/src/browser_backend.rs
@@ -128,6 +128,14 @@ pub trait BrowserBackend: Debug {
         self.page_map(None, false).await
     }
 
+    async fn extract_dom_snapshot(
+        &mut self,
+        scope: Option<&str>,
+    ) -> Result<serde_json::Value, BridgeError> {
+        let _ = scope;
+        Ok(serde_json::json!({ "elements": [] }))
+    }
+
     /// Drains buffered observation events. Required for every backend — no
     /// default impl on purpose: observation tools dispatch through
     /// `dyn BrowserBackend`, so a missing override silently breaks the feature.

--- a/crates/browser/src/browser_backend.rs
+++ b/crates/browser/src/browser_backend.rs
@@ -124,8 +124,11 @@ pub trait BrowserBackend: Debug {
         options: &serde_json::Value,
     ) -> Result<serde_json::Value, BridgeError>;
 
-    async fn page_map_feedback(&mut self) -> Result<serde_json::Value, BridgeError> {
-        self.page_map(None, false).await
+    async fn page_map_feedback(
+        &mut self,
+        scope: Option<&str>,
+    ) -> Result<serde_json::Value, BridgeError> {
+        self.page_map(scope, false).await
     }
 
     async fn extract_dom_snapshot(

--- a/crates/browser/src/context.rs
+++ b/crates/browser/src/context.rs
@@ -137,6 +137,15 @@ impl BrowserContext {
         self.page_snapshots.last().map(|((url, _), _)| url.as_str())
     }
 
+    #[must_use]
+    pub fn last_snapshot_region_selector(&self, handle: &str) -> Option<&str> {
+        self.page_snapshots
+            .last()
+            .and_then(|(_, snapshot)| snapshot.get("regions"))
+            .and_then(Value::as_array)
+            .and_then(|regions| find_region_selector(regions, handle))
+    }
+
     pub fn ref_map_mut(&mut self) -> &mut RefMap {
         &mut self.ref_map
     }
@@ -145,6 +154,24 @@ impl BrowserContext {
     pub fn ref_map(&self) -> &RefMap {
         &self.ref_map
     }
+}
+
+fn find_region_selector<'a>(regions: &'a [Value], handle: &str) -> Option<&'a str> {
+    for region in regions {
+        if region.get("handle").and_then(Value::as_str) == Some(handle) {
+            if let Some(selector) = region.get("selector").and_then(Value::as_str) {
+                return Some(selector);
+            }
+        }
+
+        if let Some(children) = region.get("children").and_then(Value::as_array) {
+            if let Some(selector) = find_region_selector(children, handle) {
+                return Some(selector);
+            }
+        }
+    }
+
+    None
 }
 
 #[cfg(test)]
@@ -237,6 +264,30 @@ mod tests {
         ctx.set_page_snapshot("https://example.com/page2", None, json!({}));
 
         assert_eq!(ctx.snapshot_url(), Some("https://example.com/page2"));
+    }
+
+    #[test]
+    fn last_snapshot_region_selector_finds_nested_region_handle() {
+        let mut ctx = BrowserContext::new(test_bridge());
+
+        ctx.set_page_snapshot(
+            "https://example.com/page2",
+            None,
+            json!({
+                "regions": [{
+                    "handle": "@r1",
+                    "selector": "main",
+                    "children": [{
+                        "handle": "@r2",
+                        "selector": "#dialog",
+                        "children": []
+                    }]
+                }]
+            }),
+        );
+
+        assert_eq!(ctx.last_snapshot_region_selector("@r2"), Some("#dialog"));
+        assert_eq!(ctx.last_snapshot_region_selector("@r99"), None);
     }
 
     #[test]

--- a/crates/browser/src/context.rs
+++ b/crates/browser/src/context.rs
@@ -138,6 +138,11 @@ impl BrowserContext {
     }
 
     #[must_use]
+    pub fn last_page_snapshot(&self) -> Option<&Value> {
+        self.page_snapshots.last().map(|(_, snapshot)| snapshot)
+    }
+
+    #[must_use]
     pub fn last_snapshot_region_selector(&self, handle: &str) -> Option<&str> {
         self.page_snapshots
             .last()

--- a/crates/browser/src/context.rs
+++ b/crates/browser/src/context.rs
@@ -4,15 +4,25 @@ use tokio::sync::MutexGuard;
 use crate::ref_map::RefMap;
 use crate::{BridgeError, BrowserBackend, SharedBridge};
 
+/// Normalize a URL for snapshot storage: strips fragment unless it's a hash-based route.
+fn normalize_url_for_snapshot(url: &str) -> String {
+    match url.split_once('#') {
+        Some((_, frag)) if frag.starts_with('/') || frag.starts_with("!/") => url.to_string(),
+        Some((base, _)) => base.to_string(),
+        None => url.to_string(),
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct BrowserContext {
     bridge: SharedBridge,
     page_index: usize,
     current_url: Option<String>,
     browser_has_url: Option<String>,
-    /// Cached `page_map` from the last post-action feedback, keyed by URL.
+    /// Cached `page_map` snapshots, keyed by (`normalized_url`, `scope_key`).
+    /// `scope_key` is the scope string or "" for `None`. Bounded to 8 entries (LRU/insertion-order eviction).
     /// Used for differential comparison on subsequent same-page interactions.
-    last_page_snapshot: Option<(String, Value)>,
+    page_snapshots: Vec<((String, String), Value)>,
     ref_map: RefMap,
 }
 
@@ -29,7 +39,7 @@ impl BrowserContext {
             page_index,
             current_url: None,
             browser_has_url: None,
-            last_page_snapshot: None,
+            page_snapshots: Vec::new(),
             ref_map: RefMap::new(),
         }
     }
@@ -93,28 +103,38 @@ impl BrowserContext {
         self.page_index = page_index;
     }
 
-    pub fn set_page_snapshot(&mut self, url: String, page_map: Value) {
-        self.last_page_snapshot = Some((url, page_map));
+    pub fn set_page_snapshot(&mut self, url: &str, scope: Option<&str>, page_map: Value) {
+        let normalized_url = normalize_url_for_snapshot(url);
+        let scope_key = scope.unwrap_or("").to_string();
+        let key = (normalized_url, scope_key);
+
+        self.page_snapshots.retain(|(k, _)| k != &key);
+        self.page_snapshots.push((key, page_map));
+
+        if self.page_snapshots.len() > 8 {
+            self.page_snapshots.remove(0);
+        }
     }
 
     #[must_use]
-    pub fn page_snapshot_for_url(&self, url: &str) -> Option<&Value> {
-        self.last_page_snapshot
-            .as_ref()
-            .filter(|(cached_url, _)| cached_url == url)
+    pub fn page_snapshot_for_url(&self, url: &str, scope: Option<&str>) -> Option<&Value> {
+        let normalized_url = normalize_url_for_snapshot(url);
+        let scope_key = scope.unwrap_or("").to_string();
+        let key = (normalized_url, scope_key);
+
+        self.page_snapshots
+            .iter()
+            .find(|(k, _)| k == &key)
             .map(|(_, map)| map)
     }
 
     pub fn clear_page_snapshot(&mut self) {
-        self.last_page_snapshot = None;
+        self.page_snapshots.clear();
     }
 
-    /// Returns the URL of the currently cached page snapshot, if any.
     #[must_use]
     pub fn snapshot_url(&self) -> Option<&str> {
-        self.last_page_snapshot
-            .as_ref()
-            .map(|(url, _)| url.as_str())
+        self.page_snapshots.last().map(|((url, _), _)| url.as_str())
     }
 
     pub fn ref_map_mut(&mut self) -> &mut RefMap {
@@ -124,5 +144,141 @@ impl BrowserContext {
     #[must_use]
     pub fn ref_map(&self) -> &RefMap {
         &self.ref_map
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::NopBridge;
+    use serde_json::json;
+
+    fn test_bridge() -> SharedBridge {
+        std::sync::Arc::new(tokio::sync::Mutex::new(
+            Box::new(NopBridge) as Box<dyn BrowserBackend + Send>
+        ))
+    }
+
+    #[test]
+    fn snapshot_store_retrieve_with_scope_none() {
+        let mut ctx = BrowserContext::new(test_bridge());
+        let value = json!({"test": "data"});
+
+        ctx.set_page_snapshot("https://example.com", None, value.clone());
+
+        let retrieved = ctx.page_snapshot_for_url("https://example.com", None);
+        assert_eq!(retrieved, Some(&value));
+    }
+
+    #[test]
+    fn snapshot_store_retrieve_with_scope() {
+        let mut ctx = BrowserContext::new(test_bridge());
+        let value1 = json!({"scope": "dialog"});
+        let value2 = json!({"scope": "main"});
+
+        ctx.set_page_snapshot("https://example.com", Some("dialog"), value1.clone());
+        ctx.set_page_snapshot("https://example.com", Some("main"), value2.clone());
+
+        assert_eq!(
+            ctx.page_snapshot_for_url("https://example.com", Some("dialog")),
+            Some(&value1)
+        );
+        assert_eq!(
+            ctx.page_snapshot_for_url("https://example.com", Some("main")),
+            Some(&value2)
+        );
+        assert_eq!(ctx.page_snapshot_for_url("https://example.com", None), None);
+    }
+
+    #[test]
+    fn snapshot_different_scopes_independent() {
+        let mut ctx = BrowserContext::new(test_bridge());
+        let value_dialog = json!({"type": "dialog"});
+        let value_none = json!({"type": "none"});
+
+        ctx.set_page_snapshot("https://example.com", Some("dialog"), value_dialog.clone());
+        ctx.set_page_snapshot("https://example.com", None, value_none.clone());
+
+        assert_eq!(
+            ctx.page_snapshot_for_url("https://example.com", Some("dialog")),
+            Some(&value_dialog)
+        );
+        assert_eq!(
+            ctx.page_snapshot_for_url("https://example.com", None),
+            Some(&value_none)
+        );
+    }
+
+    #[test]
+    fn snapshot_eviction_at_8_entries() {
+        let mut ctx = BrowserContext::new(test_bridge());
+
+        for i in 0..9 {
+            let url = format!("https://example.com/page{i}");
+            let value = json!({"page": i});
+            ctx.set_page_snapshot(&url, None, value);
+        }
+
+        assert_eq!(ctx.page_snapshots.len(), 8);
+        assert_eq!(
+            ctx.page_snapshot_for_url("https://example.com/page0", None),
+            None
+        );
+        assert!(ctx
+            .page_snapshot_for_url("https://example.com/page8", None)
+            .is_some());
+    }
+
+    #[test]
+    fn snapshot_url_returns_most_recent() {
+        let mut ctx = BrowserContext::new(test_bridge());
+
+        ctx.set_page_snapshot("https://example.com/page1", None, json!({}));
+        ctx.set_page_snapshot("https://example.com/page2", None, json!({}));
+
+        assert_eq!(ctx.snapshot_url(), Some("https://example.com/page2"));
+    }
+
+    #[test]
+    fn snapshot_normalize_url_strips_fragment() {
+        let mut ctx = BrowserContext::new(test_bridge());
+        let value = json!({"test": "data"});
+
+        ctx.set_page_snapshot("https://example.com#section", None, value.clone());
+
+        let retrieved = ctx.page_snapshot_for_url("https://example.com", None);
+        assert_eq!(retrieved, Some(&value));
+    }
+
+    #[test]
+    fn snapshot_normalize_url_preserves_hash_routes() {
+        let mut ctx = BrowserContext::new(test_bridge());
+        let value1 = json!({"route": "home"});
+        let value2 = json!({"route": "about"});
+
+        ctx.set_page_snapshot("https://example.com#/home", None, value1.clone());
+        ctx.set_page_snapshot("https://example.com#/about", None, value2.clone());
+
+        assert_eq!(
+            ctx.page_snapshot_for_url("https://example.com#/home", None),
+            Some(&value1)
+        );
+        assert_eq!(
+            ctx.page_snapshot_for_url("https://example.com#/about", None),
+            Some(&value2)
+        );
+    }
+
+    #[test]
+    fn snapshot_clear_removes_all() {
+        let mut ctx = BrowserContext::new(test_bridge());
+
+        ctx.set_page_snapshot("https://example.com", None, json!({}));
+        ctx.set_page_snapshot("https://example.com", Some("dialog"), json!({}));
+
+        ctx.clear_page_snapshot();
+
+        assert_eq!(ctx.page_snapshots.len(), 0);
+        assert_eq!(ctx.snapshot_url(), None);
     }
 }

--- a/crates/browser/src/context.rs
+++ b/crates/browser/src/context.rs
@@ -144,8 +144,12 @@ impl BrowserContext {
 
     #[must_use]
     pub fn last_snapshot_region_selector(&self, handle: &str) -> Option<&str> {
+        // Resolve from the most recent *full-page* snapshot (scope == "") so that a scoped
+        // post-action diff stored after page_map doesn't silently break @rN handle lookups.
         self.page_snapshots
-            .last()
+            .iter()
+            .rev()
+            .find(|((_, scope), _)| scope.is_empty())
             .and_then(|(_, snapshot)| snapshot.get("regions"))
             .and_then(Value::as_array)
             .and_then(|regions| find_region_selector(regions, handle))
@@ -293,6 +297,25 @@ mod tests {
 
         assert_eq!(ctx.last_snapshot_region_selector("@r2"), Some("#dialog"));
         assert_eq!(ctx.last_snapshot_region_selector("@r99"), None);
+    }
+
+    #[test]
+    fn last_snapshot_region_selector_uses_full_page_snapshot_when_scoped_is_newer() {
+        let mut ctx = BrowserContext::new(test_bridge());
+
+        // Full-page snapshot with region @r1
+        ctx.set_page_snapshot(
+            "https://example.com",
+            None,
+            json!({
+                "regions": [{"handle": "@r1", "selector": "main", "children": []}]
+            }),
+        );
+
+        // Scoped snapshot stored AFTER (no regions) — must not shadow @r1
+        ctx.set_page_snapshot("https://example.com", Some("#dialog"), json!({}));
+
+        assert_eq!(ctx.last_snapshot_region_selector("@r1"), Some("main"));
     }
 
     #[test]

--- a/crates/browser/src/extension.rs
+++ b/crates/browser/src/extension.rs
@@ -223,12 +223,6 @@ impl BrowserBackend for ExtensionBridge {
         Self::require_result(response, "page_map")
     }
 
-    async fn page_map_feedback(&mut self) -> Result<Value, BridgeError> {
-        let payload = json!({"diff": true});
-        let response = self.send_command("page_map", payload).await?;
-        Self::require_result(response, "page_map")
-    }
-
     async fn read_content(
         &mut self,
         heading: Option<&str>,

--- a/crates/browser/src/extension.rs
+++ b/crates/browser/src/extension.rs
@@ -223,6 +223,15 @@ impl BrowserBackend for ExtensionBridge {
         Self::require_result(response, "page_map")
     }
 
+    async fn extract_dom_snapshot(&mut self, scope: Option<&str>) -> Result<Value, BridgeError> {
+        let mut payload = json!({});
+        if let Some(s) = scope {
+            payload["scope"] = json!(s);
+        }
+        let response = self.send_command("extract_dom_snapshot", payload).await?;
+        Self::require_result(response, "extract_dom_snapshot")
+    }
+
     async fn read_content(
         &mut self,
         heading: Option<&str>,

--- a/crates/browser/src/playwright/backend_impl.rs
+++ b/crates/browser/src/playwright/backend_impl.rs
@@ -96,6 +96,13 @@ impl BrowserBackend for PlaywrightBridge {
         PlaywrightBridge::page_map(self, scope, compound_enrichment).await
     }
 
+    async fn extract_dom_snapshot(
+        &mut self,
+        scope: Option<&str>,
+    ) -> Result<serde_json::Value, BridgeError> {
+        PlaywrightBridge::extract_dom_snapshot(self, scope).await
+    }
+
     async fn read_content(
         &mut self,
         heading: Option<&str>,

--- a/crates/browser/src/playwright/bridge.rs
+++ b/crates/browser/src/playwright/bridge.rs
@@ -287,6 +287,17 @@ impl PlaywrightBridge {
         self.send_raw_command(&cmd).await
     }
 
+    pub async fn extract_dom_snapshot(
+        &mut self,
+        scope: Option<&str>,
+    ) -> Result<serde_json::Value, BridgeError> {
+        let mut cmd = serde_json::json!({ "action": "extract_dom_snapshot" });
+        if let Some(s) = scope {
+            cmd["scope"] = serde_json::Value::String(s.to_string());
+        }
+        self.send_raw_command(&cmd).await
+    }
+
     pub async fn read_content(
         &mut self,
         heading: Option<&str>,

--- a/crates/browser/src/playwright/bridge_script.rs
+++ b/crates/browser/src/playwright/bridge_script.rs
@@ -830,7 +830,7 @@ async function bootstrap() {
               })(el, root),
               parent_idx: parentIdx >= 0 ? parentIdx : null,
               selector: cssPath(el),
-              visible: el.offsetParent !== null && !el.hidden,
+              visible: !el.hidden && (function(e) { const s = window.getComputedStyle(e); return s.display !== 'none' && s.visibility !== 'hidden' && e.getBoundingClientRect().height > 0; })(el),
             };
           });
           const total_landmarks = landmarks.length;

--- a/crates/browser/src/playwright/bridge_script.rs
+++ b/crates/browser/src/playwright/bridge_script.rs
@@ -1109,8 +1109,11 @@ async function bootstrap() {
           }
 
           function isVisible(el) {
+            if (el.hidden) return false;
             const style = getComputedStyle(el);
-            return el.offsetParent !== null && !el.hidden && style.visibility !== 'hidden';
+            if (style.display === 'none' || style.visibility === 'hidden') return false;
+            const rect = el.getBoundingClientRect();
+            return rect.width > 0 || rect.height > 0;
           }
 
           function isFloating(el) {

--- a/crates/browser/src/playwright/bridge_script.rs
+++ b/crates/browser/src/playwright/bridge_script.rs
@@ -805,6 +805,34 @@ async function bootstrap() {
             selector: cssPath(el),
             text_preview: (el.innerText || '').trim().slice(0, 120),
           }));
+          const regionSelector = 'nav, main, aside, article, header, footer, section, form, ' +
+            '[role="dialog"], [role="alertdialog"], [role="region"], ' +
+            '[role="navigation"], [role="main"], [role="complementary"], ' +
+            '[role="banner"], [role="form"], ' +
+            '[aria-modal="true"], section[aria-label], [popover]';
+          const regionNodes = Array.from(root.querySelectorAll(regionSelector));
+          const regionCandidates = regionNodes.map((el) => {
+            const parent = el.parentElement;
+            const parentIdx = parent ? regionNodes.indexOf(parent) : null;
+            return {
+              tag: el.tagName.toLowerCase(),
+              role: el.getAttribute('role') || null,
+              aria_label: el.getAttribute('aria-label') || null,
+              id: el.id || null,
+              depth: (function countDepth(node, scopeRoot) {
+                let d = 0;
+                let cur = node;
+                while (cur && cur !== scopeRoot) {
+                  d++;
+                  cur = cur.parentElement;
+                }
+                return d;
+              })(el, root),
+              parent_idx: parentIdx >= 0 ? parentIdx : null,
+              selector: cssPath(el),
+              visible: el.offsetParent !== null && !el.hidden,
+            };
+          });
           const total_landmarks = landmarks.length;
           const cappedLandmarks = landmarks.slice(0, 20);
 
@@ -1000,6 +1028,27 @@ async function bootstrap() {
             }
           }
           const interactive = { counts, elements: interactiveEls };
+          const nonFormControls = Array.from(root.querySelectorAll(
+            'input:not(form input), select:not(form select), textarea:not(form textarea), ' +
+            'button:not(form button), [role="checkbox"]:not(form [role="checkbox"]), ' +
+            '[role="switch"]:not(form [role="switch"]), [role="combobox"]:not(form [role="combobox"])'
+          )).map(el => ({
+            tag: el.tagName.toLowerCase(),
+            role: el.getAttribute('role') || null,
+            text: (el.innerText || '').trim().slice(0, 120),
+            aria_label: el.getAttribute('aria-label') || null,
+            aria_labelledby_text: (() => {
+              const id = el.getAttribute('aria-labelledby');
+              return id ? (document.getElementById(id)?.innerText?.trim() || null) : null;
+            })(),
+            title: el.title || null,
+            placeholder: el.placeholder || null,
+            name: el.name || null,
+            value: el.value || null,
+            required: Boolean(el.required),
+            disabled: Boolean(el.disabled),
+            selector: cssPath(el),
+          }));
 
           const meta = {
             title: document.title,
@@ -1007,11 +1056,108 @@ async function bootstrap() {
             url: window.location.href,
           };
 
-          return { headings, landmarks: cappedLandmarks, forms, links, interactive, meta, total_landmarks, total_forms, total_links };
+          return { headings, landmarks: cappedLandmarks, forms, links, interactive, meta, regionCandidates, nonFormControls, total_landmarks, total_forms, total_links };
         }, {scope, compoundEnrichment});
         process.stdout.write(JSON.stringify({ event: 'bridge_response', ok: true, result }) + '\n');
       } catch (error) {
         process.stdout.write(JSON.stringify({ event: 'bridge_response', ok: false, error: { kind: 'page_map_error', message: String(error) } }) + '\n');
+      }
+      continue;
+    }
+
+    if (command.action === 'extract_dom_snapshot') {
+      try {
+        const scope = command.scope || null;
+        const result = await page.evaluate((scope) => {
+          let root = document;
+          if (scope) {
+            const scoped = document.querySelector(scope);
+            if (!scoped) {
+              return { elements: [] };
+            }
+            root = scoped;
+          }
+
+          function cssPath(el) {
+            if (el.id) return '#' + CSS.escape(el.id);
+            const parts = [];
+            let cur = el;
+            while (cur && cur !== document.body && cur !== document.documentElement) {
+              let seg = cur.tagName.toLowerCase();
+              const parent = cur.parentElement;
+              if (parent) {
+                const sibs = Array.from(parent.children).filter(c => c.tagName === cur.tagName);
+                if (sibs.length > 1) seg += ':nth-of-type(' + (sibs.indexOf(cur) + 1) + ')';
+              }
+              parts.unshift(seg);
+              cur = cur.parentElement;
+            }
+            return parts.join(' > ');
+          }
+
+          function getLabelledByText(el) {
+            const labelledBy = el.getAttribute('aria-labelledby');
+            if (!labelledBy) return null;
+            const text = labelledBy
+              .split(/\s+/)
+              .filter(Boolean)
+              .map((id) => document.getElementById(id)?.innerText?.trim() || '')
+              .filter(Boolean)
+              .join(' ')
+              .trim();
+            return text || null;
+          }
+
+          function isVisible(el) {
+            const style = getComputedStyle(el);
+            return el.offsetParent !== null && !el.hidden && style.visibility !== 'hidden';
+          }
+
+          function isFloating(el) {
+            const style = getComputedStyle(el);
+            return ['fixed', 'absolute'].includes(style.position) && Number.parseInt(style.zIndex || '0', 10) > 0;
+          }
+
+          const selectors = [
+            'button', 'input', 'select', 'textarea',
+            '[role="combobox"]', '[role="listbox"]', '[role="option"]',
+            '[role="menuitem"]', '[role="treeitem"]', '[role="tab"]',
+            '[role="menu"]', '[role="menubar"]', 'li[role]',
+            '[aria-expanded]', '[aria-controls]', '[aria-owns]',
+            '[popover]', '[aria-haspopup]'
+          ];
+
+          const seen = new Set();
+          const elements = [];
+          for (const el of root.querySelectorAll(selectors.join(','))) {
+            const selector = cssPath(el);
+            if (seen.has(selector)) continue;
+            seen.add(selector);
+            elements.push({
+              tag: el.tagName.toLowerCase(),
+              role: el.getAttribute('role'),
+              aria_expanded: el.getAttribute('aria-expanded'),
+              aria_selected: el.getAttribute('aria-selected'),
+              aria_pressed: el.getAttribute('aria-pressed'),
+              aria_controls: el.getAttribute('aria-controls'),
+              aria_owns: el.getAttribute('aria-owns'),
+              text: el.innerText?.trim()?.slice(0, 120) || null,
+              aria_label: el.getAttribute('aria-label'),
+              aria_labelledby_text: getLabelledByText(el),
+              title: el.getAttribute('title'),
+              placeholder: el.getAttribute('placeholder'),
+              name: el.getAttribute('name'),
+              visible: isVisible(el),
+              floating: isFloating(el),
+              selector,
+            });
+          }
+
+          return { elements };
+        }, scope);
+        process.stdout.write(JSON.stringify({ event: 'bridge_response', ok: true, result }) + '\n');
+      } catch (error) {
+        process.stdout.write(JSON.stringify({ event: 'bridge_response', ok: false, error: { kind: 'extract_dom_snapshot_error', message: String(error) } }) + '\n');
       }
       continue;
     }

--- a/crates/mcp-server/src/server.rs
+++ b/crates/mcp-server/src/server.rs
@@ -1162,12 +1162,15 @@ mod tests {
 
     #[test]
     fn read_protocol_message_skips_leading_whitespace_before_json() {
-        let body = r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#;
-        let data = format!("\r\n  {body}\n").into_bytes();
-        let mut cursor = Cursor::new(data);
-        let parsed =
-            read_protocol_message(&mut cursor).expect("leading whitespace should be drained");
-        assert_eq!(parsed, body.as_bytes());
+        with_transport_mode_lock(|| {
+            let body = r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#;
+            let data = format!("\r\n  {body}\n").into_bytes();
+            let mut cursor = Cursor::new(data);
+            let parsed =
+                read_protocol_message(&mut cursor).expect("leading whitespace should be drained");
+            assert_eq!(parsed, body.as_bytes());
+            assert_eq!(output_mode(), TransportMode::LineDelimited);
+        });
     }
 
     #[test]

--- a/extension/background.js
+++ b/extension/background.js
@@ -9,6 +9,7 @@ try {
     'commands/screenshot.js',
     'commands/execute_js.js',
     'commands/page_map.js',
+    'commands/extract_dom_snapshot.js',
     'commands/read_content.js',
     'commands/list_resources.js',
     'commands/hover.js',
@@ -511,6 +512,9 @@ async function handleCommand(cmd) {
             break;
           case 'page_map':
             result = await handlePageMap(tabId, cmd.payload || {});
+            break;
+          case 'extract_dom_snapshot':
+            result = await handleExtractDomSnapshot(tabId, cmd.payload || {});
             break;
           case 'read_content':
             result = await handleReadContent(tabId, cmd.payload || {});

--- a/extension/commands/execute_js.js
+++ b/extension/commands/execute_js.js
@@ -16,5 +16,5 @@ async function handleExecuteJs(tabId, payload) {
     throw new Error(res.exceptionDetails.text || 'JS execution threw exception');
   }
 
-  return { result: res.result?.value };
+  return { value: res.result?.value };
 }

--- a/extension/commands/extract_dom_snapshot.js
+++ b/extension/commands/extract_dom_snapshot.js
@@ -1,0 +1,110 @@
+'use strict';
+
+function extractDomSnapshotScript(payload) {
+  const scope = payload?.scope || null;
+  let root = document;
+  if (scope) {
+    const scoped = document.querySelector(scope);
+    if (!scoped) {
+      return { elements: [] };
+    }
+    root = scoped;
+  }
+
+  function cssPath(el) {
+    if (el.id) return '#' + CSS.escape(el.id);
+    const parts = [];
+    let cur = el;
+    while (cur && cur !== document.body && cur !== document.documentElement) {
+      let seg = cur.tagName.toLowerCase();
+      const parent = cur.parentElement;
+      if (parent) {
+        const sibs = Array.from(parent.children).filter(c => c.tagName === cur.tagName);
+        if (sibs.length > 1) seg += ':nth-of-type(' + (sibs.indexOf(cur) + 1) + ')';
+      }
+      parts.unshift(seg);
+      cur = cur.parentElement;
+    }
+    return parts.join(' > ');
+  }
+
+  function getLabelledByText(el) {
+    const labelledBy = el.getAttribute('aria-labelledby');
+    if (!labelledBy) return null;
+    const text = labelledBy
+      .split(/\s+/)
+      .filter(Boolean)
+      .map((id) => document.getElementById(id)?.innerText?.trim() || '')
+      .filter(Boolean)
+      .join(' ')
+      .trim();
+    return text || null;
+  }
+
+  function isVisible(el) {
+    const style = getComputedStyle(el);
+    return el.offsetParent !== null && !el.hidden && style.visibility !== 'hidden';
+  }
+
+  function isFloating(el) {
+    const style = getComputedStyle(el);
+    return ['fixed', 'absolute'].includes(style.position) && Number.parseInt(style.zIndex || '0', 10) > 0;
+  }
+
+  const selectors = [
+    'button', 'input', 'select', 'textarea',
+    '[role="combobox"]', '[role="listbox"]', '[role="option"]',
+    '[role="menuitem"]', '[role="treeitem"]', '[role="tab"]',
+    '[role="menu"]', '[role="menubar"]', 'li[role]',
+    '[aria-expanded]', '[aria-controls]', '[aria-owns]',
+    '[popover]', '[aria-haspopup]'
+  ];
+
+  const seen = new Set();
+  const elements = [];
+  for (const el of root.querySelectorAll(selectors.join(','))) {
+    const selector = cssPath(el);
+    if (seen.has(selector)) continue;
+    seen.add(selector);
+    elements.push({
+      tag: el.tagName.toLowerCase(),
+      role: el.getAttribute('role'),
+      aria_expanded: el.getAttribute('aria-expanded'),
+      aria_selected: el.getAttribute('aria-selected'),
+      aria_pressed: el.getAttribute('aria-pressed'),
+      aria_controls: el.getAttribute('aria-controls'),
+      aria_owns: el.getAttribute('aria-owns'),
+      text: el.innerText?.trim()?.slice(0, 120) || null,
+      aria_label: el.getAttribute('aria-label'),
+      aria_labelledby_text: getLabelledByText(el),
+      title: el.getAttribute('title'),
+      placeholder: el.getAttribute('placeholder'),
+      name: el.getAttribute('name'),
+      visible: isVisible(el),
+      floating: isFloating(el),
+      selector,
+    });
+  }
+
+  return { elements };
+}
+
+async function handleExtractDomSnapshot(tabId, payload) {
+  await ensureAttached(tabId);
+
+  const evalPayload = {
+    scope: payload?.scope || null,
+  };
+
+  const expression = `(${extractDomSnapshotScript.toString()})(${JSON.stringify(evalPayload)})`;
+  const res = await cdp(tabId, 'Runtime.evaluate', {
+    expression,
+    returnByValue: true,
+  });
+
+  if (res.exceptionDetails) {
+    throw new Error(res.exceptionDetails.text || 'extract_dom_snapshot script threw exception');
+  }
+
+  return res.result?.value || { elements: [] };
+}

--- a/extension/commands/extract_dom_snapshot.js
+++ b/extension/commands/extract_dom_snapshot.js
@@ -42,8 +42,11 @@ function extractDomSnapshotScript(payload) {
   }
 
   function isVisible(el) {
+    if (el.hidden) return false;
     const style = getComputedStyle(el);
-    return el.offsetParent !== null && !el.hidden && style.visibility !== 'hidden';
+    if (style.display === 'none' || style.visibility === 'hidden') return false;
+    const rect = el.getBoundingClientRect();
+    return rect.width > 0 || rect.height > 0;
   }
 
   function isFloating(el) {

--- a/extension/commands/page_map.js
+++ b/extension/commands/page_map.js
@@ -1,151 +1,5 @@
 'use strict';
 
-const pageMapCache = new Map();
-
-function urlWithoutHash(url) {
-  const idx = url.indexOf('#');
-  if (idx === -1) return url;
-  const frag = url.slice(idx + 1);
-  if (frag.startsWith('/') || frag.startsWith('!/')) return url;
-  return url.slice(0, idx);
-}
-
-function headingKey(h) { return `${h.level}:${h.text}`; }
-function linkKey(l) { return `${l.text}\x00${l.href}`; }
-function landmarkKey(lm) { return `${lm.tag || ''}\x00${lm.role || ''}\x00${lm.id || ''}`; }
-
-function diffArrays(prev, curr, keyFn) {
-  const prevCounts = Object.create(null);
-  for (const item of prev) {
-    const k = keyFn(item);
-    prevCounts[k] = (prevCounts[k] || 0) + 1;
-  }
-  const currCounts = Object.create(null);
-  for (const item of curr) {
-    const k = keyFn(item);
-    currCounts[k] = (currCounts[k] || 0) + 1;
-  }
-
-  const addedBudget = Object.create(null);
-  for (const k of Object.keys(currCounts)) {
-    const diff = currCounts[k] - (prevCounts[k] || 0);
-    if (diff > 0) addedBudget[k] = diff;
-  }
-  const removedBudget = Object.create(null);
-  for (const k of Object.keys(prevCounts)) {
-    const diff = prevCounts[k] - (currCounts[k] || 0);
-    if (diff > 0) removedBudget[k] = diff;
-  }
-
-  const added = curr.filter(item => {
-    const k = keyFn(item);
-    if (addedBudget[k] > 0) { addedBudget[k]--; return true; }
-    return false;
-  });
-  const removed = prev.filter(item => {
-    const k = keyFn(item);
-    if (removedBudget[k] > 0) { removedBudget[k]--; return true; }
-    return false;
-  });
-  return { added, removed };
-}
-
-function computePageMapDiff(prev, current) {
-  const url = current.meta?.url || 'unknown';
-  const title = current.meta?.title || 'unknown';
-
-  const { added: addedHeadings, removed: removedHeadings } =
-    diffArrays(prev.headings || [], current.headings || [], headingKey);
-  const { added: addedLinks, removed: removedLinks } =
-    diffArrays(prev.links || [], current.links || [], linkKey);
-  const { added: addedLandmarks, removed: removedLandmarks } =
-    diffArrays(prev.landmarks || [], current.landmarks || [], landmarkKey);
-
-  const STATE_FIELDS = ['disabled', 'checked', 'value', 'aria_pressed', 'aria_expanded', 'aria_selected'];
-  const MAX_INTERACTIVE_DIFF = 5;
-  const prevElements = prev.interactive?.elements || [];
-  const currElements = current.interactive?.elements || [];
-  const prevBySelector = Object.create(null);
-  for (const el of prevElements) {
-    if (el.selector) prevBySelector[el.selector] = el;
-  }
-  const currBySelector = Object.create(null);
-  for (const el of currElements) {
-    if (el.selector) currBySelector[el.selector] = el;
-  }
-
-  const briefEntry = (el) => {
-    const e = { selector: el.selector };
-    if (el.tag) e.tag = el.tag;
-    if (el.text) e.text = el.text;
-    if (el.role) e.role = el.role;
-    return e;
-  };
-
-  const addedInteractive = currElements
-    .filter(el => el.selector && !prevBySelector[el.selector])
-    .slice(0, MAX_INTERACTIVE_DIFF)
-    .map(briefEntry);
-
-  const removedInteractive = prevElements
-    .filter(el => el.selector && !currBySelector[el.selector])
-    .slice(0, MAX_INTERACTIVE_DIFF)
-    .map(briefEntry);
-
-  const modifiedInteractive = [];
-  for (const el of currElements) {
-    if (!el.selector) continue;
-    const prevEl = prevBySelector[el.selector];
-    if (!prevEl) continue;
-    const stateChanges = {};
-    for (const field of STATE_FIELDS) {
-      const pv = prevEl[field] ?? null;
-      const cv = el[field] ?? null;
-      if (pv !== cv) stateChanges[field] = cv;
-    }
-    if (Object.keys(stateChanges).length > 0) {
-      const entry = { selector: el.selector };
-      if (el.tag) entry.tag = el.tag;
-      if (el.text) entry.text = el.text;
-      entry.state_changes = stateChanges;
-      modifiedInteractive.push(entry);
-    }
-  }
-
-  const hasChanges = addedHeadings.length + removedHeadings.length +
-    addedLinks.length + removedLinks.length +
-    addedLandmarks.length + removedLandmarks.length +
-    addedInteractive.length + removedInteractive.length +
-    modifiedInteractive.length > 0;
-
-  if (!hasChanges) {
-    return { url, title, changed: false };
-  }
-
-  const totalPrev = (prev.headings || []).length +
-    (prev.links || []).length + (prev.landmarks || []).length;
-  const totalChanged = addedHeadings.length + removedHeadings.length +
-    addedLinks.length + removedLinks.length +
-    addedLandmarks.length + removedLandmarks.length;
-
-  if (totalPrev > 0 && totalChanged > totalPrev) {
-    return null; // diff too large, caller should return full
-  }
-
-  const changes = {};
-  if (addedHeadings.length) changes.added_headings = addedHeadings;
-  if (removedHeadings.length) changes.removed_headings = removedHeadings;
-  if (addedLinks.length) changes.added_links = addedLinks;
-  if (removedLinks.length) changes.removed_links = removedLinks;
-  if (addedLandmarks.length) changes.added_landmarks = addedLandmarks;
-  if (removedLandmarks.length) changes.removed_landmarks = removedLandmarks;
-  if (addedInteractive.length) changes.added_interactive = addedInteractive;
-  if (removedInteractive.length) changes.removed_interactive = removedInteractive;
-  if (modifiedInteractive.length) changes.modified_interactive = modifiedInteractive;
-
-  return { url, title, changed: true, changes };
-}
-
 function pageMapScript(scope) {
   let root = document;
   if (scope) {
@@ -356,7 +210,6 @@ async function handlePageMap(tabId, payload) {
   await ensureAttached(tabId);
 
   const scope = (payload && payload.scope) || null;
-  const diffMode = Boolean(payload && payload.diff);
   const expression = scope
     ? `(${pageMapScript.toString()})(${JSON.stringify(scope)})`
     : `(${pageMapScript.toString()})(null)`;
@@ -370,25 +223,5 @@ async function handlePageMap(tabId, payload) {
     throw new Error(res.exceptionDetails.text || 'page_map script threw exception');
   }
 
-  const current = res.result?.value || {};
-
-  if (diffMode && !scope) {
-    const currentUrl = urlWithoutHash(current.meta?.url || '');
-    const cached = pageMapCache.get(tabId);
-
-    if (cached && cached.url === currentUrl) {
-      const diff = computePageMapDiff(cached.data, current);
-      pageMapCache.set(tabId, { url: currentUrl, data: current });
-      if (diff !== null) {
-        return diff;
-      }
-    } else {
-      pageMapCache.set(tabId, { url: currentUrl, data: current });
-    }
-  } else if (!scope) {
-    const currentUrl = urlWithoutHash(current.meta?.url || '');
-    pageMapCache.set(tabId, { url: currentUrl, data: current });
-  }
-
-  return current;
+  return res.result?.value || {};
 }

--- a/extension/commands/page_map.js
+++ b/extension/commands/page_map.js
@@ -77,7 +77,7 @@ function pageMapScript(scope) {
       })(el, root),
       parent_idx: parentIdx >= 0 ? parentIdx : null,
       selector: cssPath(el),
-      visible: el.offsetParent !== null && !el.hidden,
+      visible: !el.hidden && (function(e) { const s = window.getComputedStyle(e); return s.display !== 'none' && s.visibility !== 'hidden' && e.getBoundingClientRect().height > 0; })(el),
     };
   });
   const total_landmarks = landmarks.length;

--- a/extension/commands/page_map.js
+++ b/extension/commands/page_map.js
@@ -52,6 +52,34 @@ function pageMapScript(scope) {
     selector: cssPath(el),
     text_preview: (el.innerText || '').trim().slice(0, 120),
   }));
+  const regionSelector = 'nav, main, aside, article, header, footer, section, form, ' +
+    '[role="dialog"], [role="alertdialog"], [role="region"], ' +
+    '[role="navigation"], [role="main"], [role="complementary"], ' +
+    '[role="banner"], [role="form"], ' +
+    '[aria-modal="true"], section[aria-label], [popover]';
+  const regionNodes = Array.from(root.querySelectorAll(regionSelector));
+  const regionCandidates = regionNodes.map((el) => {
+    const parent = el.parentElement;
+    const parentIdx = parent ? regionNodes.indexOf(parent) : null;
+    return {
+      tag: el.tagName.toLowerCase(),
+      role: el.getAttribute('role') || null,
+      aria_label: el.getAttribute('aria-label') || null,
+      id: el.id || null,
+      depth: (function countDepth(node, scopeRoot) {
+        let d = 0;
+        let cur = node;
+        while (cur && cur !== scopeRoot) {
+          d++;
+          cur = cur.parentElement;
+        }
+        return d;
+      })(el, root),
+      parent_idx: parentIdx >= 0 ? parentIdx : null,
+      selector: cssPath(el),
+      visible: el.offsetParent !== null && !el.hidden,
+    };
+  });
   const total_landmarks = landmarks.length;
   const cappedLandmarks = landmarks.slice(0, 20);
 
@@ -196,6 +224,27 @@ function pageMapScript(scope) {
     }
   }
   const interactive = { counts, elements: interactiveEls };
+  const nonFormControls = Array.from(root.querySelectorAll(
+    'input:not(form input), select:not(form select), textarea:not(form textarea), ' +
+    'button:not(form button), [role="checkbox"]:not(form [role="checkbox"]), ' +
+    '[role="switch"]:not(form [role="switch"]), [role="combobox"]:not(form [role="combobox"])'
+  )).map(el => ({
+    tag: el.tagName.toLowerCase(),
+    role: el.getAttribute('role') || null,
+    text: (el.innerText || '').trim().slice(0, 120),
+    aria_label: el.getAttribute('aria-label') || null,
+    aria_labelledby_text: (() => {
+      const id = el.getAttribute('aria-labelledby');
+      return id ? (document.getElementById(id)?.innerText?.trim() || null) : null;
+    })(),
+    title: el.title || null,
+    placeholder: el.placeholder || null,
+    name: el.name || null,
+    value: el.value || null,
+    required: Boolean(el.required),
+    disabled: Boolean(el.disabled),
+    selector: cssPath(el),
+  }));
 
   const meta = {
     title: document.title,
@@ -203,7 +252,7 @@ function pageMapScript(scope) {
     url: window.location.href,
   };
 
-  return { headings, landmarks: cappedLandmarks, forms, links, interactive, meta, total_landmarks, total_forms, total_links };
+  return { headings, landmarks: cappedLandmarks, forms, links, interactive, meta, regionCandidates, nonFormControls, total_landmarks, total_forms, total_links };
 }
 
 async function handlePageMap(tabId, payload) {


### PR DESCRIPTION
﻿## Summary

Addresses six SPA admin-UI friction points reported by a user testing acrawl against a portal/tab/modal-heavy admin application. Root cause: acrawl modeled the DOM *syntactically* (brittle CSS paths, flat lists, `<form>`-bounded fields) instead of *semantically* (regions, accessible names, ARIA relationships, overlay stack). This PR upgrades acrawl's DOM model to be semantic across all four affected tools and the shared feedback path.

**Zero net new tools — stays at 42. Both backends at full parity. New behavior on by default.**

---

## What changed

### `page_map` — semantic UI map (#3 modal awareness + #4 hierarchical model)
- Emits a `regions` tree with human-readable labels (`sidebar`, `main panel`, `admin modal`) and ephemeral `@rN` handles
- Adds `active_dialog` pointer to the topmost visible overlay
- Surfaces non-`<form>` controls (div-based modal inputs) with accessible labels
- Semantic scope tokens: pass `scope: "dialog"`, `"main"`, `"sidebar"`, or `"@r1"` instead of hand-crafting CSS selectors
- Caps in Rust (`truncated_regions` / `truncated_controls` flags); both backends emit identical raw candidates

### `fill_form` — page-wide fuzzy label fill (#2 semantic form filling)
- Field keys now resolve by visible label text **page-wide**, no `<form>` boundary required
- Fallback chain: exact CSS/name/id/aria-label fast path → fuzzy match via `crate::semantic::match_text`
- Works for modal/admin UIs built from divs

### `select_option` — portal-aware combobox engine (#1 combobox/listbox support)
- Handles native `<select>`, ARIA combobox/listbox, and div-soup dropdowns with portal-rendered options
- Open → detect (4 signals: aria-expanded, new listbox/menu, new options, floating panel) → locate options portal-aware (aria-controls/owns → document-wide search) → enumerate → select by text
- **List-options mode**: omit `value`/`label`/`index` to open + return available options without selecting
- Keyboard-first selection (ArrowDown + Enter) with click fallback
- Excludes: nested submenus, multi-select, native date/color pickers, full virtual-scroll

### `click` — text + role + region activation (#5 text-based helpers)
- New optional params: `text` (visible label), `role` (ARIA role filter), `region` (`@rN` or token)
- `selector` XOR `text` — use whichever is cleaner for the task
- Resolves live at click time; robust to re-renders
- Accessible-name derivation includes `<label for=id>` and wrapping `<label>` (mirrors fill_form)

### Post-action diffs — auto-scoped (#6 noisy diffs)
- Diffs auto-scope to the interacted container / active dialog by default
- `widen: true` on any of the six page_state tools returns the full-page diff
- Net token reduction on multi-region pages

---

## Architecture

One shared `crate::semantic` module (pure Rust, no I/O) provides:
- `compute_accessible_name` — mirrors JS precedence exactly
- `assemble_region_tree` / `select_active_dialog`
- `match_text` — exact → case-insensitive → trimmed → contains → token/fuzzy
- `RegionCandidate`, `RegionNode`, `OptionCandidate`, `ControlInfo`

The bridge JS stays thin (raw DOM extraction only); Rust does all labeling, tree assembly, diff scoping, and fuzzy matching — maximizing testability without a live browser.

Diff computation consolidated to Rust: the Chrome extension's `computePageMapDiff` / `pageMapCache` deleted; both backends now flow through the single `build_diff_page_state` in `feedback.rs`.

---

## Post-review fixes (commit `84297bd`)

A code review pass after the initial implementation caught seven correctness gaps, all resolved before merge:

| # | Fix | Files |
|---|-----|-------|
| 1 | Extension `execute_js` returned `{ result: }` instead of `{ value: }` — all Rust callers parse `.get("value")` | `extension/commands/execute_js.js` |
| 2 | Extension `page_map.js` region visibility used `offsetParent` — misclassifies `position:fixed` dialogs/overlays as invisible | `extension/commands/page_map.js` |
| 3 | `extract_dom_snapshot.js` and `select_option` inline JS used same `offsetParent` check — portal menus excluded | `extension/commands/extract_dom_snapshot.js`, `crates/agent/src/tools/select_option.rs` |
| 4 | `click`-by-text did not resolve `<label for=id>` or wrapping `<label>` — labeled checkboxes/radios not found | `crates/agent/src/tools/click.rs` |
| 5 | `@rN` handles resolved from `.page_snapshots.last()` — a subsequent scoped diff overwrote the handle table | `crates/browser/src/context.rs` |
| 6 | `extract_dom_snapshot` default impl silently returned `Ok({"elements":[]})` — backends that forget to implement it compile green but break silently | `crates/browser/src/browser_backend.rs` |

All fixes covered by new unit tests; `cargo test --workspace` clean after.

---

## E2E QA (via MCP session)

Exercised against live sites using the acrawl MCP tools loaded into the review session:

| Scenario | Site | Result |
|----------|------|--------|
| `execute_js` response contract | example.com | ✅ Returned `{title, type, tags}` correctly |
| `page_map` regions tree + `@rN` handles | BBC News | ✅ 14 `@rN` handles emitted across article sections |
| `@rN` stability after scoped snapshot | BBC News | ✅ `@r5` resolved correctly from full-page snapshot after scoped `page_map(@r5)` stored on top |
| `click` by `<label for=id>` text | Injected element on GitHub login | ✅ `text="Subscribe to newsletter"` clicked `#acrawl-test-cb` (checkbox checked) |
| `active_dialog` — fixed-position overlay | MUI docs | ✅ Cookie consent modal (`position:fixed`) detected as visible, surfaced as `active_dialog` |
| `select_option` — MUI portal combobox | MUI Select demo | ✅ Portal-rendered `<ul>` (outside combobox subtree, `position:fixed`) enumerated; `"Twenty"` selected |

---

## Verification
- **1647 tests, 0 failures** (`cargo test --workspace`)
- **`cargo clippy --workspace --all-targets -- -D warnings`** — clean
- **`cargo fmt --check`** — clean
- Tool count: **42** (unchanged)
- MCP surface: **38 + run_goal** (unchanged)
- System prompt: **9 sections** (unchanged)
- Both backends (CloakBrowser + Chrome extension) at full parity for every new DOM primitive