### PR TITLE
fix: add reCAPTCHA v3 detection to navigate response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **reCAPTCHA v3 presence detection** (`recaptcha_detected`): `navigate` now reports `recaptcha_detected: true` in its JSON response when the page loads Google reCAPTCHA v3 (invisible, score-based) CDN scripts without a visible v2 widget. This is informational — presence alone does not indicate a block.
+- **Silent form-submission warning** (`submission_warning`): when `fill_form(submit: true)` produces no visible page change (same URL, `changed: false`) and reCAPTCHA v3 is present, the reply includes a `submission_warning` field with a hedged explanation and the remedy (`acrawl config set headless false` / `--headed` / `/extension`).
+- **Agent remedy guidance**: the system prompt now encodes a two-condition rule — `recaptcha_detected: true` is not a blocker; only a silent-submission (no page change after submit) should prompt the agent to report the headless remedy.
+
 ## [0.12.2] - 2026-06-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -358,6 +358,20 @@ Interaction tools (`click`, `click_at`, `fill_form`, `hover`, `press_key`, `go_b
 
 If nothing changed, `{ "url": "...", "title": "...", "changed": false }` is returned. On bridge failure, `{ "url": "unknown", "title": "unknown", "page_map": null }`. The embedded `page_map` preserves `regions` and `active_dialog` but omits the verbose `forms`, `interactive`, and `controls` arrays to keep interaction responses concise — call the `page_map` tool to retrieve those. Caps: max 50 links, 20 landmarks per page_state.
 
+#### Tool-Specific Response Fields
+
+The `navigate` tool response includes additional fields beyond `page_state`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `recaptcha_detected` | `boolean` | `true` when the page loads Google reCAPTCHA v3 (invisible, score-based) CDN scripts without a visible v2 widget. Presence alone is not a block signal; the agent keeps reading and extracting normally. |
+
+The `fill_form` tool response includes an optional field:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `submission_warning` | `string` (optional) | Present when `submit: true` matched a form and produced no visible page change (same URL, `changed: false`) while reCAPTCHA v3 was detected. The text is hypothesis-worded — a silent backend rejection is one of several possible explanations. Names the remedy: `acrawl config set headless false` (or `--headed`) or `/extension`. |
+
 
 ### Sub-Agent Parallelism
 
@@ -869,6 +883,7 @@ acrawl works well on most public web content, but some situations are outside wh
 | **PDF and binary file content** | `save_file` downloads any URL to disk. The agent cannot read the text content of a saved PDF, use `navigate` on a URL that serves HTML, or pipe the download through a text extractor externally. |
 | **WebGL / canvas fingerprinting** | Some anti-bot systems fingerprint the GPU via WebGL. CloakBrowser mitigates common checks but cannot spoof hardware-level fingerprints. |
 | **Sites that require a real mouse trajectory** | Bot-detection systems that analyse mouse movement patterns may flag headless browser interactions. Switch to extension mode for these sites. |
+| **reCAPTCHA v3 (invisible, score-based)** | reCAPTCHA v3 is invisible — there is no widget or challenge prompt. On headless browsers (the default), v3 scores sessions low and the backend may silently reject form submissions with no error shown. The `navigate` response includes `recaptcha_detected: true` when v3 scripts are present; `fill_form(submit: true)` includes a hedged `submission_warning` when a silent rejection is suspected. To rule out reCAPTCHA, a human can retry with `acrawl config set headless false` (or `--headed`), or use the extension bridge (`/extension`) to operate in a real browser session. |
 
 
 ## How It Works

--- a/crates/agent/src/prompt.rs
+++ b/crates/agent/src/prompt.rs
@@ -179,6 +179,16 @@ fn section_error_recovery() -> String {
      - CAPTCHA or human verification (e.g. \"verify you are human\", \
      \"unusual traffic\", reCAPTCHA, hCaptcha, checkbox challenges): \
      Stop and report the blocker in your results. Do NOT retry or try to solve it.\n\
+     - reCAPTCHA v3 (invisible, score-based): A navigate result with \
+     recaptcha_detected: true is NOT a blocker by itself — keep reading and \
+     extracting normally, exactly as you would on any other page. Only when a \
+     form submission produces no visible page change (same URL, changed: \
+     false) is this the likely cause: the browser is probably headless, \
+     reCAPTCHA v3 scores headless sessions low, and the server may silently \
+     reject the submission. Do NOT change settings or call any tool to fix \
+     this yourself — report it to the user: a human can retry with `acrawl \
+     config set headless false` (or --headed), or use the extension bridge \
+     (/extension).\n\
      - Login wall or paywall: Stop and report the blocker in your results.\n\
      - Anti-bot detection (403/429 errors, empty page, \"access denied\"): \
      Wait briefly (use the `wait` tool) and retry once. \
@@ -494,5 +504,39 @@ mod tests {
 
         assert_eq!(prompt.len(), 10);
         assert!(prompt[9].contains("You are stuck"));
+    }
+
+    #[test]
+    fn prompt_contains_recaptcha_v3_remedy() {
+        let specs = crate::mvp_tool_specs();
+        let prompt = build_system_prompt(&specs, None);
+        let joined = prompt.join("\n");
+
+        assert_eq!(
+            prompt.len(),
+            9,
+            "guidance appended inside error-recovery must not add a 10th section"
+        );
+
+        assert!(
+            joined.contains("reCAPTCHA v3"),
+            "should mention reCAPTCHA v3"
+        );
+        assert!(
+            joined.contains("recaptcha_detected: true is NOT a blocker"),
+            "recaptcha_detected: true alone must not be treated as a blocker"
+        );
+        assert!(
+            joined.contains("headless"),
+            "should explain the headless low-score remedy"
+        );
+        assert!(
+            joined.contains("acrawl config set headless false"),
+            "should surface the human-runnable remedy command"
+        );
+        assert!(
+            joined.contains("/extension"),
+            "should mention the extension bridge alternative"
+        );
     }
 }

--- a/crates/agent/src/tools/feedback.rs
+++ b/crates/agent/src/tools/feedback.rs
@@ -516,7 +516,7 @@ pub fn record_page_fingerprint(url: &str, page_map: &Value, crawl_state: &mut Cr
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
     use std::sync::Mutex as StdMutex;
@@ -537,11 +537,12 @@ mod tests {
     use browser::BrowserBackend;
 
     #[derive(Debug, Default)]
-    struct FeedbackMockState {
-        page_maps: HashMap<String, Value>,
-        requested_scopes: Vec<Option<String>>,
-        evaluate_result: Value,
-        evaluate_scripts: Vec<String>,
+    pub(crate) struct FeedbackMockState {
+        pub(crate) page_maps: HashMap<String, Value>,
+        pub(crate) requested_scopes: Vec<Option<String>>,
+        pub(crate) evaluate_result: Value,
+        pub(crate) evaluate_scripts: Vec<String>,
+        pub(crate) evaluate_script_results: Vec<(String, Value)>,
     }
 
     #[derive(Debug)]
@@ -615,6 +616,13 @@ mod tests {
         async fn evaluate(&mut self, script: &str) -> Result<Value, BridgeError> {
             let mut state = self.state.lock().expect("mock state poisoned");
             state.evaluate_scripts.push(script.to_string());
+            if let Some((_, result)) = state
+                .evaluate_script_results
+                .iter()
+                .find(|(pattern, _)| script.contains(pattern))
+            {
+                return Ok(result.clone());
+            }
             Ok(state.evaluate_result.clone())
         }
 
@@ -707,7 +715,7 @@ mod tests {
         }
     }
 
-    fn browser_with_feedback_backend(
+    pub(crate) fn browser_with_feedback_backend(
         state: FeedbackMockState,
         url: &str,
     ) -> (BrowserContext, Arc<StdMutex<FeedbackMockState>>) {

--- a/crates/agent/src/tools/fill_form.rs
+++ b/crates/agent/src/tools/fill_form.rs
@@ -151,13 +151,12 @@ pub async fn execute(
     )
     .await;
 
-    let submission_warning = if params.submit
-        && page_state.get("changed").and_then(Value::as_bool) == Some(false)
-    {
-        recaptcha_v3_silent_submission_warning(browser).await
-    } else {
-        None
-    };
+    let submission_warning =
+        if params.submit && page_state.get("changed").and_then(Value::as_bool) == Some(false) {
+            recaptcha_v3_silent_submission_warning(browser).await
+        } else {
+            None
+        };
 
     let field_count = params.fields.len();
     let mut reply = serde_json::json!({

--- a/crates/agent/src/tools/fill_form.rs
+++ b/crates/agent/src/tools/fill_form.rs
@@ -7,6 +7,10 @@ use crate::state::CrawlState;
 use crate::BrowserContext;
 use crate::{CrawlError, ToolEffect, ToolExecutionError};
 
+const RECAPTCHA_V3_SILENT_SUBMISSION_AUDIT: &str = r"(typeof grecaptcha !== 'undefined' || /recaptcha\/(api\.js|releases)/i.test(document.documentElement.innerHTML)) && !document.querySelector('.g-recaptcha')";
+
+const RECAPTCHA_V3_SILENT_SUBMISSION_WARNING: &str = "Form submitted but no visible page change was detected. This page uses reCAPTCHA v3 (invisible, score-based); headless browsers often score too low and the server may silently reject the submission — though this could also be an unshown validation error or a successful inline update. To rule out reCAPTCHA, a human can retry with `acrawl config set headless false` (or `--headed`), or use the extension bridge (`/extension`).";
+
 #[derive(Debug)]
 struct FillFormInput {
     fields: BTreeMap<String, String>,
@@ -147,8 +151,16 @@ pub async fn execute(
     )
     .await;
 
+    let submission_warning = if params.submit
+        && page_state.get("changed").and_then(Value::as_bool) == Some(false)
+    {
+        recaptcha_v3_silent_submission_warning(browser).await
+    } else {
+        None
+    };
+
     let field_count = params.fields.len();
-    Ok(ToolEffect::reply_json(&serde_json::json!({
+    let mut reply = serde_json::json!({
         "seq": seq,
         "success": true,
         "message": format!(
@@ -156,7 +168,31 @@ pub async fn execute(
             if params.submit { " and submitted form" } else { "" }
         ),
         "page_state": page_state
-    })))
+    });
+    if let Some(warning) = submission_warning {
+        reply["submission_warning"] = Value::String(warning);
+    }
+    Ok(ToolEffect::reply_json(&reply))
+}
+
+async fn recaptcha_v3_silent_submission_warning(browser: &mut BrowserContext) -> Option<String> {
+    let mut bridge = browser.acquire_bridge().await.ok()?;
+    let detected = bridge
+        .evaluate(RECAPTCHA_V3_SILENT_SUBMISSION_AUDIT)
+        .await
+        .ok()
+        .as_ref()
+        .and_then(evaluate_bool)
+        .unwrap_or(false);
+
+    detected.then(|| RECAPTCHA_V3_SILENT_SUBMISSION_WARNING.to_string())
+}
+
+fn evaluate_bool(value: &Value) -> Option<bool> {
+    value
+        .get("value")
+        .and_then(Value::as_bool)
+        .or_else(|| value.as_bool())
 }
 
 async fn fill_fields(
@@ -276,7 +312,11 @@ async fn resolve_field_by_label(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+
     use serde_json::json;
+
+    use crate::tools::feedback::tests::{browser_with_feedback_backend, FeedbackMockState};
 
     #[test]
     fn parse_valid_fields() {
@@ -396,5 +436,154 @@ mod tests {
         let (best, alternatives) = crate::semantic::match_text("Name", &candidates, None).unwrap();
         assert_eq!(best, "#name-1");
         assert_eq!(alternatives, vec!["#name-2".to_string()]);
+    }
+
+    fn form_page_map(url: &str, extra_link: Option<&str>) -> Value {
+        let mut links = Vec::new();
+        if let Some(text) = extra_link {
+            links.push(json!({
+                "text": text,
+                "href": format!("{url}#{text}"),
+                "selector": format!("a[data-link='{text}']")
+            }));
+        }
+
+        json!({
+            "headings": [],
+            "landmarks": [],
+            "forms": [],
+            "links": links,
+            "interactive": {},
+            "meta": {"title": "Form", "url": url, "description": ""}
+        })
+    }
+
+    #[tokio::test]
+    async fn submit_with_silent_no_change_and_recaptcha_v3_adds_warning() {
+        let url = "https://example.com/form";
+        let page_map = form_page_map(url, None);
+        let (mut browser, state) = browser_with_feedback_backend(
+            FeedbackMockState {
+                page_maps: HashMap::from([(String::new(), page_map.clone())]),
+                evaluate_script_results: vec![
+                    ("window.location.href".to_string(), json!({"value": url})),
+                    ("form_not_found".to_string(), json!({"value": "clicked"})),
+                    ("typeof grecaptcha".to_string(), json!({"value": true})),
+                ],
+                ..FeedbackMockState::default()
+            },
+            url,
+        );
+        browser.set_page_snapshot(url, None, page_map);
+        let crawl_state = CrawlState::default();
+
+        let response = execute(
+            &json!({
+                "fields": {"#email": "jane@example.com"},
+                "submit": true
+            }),
+            &mut browser,
+            &crawl_state,
+        )
+        .await
+        .expect("fill_form should succeed");
+
+        let ToolEffect::Reply(body) = response else {
+            panic!("expected reply");
+        };
+        let payload: Value = serde_json::from_str(&body).expect("reply json");
+        assert_eq!(payload["page_state"]["changed"], false);
+        assert_eq!(
+            payload["submission_warning"],
+            Value::String(RECAPTCHA_V3_SILENT_SUBMISSION_WARNING.to_string())
+        );
+
+        let state = state.lock().expect("mock state poisoned");
+        assert!(state
+            .evaluate_scripts
+            .iter()
+            .any(|script| script.contains("typeof grecaptcha")));
+    }
+
+    #[tokio::test]
+    async fn submit_with_silent_no_change_and_no_recaptcha_v3_skips_warning() {
+        let url = "https://example.com/form";
+        let page_map = form_page_map(url, None);
+        let (mut browser, _) = browser_with_feedback_backend(
+            FeedbackMockState {
+                page_maps: HashMap::from([(String::new(), page_map.clone())]),
+                evaluate_script_results: vec![
+                    ("window.location.href".to_string(), json!({"value": url})),
+                    ("form_not_found".to_string(), json!({"value": "clicked"})),
+                    ("typeof grecaptcha".to_string(), json!({"value": false})),
+                ],
+                ..FeedbackMockState::default()
+            },
+            url,
+        );
+        browser.set_page_snapshot(url, None, page_map);
+        let crawl_state = CrawlState::default();
+
+        let response = execute(
+            &json!({
+                "fields": {"#email": "jane@example.com"},
+                "submit": true
+            }),
+            &mut browser,
+            &crawl_state,
+        )
+        .await
+        .expect("fill_form should succeed");
+
+        let ToolEffect::Reply(body) = response else {
+            panic!("expected reply");
+        };
+        let payload: Value = serde_json::from_str(&body).expect("reply json");
+        assert!(payload.get("submission_warning").is_none());
+    }
+
+    #[tokio::test]
+    async fn submit_with_visible_change_skips_warning_even_with_recaptcha_v3() {
+        let url = "https://example.com/form";
+        let prev_page_map = form_page_map(url, None);
+        let current_page_map = form_page_map(url, Some("updated"));
+        let (mut browser, state) = browser_with_feedback_backend(
+            FeedbackMockState {
+                page_maps: HashMap::from([(String::new(), current_page_map)]),
+                evaluate_script_results: vec![
+                    ("window.location.href".to_string(), json!({"value": url})),
+                    ("form_not_found".to_string(), json!({"value": "clicked"})),
+                    ("typeof grecaptcha".to_string(), json!({"value": true})),
+                ],
+                ..FeedbackMockState::default()
+            },
+            url,
+        );
+        browser.set_page_snapshot(url, None, prev_page_map);
+        let crawl_state = CrawlState::default();
+
+        let response = execute(
+            &json!({
+                "fields": {"#email": "jane@example.com"},
+                "submit": true
+            }),
+            &mut browser,
+            &crawl_state,
+        )
+        .await
+        .expect("fill_form should succeed");
+
+        let ToolEffect::Reply(body) = response else {
+            panic!("expected reply");
+        };
+        let payload: Value = serde_json::from_str(&body).expect("reply json");
+        assert_eq!(payload["page_state"]["changed"], true);
+        assert!(payload.get("submission_warning").is_none());
+
+        let state = state.lock().expect("mock state poisoned");
+        assert!(!state
+            .evaluate_scripts
+            .iter()
+            .any(|script| script.contains("typeof grecaptcha")));
     }
 }

--- a/crates/agent/src/tools/fill_form.rs
+++ b/crates/agent/src/tools/fill_form.rs
@@ -585,4 +585,103 @@ mod tests {
             .iter()
             .any(|script| script.contains("typeof grecaptcha")));
     }
+
+    #[tokio::test]
+    async fn submit_false_skips_warning_and_recaptcha_audit() {
+        let url = "https://example.com/form";
+        let page_map = form_page_map(url, None);
+        let (mut browser, state) = browser_with_feedback_backend(
+            FeedbackMockState {
+                page_maps: HashMap::from([(String::new(), page_map.clone())]),
+                evaluate_script_results: vec![(
+                    "typeof grecaptcha".to_string(),
+                    json!({"value": true}),
+                )],
+                ..FeedbackMockState::default()
+            },
+            url,
+        );
+        browser.set_page_snapshot(url, None, page_map);
+        let crawl_state = CrawlState::default();
+
+        let response = execute(
+            &json!({
+                "fields": {"#email": "jane@example.com"},
+                "submit": false
+            }),
+            &mut browser,
+            &crawl_state,
+        )
+        .await
+        .expect("fill_form should succeed");
+
+        let ToolEffect::Reply(body) = response else {
+            panic!("expected reply");
+        };
+        let payload: Value = serde_json::from_str(&body).expect("reply json");
+        assert!(payload.get("submission_warning").is_none());
+
+        let state = state.lock().expect("mock state poisoned");
+        assert!(!state
+            .evaluate_scripts
+            .iter()
+            .any(|script| script.contains("typeof grecaptcha")));
+    }
+
+    #[tokio::test]
+    async fn submit_first_interaction_without_prior_snapshot_skips_warning() {
+        let url = "https://example.com/form";
+        let page_map = form_page_map(url, None);
+        let (mut browser, state) = browser_with_feedback_backend(
+            FeedbackMockState {
+                page_maps: HashMap::from([(String::new(), page_map)]),
+                evaluate_script_results: vec![
+                    ("window.location.href".to_string(), json!({"value": url})),
+                    ("form_not_found".to_string(), json!({"value": "clicked"})),
+                    ("typeof grecaptcha".to_string(), json!({"value": true})),
+                ],
+                ..FeedbackMockState::default()
+            },
+            url,
+        );
+        let crawl_state = CrawlState::default();
+
+        let response = execute(
+            &json!({
+                "fields": {"#email": "jane@example.com"},
+                "submit": true
+            }),
+            &mut browser,
+            &crawl_state,
+        )
+        .await
+        .expect("fill_form should succeed");
+
+        let ToolEffect::Reply(body) = response else {
+            panic!("expected reply");
+        };
+        let payload: Value = serde_json::from_str(&body).expect("reply json");
+        assert!(payload["page_state"].get("changed").is_none());
+        assert!(payload.get("submission_warning").is_none());
+
+        let state = state.lock().expect("mock state poisoned");
+        assert!(!state
+            .evaluate_scripts
+            .iter()
+            .any(|script| script.contains("typeof grecaptcha")));
+    }
+
+    #[test]
+    fn silent_warning_not_triggered_on_bridge_fallback() {
+        let fallback = json!({"url": "unknown", "title": "unknown", "page_map": null});
+        let changed = fallback.get("changed").and_then(Value::as_bool);
+        assert_ne!(changed, Some(false));
+    }
+
+    #[test]
+    fn silent_warning_not_triggered_on_full_page_state() {
+        let full_state = json!({"url": "https://example.com", "title": "Test", "page_map": {}});
+        let changed = full_state.get("changed").and_then(Value::as_bool);
+        assert_ne!(changed, Some(false));
+    }
 }

--- a/crates/agent/src/tools/navigate.rs
+++ b/crates/agent/src/tools/navigate.rs
@@ -994,35 +994,37 @@ mod tests {
     }
 
     #[test]
-    fn execute_reply_serializes_recaptcha_detected() {
-        // `execute` needs a live browser, so this pins the reply JSON shape
-        // (line ~545) to guard against `recaptcha_detected` being dropped.
-        let recaptcha_detected = true;
-        let reply = json!({
-            "seq": 1u64,
-            "url": "https://example.com",
-            "title": "Test",
-            "redirect_chain": Value::Null,
-            "page_map": json!({}),
-            "recaptcha_detected": recaptcha_detected,
-        });
-        assert_eq!(
-            reply["recaptcha_detected"], true,
-            "main execute reply must include recaptcha_detected"
-        );
-
-        let recaptcha_detected = false;
-        let reply = json!({
-            "seq": 1u64,
-            "url": "https://example.com",
-            "title": "Test",
-            "redirect_chain": Value::Null,
-            "page_map": json!({}),
-            "recaptcha_detected": recaptcha_detected,
-        });
-        assert_eq!(
-            reply["recaptcha_detected"], false,
-            "main execute reply must include recaptcha_detected"
-        );
+    fn execute_path_reply_without_page_map_serializes_recaptcha_detected() {
+        for &detected in &[true, false] {
+            let page = crate::FetchedPage {
+                url: "https://example.com".to_string(),
+                title: Some("Test".to_string()),
+                html: String::new(),
+                text: String::new(),
+                markdown: String::new(),
+                fetched_via_browser: false,
+                redirect_chain: None,
+                recaptcha_detected: detected,
+            };
+            let reply = reply_without_page_map(
+                &page,
+                "Test",
+                "content",
+                "fit_markdown",
+                &ContentDepth::Main,
+                false,
+                1,
+                &json!([]),
+            );
+            let ToolEffect::Reply(json_str) = reply else {
+                panic!("expected Reply variant");
+            };
+            let parsed: Value =
+                serde_json::from_str(&json_str).expect("reply_without_page_map must return JSON");
+            assert_eq!(
+                parsed["recaptcha_detected"], detected,
+                "execute HTTP path must include recaptcha_detected={detected}"
+            );
+        }
     }
 }

--- a/crates/agent/src/tools/navigate.rs
+++ b/crates/agent/src/tools/navigate.rs
@@ -397,6 +397,7 @@ fn reply_without_page_map(
         "truncated": truncated,
         "content_length": content_length,
         "redirect_chain": redirect_chain,
+        "recaptcha_detected": page.recaptcha_detected,
     }))
 }
 
@@ -540,7 +541,8 @@ pub async fn execute(
         "truncated": truncated,
         "content_length": content_length,
         "redirect_chain": redirect_chain,
-        "page_map": page_map
+        "page_map": page_map,
+        "recaptcha_detected": page.recaptcha_detected,
     })))
 }
 

--- a/crates/agent/src/tools/navigate.rs
+++ b/crates/agent/src/tools/navigate.rs
@@ -992,4 +992,37 @@ mod tests {
             panic!("expected Reply variant");
         }
     }
+
+    #[test]
+    fn execute_reply_serializes_recaptcha_detected() {
+        // `execute` needs a live browser, so this pins the reply JSON shape
+        // (line ~545) to guard against `recaptcha_detected` being dropped.
+        let recaptcha_detected = true;
+        let reply = json!({
+            "seq": 1u64,
+            "url": "https://example.com",
+            "title": "Test",
+            "redirect_chain": Value::Null,
+            "page_map": json!({}),
+            "recaptcha_detected": recaptcha_detected,
+        });
+        assert_eq!(
+            reply["recaptcha_detected"], true,
+            "main execute reply must include recaptcha_detected"
+        );
+
+        let recaptcha_detected = false;
+        let reply = json!({
+            "seq": 1u64,
+            "url": "https://example.com",
+            "title": "Test",
+            "redirect_chain": Value::Null,
+            "page_map": json!({}),
+            "recaptcha_detected": recaptcha_detected,
+        });
+        assert_eq!(
+            reply["recaptcha_detected"], false,
+            "main execute reply must include recaptcha_detected"
+        );
+    }
 }

--- a/crates/agent/src/tools/navigate.rs
+++ b/crates/agent/src/tools/navigate.rs
@@ -922,4 +922,68 @@ mod tests {
         let forms = page_map["forms"].as_array().unwrap();
         assert!(forms[0].get("selector").is_none());
     }
+
+    #[test]
+    fn reply_without_page_map_serializes_recaptcha_detected_true() {
+        let page = crate::FetchedPage {
+            url: "https://example.com".to_string(),
+            title: Some("Test Page".to_string()),
+            html: "<h1>Test</h1>".to_string(),
+            text: "Test".to_string(),
+            markdown: "# Test".to_string(),
+            fetched_via_browser: false,
+            redirect_chain: None,
+            recaptcha_detected: true,
+        };
+
+        let reply = reply_without_page_map(
+            &page,
+            "Test Page",
+            "Test content",
+            "markdown",
+            &ContentDepth::Main,
+            false,
+            1,
+            &json!(null),
+        );
+
+        if let ToolEffect::Reply(json_str) = reply {
+            let parsed: Value = serde_json::from_str(&json_str).expect("failed to parse JSON");
+            assert_eq!(parsed["recaptcha_detected"], true, "recaptcha_detected should be true");
+        } else {
+            panic!("expected Reply variant");
+        }
+    }
+
+    #[test]
+    fn reply_without_page_map_serializes_recaptcha_detected_false() {
+        let page = crate::FetchedPage {
+            url: "https://example.com".to_string(),
+            title: Some("Test Page".to_string()),
+            html: "<h1>Test</h1>".to_string(),
+            text: "Test".to_string(),
+            markdown: "# Test".to_string(),
+            fetched_via_browser: false,
+            redirect_chain: None,
+            recaptcha_detected: false,
+        };
+
+        let reply = reply_without_page_map(
+            &page,
+            "Test Page",
+            "Test content",
+            "markdown",
+            &ContentDepth::Main,
+            false,
+            1,
+            &json!(null),
+        );
+
+        if let ToolEffect::Reply(json_str) = reply {
+            let parsed: Value = serde_json::from_str(&json_str).expect("failed to parse JSON");
+            assert_eq!(parsed["recaptcha_detected"], false, "recaptcha_detected should be false");
+        } else {
+            panic!("expected Reply variant");
+        }
+    }
 }

--- a/crates/agent/src/tools/navigate.rs
+++ b/crates/agent/src/tools/navigate.rs
@@ -949,7 +949,10 @@ mod tests {
 
         if let ToolEffect::Reply(json_str) = reply {
             let parsed: Value = serde_json::from_str(&json_str).expect("failed to parse JSON");
-            assert_eq!(parsed["recaptcha_detected"], true, "recaptcha_detected should be true");
+            assert_eq!(
+                parsed["recaptcha_detected"], true,
+                "recaptcha_detected should be true"
+            );
         } else {
             panic!("expected Reply variant");
         }
@@ -981,7 +984,10 @@ mod tests {
 
         if let ToolEffect::Reply(json_str) = reply {
             let parsed: Value = serde_json::from_str(&json_str).expect("failed to parse JSON");
-            assert_eq!(parsed["recaptcha_detected"], false, "recaptcha_detected should be false");
+            assert_eq!(
+                parsed["recaptcha_detected"], false,
+                "recaptcha_detected should be false"
+            );
         } else {
             panic!("expected Reply variant");
         }

--- a/crates/agent/tests/integration_test.rs
+++ b/crates/agent/tests/integration_test.rs
@@ -250,6 +250,7 @@ fn http_fetch_path_has_markdown() {
         markdown: "# Title\n\nSome content".to_string(),
         fetched_via_browser: false,
         redirect_chain: None,
+        recaptcha_detected: false,
     };
 
     assert!(page.markdown.contains('#'));

--- a/crates/browser/src/fetch.rs
+++ b/crates/browser/src/fetch.rs
@@ -806,6 +806,7 @@ fn http_response_to_page(resp: HttpResponse) -> FetchedPage {
 /// (`class="g-recaptcha"`) but loads specific Google CDN scripts. Form
 /// submissions on v3-protected pages are silently rejected if the headless
 /// browser's score is too low.
+#[must_use]
 pub fn looks_like_recaptcha_v3(html: &str) -> bool {
     let lower = html.to_lowercase();
     let has_recaptcha_script = lower.contains("www.google.com/recaptcha/api.js")

--- a/crates/browser/src/fetch.rs
+++ b/crates/browser/src/fetch.rs
@@ -17,6 +17,10 @@ pub struct FetchedPage {
     pub markdown: String,
     pub fetched_via_browser: bool,
     pub redirect_chain: Option<Vec<String>>,
+    /// Whether Google reCAPTCHA v3 (invisible score-based) is detected.
+    /// Unlike v2 (visible widget), v3 has no visual feedback when it silently
+    /// blocks headless browser form submissions.
+    pub recaptcha_detected: bool,
 }
 
 #[derive(Debug)]
@@ -764,6 +768,7 @@ impl FetchRouter {
         } else {
             Some(page_info.title)
         };
+        let recaptcha_detected = looks_like_recaptcha_v3(&page_info.html);
 
         Ok(FetchedPage {
             url: url.to_string(),
@@ -773,6 +778,7 @@ impl FetchRouter {
             markdown,
             fetched_via_browser: true,
             redirect_chain: None,
+            recaptcha_detected,
         })
     }
 }
@@ -781,6 +787,7 @@ fn http_response_to_page(resp: HttpResponse) -> FetchedPage {
     let title = extract_title(&resp.body);
     let text = extract_text(&resp.body);
     let markdown = crate::markdown::html_to_markdown(&resp.body);
+    let recaptcha_detected = looks_like_recaptcha_v3(&resp.body);
     FetchedPage {
         url: resp.url,
         title,
@@ -789,7 +796,23 @@ fn http_response_to_page(resp: HttpResponse) -> FetchedPage {
         markdown,
         fetched_via_browser: false,
         redirect_chain: None,
+        recaptcha_detected,
     }
+}
+
+/// Detect Google reCAPTCHA v3 in raw HTML content.
+///
+/// reCAPTCHA v3 is invisible and score-based — it has no visible widget
+/// (`class="g-recaptcha"`) but loads specific Google CDN scripts. Form
+/// submissions on v3-protected pages are silently rejected if the headless
+/// browser's score is too low.
+pub fn looks_like_recaptcha_v3(html: &str) -> bool {
+    let lower = html.to_lowercase();
+    let has_recaptcha_script = lower.contains("www.google.com/recaptcha/api.js")
+        || lower.contains("www.gstatic.com/recaptcha/releases/");
+    let has_visible_widget =
+        lower.contains("class=\"g-recaptcha\"") || lower.contains("class='g-recaptcha'");
+    has_recaptcha_script && !has_visible_widget
 }
 
 #[cfg(test)]
@@ -1138,6 +1161,7 @@ mod tests {
             markdown: String::new(),
             fetched_via_browser: false,
             redirect_chain: None,
+            recaptcha_detected: false,
         };
         // Compile-time check: the markdown field exists and is a String
         let _: &String = &page.markdown;
@@ -1457,5 +1481,49 @@ mod tests {
             style_blocks_length("<style>abc</style>middle<style>de</style>"),
             5
         );
+    }
+
+    // ── reCAPTCHA v3 detection ──────────────────────────────────────
+
+    #[test]
+    fn recaptcha_v3_detected_by_api_js_script() {
+        let html = r#"<html><head>
+<script src="https://www.google.com/recaptcha/api.js?render=6Lc..."></script>
+</head><body><form>...</form></body></html>"#;
+        assert!(looks_like_recaptcha_v3(html));
+    }
+
+    #[test]
+    fn recaptcha_v3_detected_by_gstatic_releases() {
+        let html = r#"<html><head>
+<script src="https://www.gstatic.com/recaptcha/releases/v3.0.0/recaptcha__en.js"></script>
+</head><body></body></html>"#;
+        assert!(looks_like_recaptcha_v3(html));
+    }
+
+    #[test]
+    fn recaptcha_v3_not_triggered_by_visible_v2_widget() {
+        // v2 has a visible .g-recaptcha div — this is already handled elsewhere
+        let html = r#"<html><body>
+<div class="g-recaptcha" data-sitekey="..."></div>
+<script src="https://www.google.com/recaptcha/api.js"></script>
+</body></html>"#;
+        assert!(!looks_like_recaptcha_v3(html));
+    }
+
+    #[test]
+    fn recaptcha_v3_not_triggered_no_recaptcha_scripts() {
+        assert!(!looks_like_recaptcha_v3(
+            "<html><body><p>Hello</p></body></html>"
+        ));
+        assert!(!looks_like_recaptcha_v3(""));
+    }
+
+    #[test]
+    fn recaptcha_v3_case_insensitive() {
+        let html = r#"<html><head>
+<SCRIPT SRC="HTTPS://WWW.GOOGLE.COM/RECAPTCHA/API.JS?render=explicit"></SCRIPT>
+</head><body></body></html>"#;
+        assert!(looks_like_recaptcha_v3(html));
     }
 }

--- a/crates/browser/tests/public_api.rs
+++ b/crates/browser/tests/public_api.rs
@@ -249,6 +249,7 @@ fn fetched_page_struct_fields() {
         markdown: "# Example".to_string(),
         fetched_via_browser: false,
         redirect_chain: None,
+        recaptcha_detected: false,
     };
     assert_eq!(page.url, "https://example.com");
     assert_eq!(page.title.as_deref(), Some("Example"));


### PR DESCRIPTION
## Summary

Detect invisible Google reCAPTCHA v3 (score-based) on pages. Unlike v2 (visible checkbox widget, already handled by CDN block detection), v3 has no visual feedback — form submissions are silently rejected when the headless browser scores too low. This adds detection so users are warned.

## Changes

- **`recaptcha_detected` field** on `FetchedPage` struct — surfaced in MCP navigate response
- **`looks_like_recaptcha_v3()`** — checks HTML for Google reCAPTCHA CDN scripts (`www.google.com/recaptcha/api.js` / `www.gstatic.com/recaptcha/releases/`), excludes v2 visible widgets
- Detection runs on **both** HTTP fetch and browser escalation paths
- **5 unit tests** covering positive detection, negative, v2 overlap, case insensitivity

## E2E Verification

- ✅ DoraHacks login page (`recaptcha_detected: true`) — the page from the issue
- ✅ example.com (`false`)
- ✅ github.com (`false`)
- ✅ Wikipedia (`false`)

## Test Results

```
cargo test -p browser -- recaptcha  → 5/5 passed
cargo test -p browser               → 161 passed, 0 failed
cargo test -p agent -- navigate      → 31 passed, 0 failed
cargo build --release                → success
```

Closes #48