### PR TITLE
feat: list_network_activity filters, save_file headers, and post-review fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`list_network_activity` — richer filters and inline content type**: `filter='media'` selects audio/video responses (not images); `method` filters by HTTP verb (case-insensitive); `min_size_kb`/`max_size_kb` bound requests by response size (unknown-size requests are excluded when a size filter is active); `unique_urls=true` collapses duplicate URLs to the representative with the **largest** response size (other fields including `inspect_request(@rN)` reflect that same request), with a `request_count`; every row now includes an inline `content_type` field.
+- **`save_file` — custom request headers**: new `headers` map parameter passes arbitrary HTTP request headers with the download request. Browser-restricted headers (`Referer`, `Origin`, `User-Agent`, etc.) are injected at the network layer via `declarativeNetRequest` in the Chrome-extension backend, rather than relying on the Fetch API which cannot set them. Non-restricted headers are passed directly to `fetch`. Works across both CloakBrowser and Chrome-extension backends.
+
 ## [0.12.2] - 2026-06-23
 
 ### Added

--- a/crates/agent/src/implementation/mod.rs
+++ b/crates/agent/src/implementation/mod.rs
@@ -21,6 +21,9 @@ mod fork;
 mod lifecycle;
 
 #[cfg(test)]
+use std::collections::BTreeMap;
+
+#[cfg(test)]
 use crate::BrowserBackend;
 #[cfg(test)]
 use crate::{BridgeError, BrowserState, PageInfo, ScreenshotOptions};
@@ -1327,7 +1330,12 @@ mod tests {
             Err(BridgeError::Protocol("unused".into()))
         }
 
-        async fn save_file(&mut self, _url: &str, _path: &str) -> Result<String, BridgeError> {
+        async fn save_file(
+            &mut self,
+            _url: &str,
+            _path: &str,
+            _headers: Option<&BTreeMap<String, String>>,
+        ) -> Result<String, BridgeError> {
             Err(BridgeError::Protocol("unused".into()))
         }
 

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -478,7 +478,7 @@ fn list_page_logs_tool() -> ToolSpec {
 fn list_network_activity_tool() -> ToolSpec {
     ToolSpec {
         name: "list_network_activity",
-        description: "List observed network requests buffered during this browser session. Supports temporal filtering by seq window, request-state filters, URL substring filtering, and adjective-based sorting such as slowest/fastest or newest/oldest. Returns stable @rN refs for follow-up inspection with inspect_request.",
+        description: "List observed network requests buffered during this browser session. Supports temporal filtering by seq window, request-state filters, URL substring filtering, adjective-based sorting such as slowest/fastest or newest/oldest, and an inline content_type field on each row. Returns stable @rN refs for follow-up inspection with inspect_request.",
         input_schema: json!({
             "type": "object",
             "properties": {
@@ -506,14 +506,14 @@ fn list_network_activity_tool() -> ToolSpec {
                 "unique_urls": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Collapse multiple requests to the same URL into one row (largest size kept, with request_count)."
+                    "description": "Collapse multiple requests to the same URL into one row. The representative row is the one with the largest response size (ties broken by most recent). Includes request_count."
                 },
                 "min_size_kb": {
-                    "type": "number",
+                    "type": "integer",
                     "description": "Only include requests whose response size is at least this many kilobytes."
                 },
                 "max_size_kb": {
-                    "type": "number",
+                    "type": "integer",
                     "description": "Only include requests whose response size is at most this many kilobytes."
                 },
                 "sort_by": {
@@ -532,7 +532,7 @@ fn list_network_activity_tool() -> ToolSpec {
             "required": [],
             "additionalProperties": false
         }),
-        instructions: Some("Use this to inspect buffered request activity from the current browser session. Default window is since the previous action. Use since='all' for the whole retained session buffer, numeric since/until for half-open [since, until) filtering, filter='xhr' for fetch/XHR-style calls, filter='media' for audio/video, method='POST' to narrow by verb, unique_urls=true to deduplicate, min_size_kb/max_size_kb for size filtering, and sort_by adjective pairs like ['slowest','largest'] for stable ranking. Each listed request gets an @rN id that is only stable for the latest list_network_activity result and can be passed to inspect_request."),
+        instructions: Some("Use this to inspect buffered request activity from the current browser session. Default window is since the previous action. Use since='all' for the whole retained session buffer, numeric since/until for half-open [since, until) filtering, filter='xhr' for fetch/XHR-style calls, filter='media' for audio/video, method='POST' to narrow by verb, unique_urls=true to deduplicate, min_size_kb/max_size_kb for size filtering, and sort_by adjective pairs like ['slowest','largest'] for stable ranking. Each listed request gets an @rN id that is only stable for the latest list_network_activity result and can be passed to inspect_request. Each row includes an inline content_type field (null if no Content-Type header was received)."),
     }
 }
 

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -427,12 +427,17 @@ fn save_file_tool() -> ToolSpec {
                 "output_dir": {
                     "type": "string",
                     "description": "Override the default output directory. Can be relative (resolved against CWD) or absolute. If omitted, uses the configured output_dir from settings."
+                },
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": { "type": "string" },
+                    "description": "Optional HTTP request headers to send with the download (e.g. Referer, Origin, User-Agent). Use for CDNs that reject requests lacking a Referer."
                 }
             },
             "required": ["url"],
             "additionalProperties": false
         }),
-        instructions: Some("Downloads the resource at `url` into the output directory. Optionally specify `filename`, `subdir`, and `output_dir`."),
+        instructions: Some("Downloads the resource at `url` into the output directory. Optionally specify `filename`, `subdir`, `output_dir`, and `headers` (for CDNs that require a Referer or custom header)."),
     }
 }
 
@@ -479,7 +484,7 @@ fn list_network_activity_tool() -> ToolSpec {
             "properties": {
                 "since": {
                     "type": ["string", "number"],
-                    "description": "Start of time window. 'all' = entire session, 'last' = since last action (default), or a seq number from a previous action response."
+                    "description": "Start of time window. 'all' = entire session, 'last' = since last action (default), or a seq number from a previous action response. Network capture starts automatically at browser launch — use `since='all'` to retrieve any request from any point in the session regardless of when it occurred."
                 },
                 "until": {
                     "type": ["string", "number"],
@@ -487,12 +492,29 @@ fn list_network_activity_tool() -> ToolSpec {
                 },
                 "filter": {
                     "type": "string",
-                    "enum": ["all", "xhr", "failed", "pending", "aborted"],
+                    "enum": ["all", "xhr", "media", "failed", "pending", "aborted"],
                     "default": "all"
                 },
                 "pattern": {
                     "type": "string",
                     "description": "URL substring filter"
+                },
+                "method": {
+                    "type": "string",
+                    "description": "Filter by HTTP method (case-insensitive), e.g. 'GET', 'POST'."
+                },
+                "unique_urls": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Collapse multiple requests to the same URL into one row (largest size kept, with request_count)."
+                },
+                "min_size_kb": {
+                    "type": "number",
+                    "description": "Only include requests whose response size is at least this many kilobytes."
+                },
+                "max_size_kb": {
+                    "type": "number",
+                    "description": "Only include requests whose response size is at most this many kilobytes."
                 },
                 "sort_by": {
                     "type": "array",
@@ -510,7 +532,7 @@ fn list_network_activity_tool() -> ToolSpec {
             "required": [],
             "additionalProperties": false
         }),
-        instructions: Some("Use this to inspect buffered request activity from the current browser session. Default window is since the previous action. Use since='all' for the whole retained session buffer, numeric since/until for half-open [since, until) filtering, filter='xhr' for fetch/XHR-style calls, and sort_by adjective pairs like ['slowest','largest'] for stable ranking. Each listed request gets an @rN id that is only stable for the latest list_network_activity result and can be passed to inspect_request."),
+        instructions: Some("Use this to inspect buffered request activity from the current browser session. Default window is since the previous action. Use since='all' for the whole retained session buffer, numeric since/until for half-open [since, until) filtering, filter='xhr' for fetch/XHR-style calls, filter='media' for image/audio/video, method='POST' to narrow by verb, unique_urls=true to deduplicate, min_size_kb/max_size_kb for size filtering, and sort_by adjective pairs like ['slowest','largest'] for stable ranking. Each listed request gets an @rN id that is only stable for the latest list_network_activity result and can be passed to inspect_request."),
     }
 }
 
@@ -1065,5 +1087,51 @@ mod tests {
                 spec.name
             );
         }
+    }
+
+    #[test]
+    fn schema_advertises_new_network_params() {
+        let specs = mvp_tool_specs();
+
+        let net = specs
+            .iter()
+            .find(|s| s.name == "list_network_activity")
+            .expect("list_network_activity tool must exist");
+
+        let props = &net.input_schema["properties"];
+
+        let filter_enum = props["filter"]["enum"]
+            .as_array()
+            .expect("filter must be an enum array");
+        assert!(
+            filter_enum.iter().any(|v| v == "media"),
+            "filter enum must contain 'media', got: {filter_enum:?}"
+        );
+        assert!(
+            props.get("method").is_some(),
+            "list_network_activity must have 'method' property"
+        );
+        assert!(
+            props.get("unique_urls").is_some(),
+            "list_network_activity must have 'unique_urls' property"
+        );
+        assert!(
+            props.get("min_size_kb").is_some(),
+            "list_network_activity must have 'min_size_kb' property"
+        );
+        assert!(
+            props.get("max_size_kb").is_some(),
+            "list_network_activity must have 'max_size_kb' property"
+        );
+
+        let save = specs
+            .iter()
+            .find(|s| s.name == "save_file")
+            .expect("save_file tool must exist");
+
+        assert!(
+            save.input_schema["properties"].get("headers").is_some(),
+            "save_file must have 'headers' property"
+        );
     }
 }

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -532,7 +532,7 @@ fn list_network_activity_tool() -> ToolSpec {
             "required": [],
             "additionalProperties": false
         }),
-        instructions: Some("Use this to inspect buffered request activity from the current browser session. Default window is since the previous action. Use since='all' for the whole retained session buffer, numeric since/until for half-open [since, until) filtering, filter='xhr' for fetch/XHR-style calls, filter='media' for image/audio/video, method='POST' to narrow by verb, unique_urls=true to deduplicate, min_size_kb/max_size_kb for size filtering, and sort_by adjective pairs like ['slowest','largest'] for stable ranking. Each listed request gets an @rN id that is only stable for the latest list_network_activity result and can be passed to inspect_request."),
+        instructions: Some("Use this to inspect buffered request activity from the current browser session. Default window is since the previous action. Use since='all' for the whole retained session buffer, numeric since/until for half-open [since, until) filtering, filter='xhr' for fetch/XHR-style calls, filter='media' for audio/video, method='POST' to narrow by verb, unique_urls=true to deduplicate, min_size_kb/max_size_kb for size filtering, and sort_by adjective pairs like ['slowest','largest'] for stable ranking. Each listed request gets an @rN id that is only stable for the latest list_network_activity result and can be passed to inspect_request."),
     }
 }
 

--- a/crates/agent/src/script_executor/tests.rs
+++ b/crates/agent/src/script_executor/tests.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
@@ -200,7 +201,12 @@ impl BrowserBackend for MockBridge {
         Ok(json!({"links": [], "images": [], "forms": []}))
     }
 
-    async fn save_file(&mut self, url: &str, path: &str) -> Result<String, BridgeError> {
+    async fn save_file(
+        &mut self,
+        url: &str,
+        path: &str,
+        _headers: Option<&BTreeMap<String, String>>,
+    ) -> Result<String, BridgeError> {
         self.log("save_file", json!({"url": url, "path": path}));
         Ok(path.to_string())
     }

--- a/crates/agent/src/tools/feedback.rs
+++ b/crates/agent/src/tools/feedback.rs
@@ -658,7 +658,12 @@ mod tests {
             Ok(json!([]))
         }
 
-        async fn save_file(&mut self, _url: &str, _path: &str) -> Result<String, BridgeError> {
+        async fn save_file(
+            &mut self,
+            _url: &str,
+            _path: &str,
+            _headers: Option<&std::collections::BTreeMap<String, String>>,
+        ) -> Result<String, BridgeError> {
             Ok(String::new())
         }
 

--- a/crates/agent/src/tools/network_activity.rs
+++ b/crates/agent/src/tools/network_activity.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{hash_map::Entry, BTreeMap, HashMap};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use browser::{NetworkRequestEvent, RequestState};
@@ -19,6 +19,7 @@ enum RequestFilter {
     Failed,
     Pending,
     Aborted,
+    Media,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -52,6 +53,10 @@ struct ListInput {
     pattern: Option<String>,
     sort_by: Vec<SortKey>,
     limit: usize,
+    unique_urls: bool,
+    method: Option<String>,
+    min_size_kb: Option<u64>,
+    max_size_kb: Option<u64>,
 }
 
 fn parse_list_input(input: &Value) -> Result<ListInput, CrawlError> {
@@ -88,9 +93,10 @@ fn parse_list_input(input: &Value) -> Result<ListInput, CrawlError> {
         "failed" => RequestFilter::Failed,
         "pending" => RequestFilter::Pending,
         "aborted" => RequestFilter::Aborted,
+        "media" => RequestFilter::Media,
         _ => {
             return Err(CrawlError::new(
-                "'filter' must be one of: all, xhr, failed, pending, aborted",
+                "'filter' must be one of: all, xhr, failed, pending, aborted, media",
             ));
         }
     };
@@ -131,6 +137,26 @@ fn parse_list_input(input: &Value) -> Result<ListInput, CrawlError> {
             usize::try_from(value).unwrap_or(MAX_LIMIT).min(MAX_LIMIT)
         });
 
+    let unique_urls = input
+        .get("unique_urls")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    let method = input
+        .get("method")
+        .and_then(Value::as_str)
+        .map(|value| value.trim().to_uppercase())
+        .filter(|value| !value.is_empty());
+
+    let min_size_kb = input.get("min_size_kb").and_then(Value::as_u64);
+    let max_size_kb = input.get("max_size_kb").and_then(Value::as_u64);
+
+    if let (Some(min), Some(max)) = (min_size_kb, max_size_kb) {
+        if min > max {
+            return Err(CrawlError::new("min_size_kb cannot exceed max_size_kb"));
+        }
+    }
+
     Ok(ListInput {
         since,
         until,
@@ -138,6 +164,10 @@ fn parse_list_input(input: &Value) -> Result<ListInput, CrawlError> {
         pattern,
         sort_by,
         limit,
+        unique_urls,
+        method,
+        min_size_kb,
+        max_size_kb,
     })
 }
 
@@ -170,6 +200,15 @@ fn request_matches_filter(event: &NetworkRequestEvent, filter: RequestFilter) ->
         RequestFilter::Failed => event.state == RequestState::Failed,
         RequestFilter::Pending => event.state == RequestState::Pending,
         RequestFilter::Aborted => event.state == RequestState::Aborted,
+        RequestFilter::Media => event.response_headers.as_ref().is_some_and(|headers| {
+            headers
+                .iter()
+                .find(|(key, _)| key.eq_ignore_ascii_case("content-type"))
+                .is_some_and(|(_, value)| {
+                    let value = value.to_ascii_lowercase();
+                    value.starts_with("video/") || value.starts_with("audio/")
+                })
+        }),
     }
 }
 
@@ -212,7 +251,55 @@ fn latest_requests(events: &[NetworkRequestEvent]) -> Vec<NetworkRequestEvent> {
     by_request_id.into_values().collect()
 }
 
-fn matching_requests(crawl_state: &CrawlState, input: &ListInput) -> Vec<NetworkRequestEvent> {
+fn within_size_bounds(
+    event: &NetworkRequestEvent,
+    min_size_kb: Option<u64>,
+    max_size_kb: Option<u64>,
+) -> bool {
+    let size = event.size_bytes.unwrap_or(0);
+    if let Some(min) = min_size_kb {
+        if size < min.saturating_mul(1024) {
+            return false;
+        }
+    }
+    if let Some(max) = max_size_kb {
+        if size > max.saturating_mul(1024) {
+            return false;
+        }
+    }
+    true
+}
+
+fn deduplicate_by_url(
+    events: Vec<NetworkRequestEvent>,
+) -> (Vec<NetworkRequestEvent>, HashMap<String, u32>) {
+    let mut counts: HashMap<String, u32> = HashMap::new();
+    let mut by_url: HashMap<String, NetworkRequestEvent> = HashMap::new();
+    for event in events {
+        *counts.entry(event.url.clone()).or_insert(0) += 1;
+        match by_url.entry(event.url.clone()) {
+            Entry::Occupied(mut occupied) => {
+                let existing = occupied.get_mut();
+                let max_size = existing.size_bytes.max(event.size_bytes);
+                let event_is_later = (event.seq_at_initiation, event.timestamp_ms)
+                    > (existing.seq_at_initiation, existing.timestamp_ms);
+                if event_is_later {
+                    *existing = event;
+                }
+                existing.size_bytes = max_size;
+            }
+            Entry::Vacant(vacant) => {
+                vacant.insert(event);
+            }
+        }
+    }
+    (by_url.into_values().collect(), counts)
+}
+
+fn matching_requests(
+    crawl_state: &CrawlState,
+    input: &ListInput,
+) -> (Vec<NetworkRequestEvent>, HashMap<String, u32>) {
     let since = match input.since {
         SinceBound::All => 0,
         SinceBound::Last => crawl_state.seq_counter.current().saturating_sub(1),
@@ -223,7 +310,7 @@ fn matching_requests(crawl_state: &CrawlState, input: &ListInput) -> Vec<Network
         UntilBound::Seq(value) => Some(value),
     };
 
-    let mut requests = latest_requests(&crawl_state.network_request_events)
+    let filtered = latest_requests(&crawl_state.network_request_events)
         .into_iter()
         .filter(|event| {
             event.seq_at_initiation >= since
@@ -236,10 +323,23 @@ fn matching_requests(crawl_state: &CrawlState, input: &ListInput) -> Vec<Network
                 .as_deref()
                 .is_none_or(|pattern| event.url.contains(pattern))
         })
+        .filter(|event| {
+            input
+                .method
+                .as_deref()
+                .is_none_or(|method| event.method.eq_ignore_ascii_case(method))
+        })
+        .filter(|event| within_size_bounds(event, input.min_size_kb, input.max_size_kb))
         .collect::<Vec<_>>();
 
+    let (mut requests, request_counts) = if input.unique_urls {
+        deduplicate_by_url(filtered)
+    } else {
+        (filtered, HashMap::new())
+    };
+
     requests.sort_by(|left, right| compare_requests(left, right, &input.sort_by));
-    requests
+    (requests, request_counts)
 }
 
 fn build_by_type(events: &[NetworkRequestEvent]) -> BTreeMap<String, usize> {
@@ -252,8 +352,23 @@ fn build_by_type(events: &[NetworkRequestEvent]) -> BTreeMap<String, usize> {
     by_type
 }
 
-fn build_request_row(event: &NetworkRequestEvent, id: &str, now_ms: u64) -> Value {
-    json!({
+fn build_request_row(
+    event: &NetworkRequestEvent,
+    id: &str,
+    now_ms: u64,
+    request_count: Option<u32>,
+) -> Value {
+    let content_type = event
+        .response_headers
+        .as_ref()
+        .and_then(|headers| {
+            headers
+                .iter()
+                .find(|(key, _)| key.eq_ignore_ascii_case("content-type"))
+        })
+        .map_or(Value::Null, |(_, value)| json!(value));
+
+    let mut row = json!({
         "id": id,
         "url": event.url,
         "method": event.method,
@@ -266,9 +381,18 @@ fn build_request_row(event: &NetworkRequestEvent, id: &str, now_ms: u64) -> Valu
         "duration_ms": event.duration_ms,
         "type": normalize_request_type(&event.request_type),
         "state": state_name(event.state),
+        "content_type": content_type,
         "initiated_ms_ago": (event.state == RequestState::Pending)
             .then_some(now_ms.saturating_sub(event.timestamp_ms)),
-    })
+    });
+
+    if let Some(count) = request_count {
+        if let Some(object) = row.as_object_mut() {
+            object.insert("request_count".to_string(), json!(count));
+        }
+    }
+
+    row
 }
 
 pub async fn list_network_activity(
@@ -287,7 +411,7 @@ pub async fn list_network_activity(
 
     crawl_state.ingest_observations(polled);
 
-    let all_matching = matching_requests(crawl_state, &input);
+    let (all_matching, request_counts) = matching_requests(crawl_state, &input);
     let truncated = all_matching.len() > input.limit;
     let visible = all_matching
         .iter()
@@ -305,7 +429,12 @@ pub async fn list_network_activity(
             crawl_state
                 .network_request_refs
                 .insert(id.clone(), event.clone());
-            build_request_row(event, &id, now_ms)
+            let request_count = if input.unique_urls {
+                request_counts.get(&event.url).copied()
+            } else {
+                None
+            };
+            build_request_row(event, &id, now_ms, request_count)
         })
         .collect::<Vec<_>>();
 
@@ -501,6 +630,10 @@ mod tests {
         assert_eq!(input.filter, RequestFilter::All);
         assert_eq!(input.sort_by, vec![SortKey::Oldest]);
         assert_eq!(input.limit, DEFAULT_LIMIT);
+        assert!(!input.unique_urls);
+        assert_eq!(input.method, None);
+        assert_eq!(input.min_size_kb, None);
+        assert_eq!(input.max_size_kb, None);
     }
 
     #[test]
@@ -539,7 +672,7 @@ mod tests {
         };
         let input = parse_list_input(&json!({"since": 2, "until": 3})).unwrap();
 
-        let requests = matching_requests(&state, &input);
+        let (requests, _counts) = matching_requests(&state, &input);
         assert_eq!(requests.len(), 1);
         assert_eq!(requests[0].request_id, "two");
     }
@@ -580,7 +713,8 @@ mod tests {
         };
         let input = parse_list_input(&json!({"sort_by": ["slowest", "newest"]})).unwrap();
 
-        let ids = matching_requests(&state, &input)
+        let (requests, _counts) = matching_requests(&state, &input);
+        let ids = requests
             .into_iter()
             .map(|request| request.request_id)
             .collect::<Vec<_>>();
@@ -669,5 +803,434 @@ mod tests {
         assert!(rendered_no_body.contains("ttfb_ms"));
         assert!(!rendered_no_body.contains("REQ_BODY_MARKER"));
         assert!(!rendered_no_body.contains("RESP_BODY_MARKER"));
+    }
+
+    fn reply_payload(effect: &ToolEffect) -> Value {
+        match effect {
+            ToolEffect::Reply(body) => {
+                serde_json::from_str(body).expect("reply body should be valid json")
+            }
+            other => panic!("expected reply effect, got {other:?}"),
+        }
+    }
+
+    fn row_urls(payload: &Value) -> Vec<String> {
+        payload["requests"]
+            .as_array()
+            .expect("requests should be an array")
+            .iter()
+            .map(|row| {
+                row["url"]
+                    .as_str()
+                    .expect("row url should be a string")
+                    .to_string()
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn media_filter_matches_video_and_audio_content_types() {
+        use crate::tools::test_support::browser_with_observations;
+
+        let mut video = event(
+            "vid",
+            1,
+            10,
+            Some(10),
+            Some(1000),
+            "media",
+            RequestState::Completed,
+        );
+        video.response_headers = Some(BTreeMap::from([(
+            "Content-Type".to_string(),
+            "video/mp4".to_string(),
+        )]));
+        let mut audio = event(
+            "aud",
+            2,
+            20,
+            Some(10),
+            Some(1000),
+            "media",
+            RequestState::Completed,
+        );
+        audio.response_headers = Some(BTreeMap::from([(
+            "content-type".to_string(),
+            "audio/ogg".to_string(),
+        )]));
+        let mut html = event(
+            "doc",
+            3,
+            30,
+            Some(10),
+            Some(1000),
+            "document",
+            RequestState::Completed,
+        );
+        html.response_headers = Some(BTreeMap::from([(
+            "content-type".to_string(),
+            "text/html".to_string(),
+        )]));
+        let no_headers = event(
+            "bare",
+            4,
+            40,
+            Some(10),
+            Some(1000),
+            "fetch",
+            RequestState::Completed,
+        );
+
+        let observations = vec![
+            ObservationEvent::NetworkRequest(Box::new(video)),
+            ObservationEvent::NetworkRequest(Box::new(audio)),
+            ObservationEvent::NetworkRequest(Box::new(html)),
+            ObservationEvent::NetworkRequest(Box::new(no_headers)),
+        ];
+        let mut browser = browser_with_observations(observations);
+        let mut state = CrawlState::default();
+
+        let effect = list_network_activity(
+            &json!({ "since": "all", "filter": "media" }),
+            &mut browser,
+            &mut state,
+        )
+        .await
+        .expect("list_network_activity should succeed");
+        let payload = reply_payload(&effect);
+
+        let urls = row_urls(&payload);
+        assert_eq!(urls.len(), 2, "only video and audio responses match media");
+        assert!(urls.iter().any(|url| url.ends_with("/vid")));
+        assert!(urls.iter().any(|url| url.ends_with("/aud")));
+        assert!(!urls.iter().any(|url| url.ends_with("/doc")));
+        assert!(
+            !urls.iter().any(|url| url.ends_with("/bare")),
+            "events without response_headers fail closed"
+        );
+    }
+
+    #[tokio::test]
+    async fn method_filter_is_case_insensitive() {
+        use crate::tools::test_support::browser_with_observations;
+
+        let mut post = event(
+            "p",
+            1,
+            10,
+            Some(10),
+            Some(100),
+            "fetch",
+            RequestState::Completed,
+        );
+        post.method = "POST".to_string();
+        let get_one = event(
+            "g1",
+            2,
+            20,
+            Some(10),
+            Some(100),
+            "fetch",
+            RequestState::Completed,
+        );
+        let get_two = event(
+            "g2",
+            3,
+            30,
+            Some(10),
+            Some(100),
+            "fetch",
+            RequestState::Completed,
+        );
+
+        let observations = vec![
+            ObservationEvent::NetworkRequest(Box::new(post)),
+            ObservationEvent::NetworkRequest(Box::new(get_one)),
+            ObservationEvent::NetworkRequest(Box::new(get_two)),
+        ];
+        let mut browser = browser_with_observations(observations);
+        let mut state = CrawlState::default();
+
+        let effect = list_network_activity(
+            &json!({ "since": "all", "method": "post" }),
+            &mut browser,
+            &mut state,
+        )
+        .await
+        .expect("list_network_activity should succeed");
+        let payload = reply_payload(&effect);
+
+        let rows = payload["requests"]
+            .as_array()
+            .expect("requests should be an array");
+        assert_eq!(rows.len(), 1, "lowercase method input matches POST events");
+        assert_eq!(rows[0]["method"].as_str(), Some("POST"));
+        assert!(rows[0]["url"].as_str().unwrap().ends_with("/p"));
+    }
+
+    #[tokio::test]
+    async fn size_range_filter_bounds_requests() {
+        use crate::tools::test_support::browser_with_observations;
+
+        let below = event(
+            "below",
+            1,
+            10,
+            Some(10),
+            Some(50_000),
+            "fetch",
+            RequestState::Completed,
+        );
+        let inside_low = event(
+            "low",
+            2,
+            20,
+            Some(10),
+            Some(200_000),
+            "fetch",
+            RequestState::Completed,
+        );
+        let inside_high = event(
+            "high",
+            3,
+            30,
+            Some(10),
+            Some(300_000),
+            "fetch",
+            RequestState::Completed,
+        );
+        let above = event(
+            "above",
+            4,
+            40,
+            Some(10),
+            Some(600_000),
+            "fetch",
+            RequestState::Completed,
+        );
+
+        let observations = vec![
+            ObservationEvent::NetworkRequest(Box::new(below)),
+            ObservationEvent::NetworkRequest(Box::new(inside_low)),
+            ObservationEvent::NetworkRequest(Box::new(inside_high)),
+            ObservationEvent::NetworkRequest(Box::new(above)),
+        ];
+        let mut browser = browser_with_observations(observations);
+        let mut state = CrawlState::default();
+
+        let effect = list_network_activity(
+            &json!({ "since": "all", "min_size_kb": 100, "max_size_kb": 500 }),
+            &mut browser,
+            &mut state,
+        )
+        .await
+        .expect("list_network_activity should succeed");
+        let payload = reply_payload(&effect);
+
+        let urls = row_urls(&payload);
+        assert_eq!(urls.len(), 2, "only in-range sizes survive");
+        assert!(urls.iter().any(|url| url.ends_with("/low")));
+        assert!(urls.iter().any(|url| url.ends_with("/high")));
+    }
+
+    #[test]
+    fn size_range_rejects_inverted_bounds() {
+        let result = parse_list_input(&json!({ "min_size_kb": 500, "max_size_kb": 100 }));
+        let error = result.expect_err("inverted size bounds should be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("min_size_kb cannot exceed max_size_kb"),
+            "unexpected error message: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn inverted_size_bounds_make_handler_error() {
+        use crate::tools::test_support::browser_with_observations;
+
+        let mut browser = browser_with_observations(vec![]);
+        let mut state = CrawlState::default();
+
+        let result = list_network_activity(
+            &json!({ "min_size_kb": 500, "max_size_kb": 100 }),
+            &mut browser,
+            &mut state,
+        )
+        .await;
+
+        assert!(result.is_err(), "handler must surface the validation error");
+    }
+
+    #[tokio::test]
+    async fn unique_urls_collapses_same_url_keeping_latest_and_max_size() {
+        use crate::tools::test_support::browser_with_observations;
+
+        let mut first = event(
+            "a",
+            1,
+            100,
+            Some(10),
+            Some(1000),
+            "fetch",
+            RequestState::Completed,
+        );
+        first.url = "https://example.com/same".to_string();
+        let mut second = event(
+            "b",
+            2,
+            200,
+            Some(10),
+            Some(3000),
+            "fetch",
+            RequestState::Completed,
+        );
+        second.url = "https://example.com/same".to_string();
+        let mut third = event(
+            "c",
+            3,
+            300,
+            Some(10),
+            Some(2000),
+            "fetch",
+            RequestState::Completed,
+        );
+        third.url = "https://example.com/same".to_string();
+
+        let observations = vec![
+            ObservationEvent::NetworkRequest(Box::new(first)),
+            ObservationEvent::NetworkRequest(Box::new(second)),
+            ObservationEvent::NetworkRequest(Box::new(third)),
+        ];
+        let mut browser = browser_with_observations(observations);
+        let mut state = CrawlState::default();
+
+        let effect = list_network_activity(
+            &json!({ "since": "all", "unique_urls": true }),
+            &mut browser,
+            &mut state,
+        )
+        .await
+        .expect("list_network_activity should succeed");
+        let payload = reply_payload(&effect);
+
+        let rows = payload["requests"]
+            .as_array()
+            .expect("requests should be an array");
+        assert_eq!(rows.len(), 1, "same-url events collapse to one row");
+        assert_eq!(rows[0]["request_count"].as_u64(), Some(3));
+        // max of {1000, 3000, 2000} bytes = 3000 -> round(3000 / 1024) = 3 KB
+        assert_eq!(rows[0]["size_kb"].as_u64(), Some(3), "dedup keeps max size");
+
+        let representative = state
+            .network_request_refs
+            .get("@r1")
+            .expect("@r1 should resolve to the representative event");
+        assert_eq!(
+            representative.request_id, "c",
+            "representative keeps the latest event's request_id"
+        );
+    }
+
+    #[tokio::test]
+    async fn content_type_present_for_typed_response_and_null_otherwise() {
+        use crate::tools::test_support::browser_with_observations;
+
+        let mut typed = event(
+            "typed",
+            1,
+            10,
+            Some(10),
+            Some(100),
+            "fetch",
+            RequestState::Completed,
+        );
+        typed.response_headers = Some(BTreeMap::from([(
+            "Content-Type".to_string(),
+            "application/json".to_string(),
+        )]));
+        let untyped = event(
+            "untyped",
+            2,
+            20,
+            Some(10),
+            Some(100),
+            "fetch",
+            RequestState::Completed,
+        );
+
+        let observations = vec![
+            ObservationEvent::NetworkRequest(Box::new(typed)),
+            ObservationEvent::NetworkRequest(Box::new(untyped)),
+        ];
+        let mut browser = browser_with_observations(observations);
+        let mut state = CrawlState::default();
+
+        let effect = list_network_activity(
+            &json!({ "since": "all", "sort_by": ["oldest"] }),
+            &mut browser,
+            &mut state,
+        )
+        .await
+        .expect("list_network_activity should succeed");
+        let payload = reply_payload(&effect);
+
+        let rows = payload["requests"]
+            .as_array()
+            .expect("requests should be an array");
+        let typed_row = rows
+            .iter()
+            .find(|row| row["url"].as_str().unwrap().ends_with("/typed"))
+            .expect("typed row present");
+        let untyped_row = rows
+            .iter()
+            .find(|row| row["url"].as_str().unwrap().ends_with("/untyped"))
+            .expect("untyped row present");
+
+        assert_eq!(
+            typed_row["content_type"].as_str(),
+            Some("application/json"),
+            "content_type surfaces inline"
+        );
+        assert!(
+            untyped_row.get("content_type").is_some(),
+            "content_type key is always present"
+        );
+        assert!(
+            untyped_row["content_type"].is_null(),
+            "content_type is null when response_headers are absent"
+        );
+    }
+
+    #[tokio::test]
+    async fn defaults_omit_request_count_field() {
+        use crate::tools::test_support::browser_with_observations;
+
+        let observations = vec![ObservationEvent::NetworkRequest(Box::new(event(
+            "data",
+            1,
+            10,
+            Some(16),
+            Some(128),
+            "fetch",
+            RequestState::Completed,
+        )))];
+        let mut browser = browser_with_observations(observations);
+        let mut state = CrawlState::default();
+
+        let effect = list_network_activity(&json!({ "since": "all" }), &mut browser, &mut state)
+            .await
+            .expect("list_network_activity should succeed");
+        let payload = reply_payload(&effect);
+
+        let rows = payload["requests"]
+            .as_array()
+            .expect("requests should be an array");
+        assert_eq!(rows.len(), 1);
+        assert!(
+            rows[0].get("request_count").is_none(),
+            "request_count is omitted without unique_urls"
+        );
+        assert_eq!(payload["summary"]["total"].as_u64(), Some(1));
     }
 }

--- a/crates/agent/src/tools/network_activity.rs
+++ b/crates/agent/src/tools/network_activity.rs
@@ -148,8 +148,8 @@ fn parse_list_input(input: &Value) -> Result<ListInput, CrawlError> {
         .map(|value| value.trim().to_uppercase())
         .filter(|value| !value.is_empty());
 
-    let min_size_kb = input.get("min_size_kb").and_then(Value::as_u64);
-    let max_size_kb = input.get("max_size_kb").and_then(Value::as_u64);
+    let min_size_kb = parse_size_kb_input(input, "min_size_kb");
+    let max_size_kb = parse_size_kb_input(input, "max_size_kb");
 
     if let (Some(min), Some(max)) = (min_size_kb, max_size_kb) {
         if min > max {
@@ -179,6 +179,14 @@ fn now_ms() -> u64 {
             let ms = duration.as_millis() as u64;
             ms
         })
+}
+
+fn parse_size_kb_input(input: &Value, key: &str) -> Option<u64> {
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    input
+        .get(key)
+        .and_then(Value::as_f64)
+        .map(|value| value.max(0.0) as u64)
 }
 
 fn normalize_request_type(request_type: &str) -> String {
@@ -256,7 +264,13 @@ fn within_size_bounds(
     min_size_kb: Option<u64>,
     max_size_kb: Option<u64>,
 ) -> bool {
-    let size = event.size_bytes.unwrap_or(0);
+    if min_size_kb.is_none() && max_size_kb.is_none() {
+        return true;
+    }
+    // Exclude requests with unknown size when a size filter is active
+    let Some(size) = event.size_bytes else {
+        return false;
+    };
     if let Some(min) = min_size_kb {
         if size < min.saturating_mul(1024) {
             return false;
@@ -280,13 +294,16 @@ fn deduplicate_by_url(
         match by_url.entry(event.url.clone()) {
             Entry::Occupied(mut occupied) => {
                 let existing = occupied.get_mut();
-                let max_size = existing.size_bytes.max(event.size_bytes);
-                let event_is_later = (event.seq_at_initiation, event.timestamp_ms)
+                // Keep the event with the largest size_bytes as the representative
+                // so that inspect_request(@rN) reflects the same request as size_kb.
+                // Tie-break: prefer the latest by (seq_at_initiation, timestamp_ms).
+                let new_is_larger = event.size_bytes > existing.size_bytes;
+                let same_size = event.size_bytes == existing.size_bytes;
+                let new_is_later = (event.seq_at_initiation, event.timestamp_ms)
                     > (existing.seq_at_initiation, existing.timestamp_ms);
-                if event_is_later {
+                if new_is_larger || (same_size && new_is_later) {
                     *existing = event;
                 }
-                existing.size_bytes = max_size;
             }
             Entry::Vacant(vacant) => {
                 vacant.insert(event);
@@ -1063,7 +1080,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unique_urls_collapses_same_url_keeping_latest_and_max_size() {
+    async fn unique_urls_collapses_same_url_keeping_largest_representative() {
         use crate::tools::test_support::browser_with_observations;
 
         let mut first = event(
@@ -1127,8 +1144,8 @@ mod tests {
             .get("@r1")
             .expect("@r1 should resolve to the representative event");
         assert_eq!(
-            representative.request_id, "c",
-            "representative keeps the latest event's request_id"
+            representative.request_id, "b",
+            "representative keeps the largest event's request_id"
         );
     }
 

--- a/crates/agent/src/tools/page_logs.rs
+++ b/crates/agent/src/tools/page_logs.rs
@@ -595,7 +595,12 @@ mod tests {
         async fn list_resources(&mut self) -> Result<Value, BridgeError> {
             Ok(json!([]))
         }
-        async fn save_file(&mut self, _: &str, _: &str) -> Result<String, BridgeError> {
+        async fn save_file(
+            &mut self,
+            _: &str,
+            _: &str,
+            _headers: Option<&BTreeMap<String, String>>,
+        ) -> Result<String, BridgeError> {
             Ok(String::new())
         }
         async fn click(&mut self, _: &str) -> Result<(), BridgeError> {

--- a/crates/agent/src/tools/save_file.rs
+++ b/crates/agent/src/tools/save_file.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::{Component, Path};
 
 use serde_json::{json, Value};
@@ -9,6 +10,7 @@ pub struct SaveFileInput {
     pub url: String,
     pub filename: String,
     pub subdir: Option<String>,
+    pub headers: Option<BTreeMap<String, String>>,
 }
 
 pub fn parse_input(input: &Value) -> Result<SaveFileInput, CrawlError> {
@@ -32,10 +34,28 @@ pub fn parse_input(input: &Value) -> Result<SaveFileInput, CrawlError> {
         validate_relative_path("subdir", subdir)?;
     }
 
+    let headers = match input.get("headers").and_then(|v| v.as_object()) {
+        Some(obj) if !obj.is_empty() => {
+            let mut map = BTreeMap::new();
+            for (key, value) in obj {
+                if let Some(value) = value.as_str() {
+                    map.insert(key.clone(), value.to_string());
+                }
+            }
+            if map.is_empty() {
+                None
+            } else {
+                Some(map)
+            }
+        }
+        _ => None,
+    };
+
     Ok(SaveFileInput {
         url,
         filename,
         subdir,
+        headers,
     })
 }
 
@@ -122,7 +142,7 @@ pub async fn execute(
         .acquire_bridge()
         .await
         .map_err(|e| ToolExecutionError::new(e.to_string()))?
-        .save_file(&parsed.url, &path_str)
+        .save_file(&parsed.url, &path_str, parsed.headers.as_ref())
         .await
         .map_err(|e| ToolExecutionError::new(e.to_string()))?;
 
@@ -136,6 +156,11 @@ pub async fn execute(
 #[cfg(test)]
 mod tests {
     use serde_json::json;
+    use std::collections::BTreeMap;
+
+    use crate::tools::test_support::{
+        browser_with_save_file_header_recorder, take_recorded_save_file_headers,
+    };
 
     use super::*;
 
@@ -175,11 +200,69 @@ mod tests {
     }
 
     #[test]
+    fn parse_input_reads_headers() {
+        let input = json!({
+            "url": "https://example.com/file.mp4",
+            "headers": { "Referer": "https://www.bilibili.com", "X-Test": "42" }
+        });
+
+        let parsed = parse_input(&input).unwrap();
+        let headers = parsed.headers.unwrap();
+
+        assert_eq!(
+            headers.get("Referer").map(std::string::String::as_str),
+            Some("https://www.bilibili.com")
+        );
+        assert_eq!(
+            headers.get("X-Test").map(std::string::String::as_str),
+            Some("42")
+        );
+    }
+
+    #[test]
+    fn parse_input_empty_headers_yields_none() {
+        let input = json!({ "url": "https://example.com/file.mp4", "headers": {} });
+        let parsed = parse_input(&input).unwrap();
+        assert!(parsed.headers.is_none());
+    }
+
+    #[test]
     fn rejects_path_traversal() {
         let input = json!({"url": "https://example.com/file.txt", "filename": "../file.txt"});
         assert!(parse_input(&input).is_err());
 
         let input = json!({"url": "https://example.com/file.txt", "filename": "file.txt", "subdir": "../outside"});
         assert!(parse_input(&input).is_err());
+    }
+
+    #[tokio::test]
+    async fn save_file_forwards_headers_to_backend() {
+        let (mut browser, recorder) = browser_with_save_file_header_recorder(vec![]);
+
+        execute(
+            &json!({
+                "url": "https://example.com/file.mp4",
+                "headers": {
+                    "Referer": "https://www.bilibili.com",
+                    "X-Test": "42"
+                }
+            }),
+            &mut browser,
+        )
+        .await
+        .expect("save_file should succeed");
+
+        let headers = take_recorded_save_file_headers(&recorder)
+            .await
+            .expect("backend should record forwarded headers");
+
+        let expected = BTreeMap::from([
+            (
+                "Referer".to_string(),
+                "https://www.bilibili.com".to_string(),
+            ),
+            ("X-Test".to_string(), "42".to_string()),
+        ]);
+        assert_eq!(headers, expected);
     }
 }

--- a/crates/agent/src/tools/screenshot.rs
+++ b/crates/agent/src/tools/screenshot.rs
@@ -251,7 +251,12 @@ mod tests {
         async fn list_resources(&mut self) -> Result<serde_json::Value, BridgeError> {
             Ok(serde_json::json!([]))
         }
-        async fn save_file(&mut self, _: &str, _: &str) -> Result<String, BridgeError> {
+        async fn save_file(
+            &mut self,
+            _: &str,
+            _: &str,
+            _headers: Option<&std::collections::BTreeMap<String, String>>,
+        ) -> Result<String, BridgeError> {
             Ok(String::new())
         }
         async fn click(&mut self, _: &str) -> Result<(), BridgeError> {

--- a/crates/agent/src/tools/select_option.rs
+++ b/crates/agent/src/tools/select_option.rs
@@ -1110,7 +1110,12 @@ mod tests {
             Ok(json!([]))
         }
 
-        async fn save_file(&mut self, _url: &str, _path: &str) -> Result<String, BridgeError> {
+        async fn save_file(
+            &mut self,
+            _url: &str,
+            _path: &str,
+            _headers: Option<&std::collections::BTreeMap<String, String>>,
+        ) -> Result<String, BridgeError> {
             Ok(String::new())
         }
 

--- a/crates/agent/src/tools/test_support.rs
+++ b/crates/agent/src/tools/test_support.rs
@@ -3,6 +3,7 @@
 //! observation tools be exercised over the full `poll_observations` dispatch
 //! path (the path that regressed in the inherent-vs-trait wiring bug).
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -13,9 +14,13 @@ use browser::{
 use serde_json::{json, Value};
 use tokio::sync::Mutex;
 
+pub type SaveFileHeadersRecord = Arc<Mutex<Option<BTreeMap<String, String>>>>;
+
 #[derive(Debug, Default)]
 pub struct ObservationMockBackend {
     pub observations: Vec<ObservationEvent>,
+    pub last_save_file_headers: Option<BTreeMap<String, String>>,
+    pub save_file_headers_sink: Option<SaveFileHeadersRecord>,
 }
 
 #[async_trait]
@@ -92,7 +97,16 @@ impl BrowserBackend for ObservationMockBackend {
     async fn list_resources(&mut self) -> Result<Value, BridgeError> {
         Ok(json!([]))
     }
-    async fn save_file(&mut self, _: &str, _: &str) -> Result<String, BridgeError> {
+    async fn save_file(
+        &mut self,
+        _: &str,
+        _: &str,
+        headers: Option<&BTreeMap<String, String>>,
+    ) -> Result<String, BridgeError> {
+        self.last_save_file_headers = headers.cloned();
+        if let Some(sink) = &self.save_file_headers_sink {
+            *sink.lock().await = self.last_save_file_headers.clone();
+        }
         Ok(String::new())
     }
     async fn click(&mut self, _: &str) -> Result<(), BridgeError> {
@@ -126,8 +140,29 @@ impl BrowserBackend for ObservationMockBackend {
 
 #[must_use]
 pub fn browser_with_observations(observations: Vec<ObservationEvent>) -> BrowserContext {
-    let bridge: SharedBridge = Arc::new(Mutex::new(
-        Box::new(ObservationMockBackend { observations }) as Box<dyn BrowserBackend + Send>,
-    ));
+    let bridge: SharedBridge = Arc::new(Mutex::new(Box::new(ObservationMockBackend {
+        observations,
+        last_save_file_headers: None,
+        save_file_headers_sink: None,
+    }) as Box<dyn BrowserBackend + Send>));
     BrowserContext::new(bridge)
+}
+
+#[must_use]
+pub fn browser_with_save_file_header_recorder(
+    observations: Vec<ObservationEvent>,
+) -> (BrowserContext, SaveFileHeadersRecord) {
+    let sink = Arc::new(Mutex::new(None));
+    let bridge: SharedBridge = Arc::new(Mutex::new(Box::new(ObservationMockBackend {
+        observations,
+        last_save_file_headers: None,
+        save_file_headers_sink: Some(sink.clone()),
+    }) as Box<dyn BrowserBackend + Send>));
+    (BrowserContext::new(bridge), sink)
+}
+
+pub async fn take_recorded_save_file_headers(
+    sink: &SaveFileHeadersRecord,
+) -> Option<BTreeMap<String, String>> {
+    sink.lock().await.clone()
 }

--- a/crates/agent/tests/integration_test.rs
+++ b/crates/agent/tests/integration_test.rs
@@ -365,7 +365,12 @@ mod set_device_integration {
         async fn list_resources(&mut self) -> Result<serde_json::Value, BridgeError> {
             unreachable!()
         }
-        async fn save_file(&mut self, _url: &str, _path: &str) -> Result<String, BridgeError> {
+        async fn save_file(
+            &mut self,
+            _url: &str,
+            _path: &str,
+            _headers: Option<&std::collections::BTreeMap<String, String>>,
+        ) -> Result<String, BridgeError> {
             unreachable!()
         }
         async fn click(&mut self, _selector: &str) -> Result<(), BridgeError> {
@@ -489,7 +494,12 @@ mod set_device_integration {
         async fn list_resources(&mut self) -> Result<serde_json::Value, BridgeError> {
             unreachable!()
         }
-        async fn save_file(&mut self, _url: &str, _path: &str) -> Result<String, BridgeError> {
+        async fn save_file(
+            &mut self,
+            _url: &str,
+            _path: &str,
+            _headers: Option<&std::collections::BTreeMap<String, String>>,
+        ) -> Result<String, BridgeError> {
             unreachable!()
         }
         async fn click(&mut self, _selector: &str) -> Result<(), BridgeError> {

--- a/crates/browser/src/browser_backend.rs
+++ b/crates/browser/src/browser_backend.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 
 use async_trait::async_trait;
@@ -110,7 +110,12 @@ pub trait BrowserBackend: Debug {
     async fn import_cookies_only(&mut self, state: &BrowserState) -> Result<(), BridgeError>;
     async fn import_local_storage(&mut self, state: &BrowserState) -> Result<(), BridgeError>;
     async fn list_resources(&mut self) -> Result<serde_json::Value, BridgeError>;
-    async fn save_file(&mut self, url: &str, path: &str) -> Result<String, BridgeError>;
+    async fn save_file(
+        &mut self,
+        url: &str,
+        path: &str,
+        headers: Option<&BTreeMap<String, String>>,
+    ) -> Result<String, BridgeError>;
     async fn click(&mut self, selector: &str) -> Result<(), BridgeError>;
     async fn click_at(&mut self, x: f64, y: f64) -> Result<(), BridgeError>;
     async fn fill(&mut self, selector: &str, value: &str) -> Result<(), BridgeError>;

--- a/crates/browser/src/extension.rs
+++ b/crates/browser/src/extension.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -347,12 +348,22 @@ impl BrowserBackend for ExtensionBridge {
         Self::require_result(response, "list_resources")
     }
 
-    async fn save_file(&mut self, url: &str, path: &str) -> Result<String, BridgeError> {
+    async fn save_file(
+        &mut self,
+        url: &str,
+        path: &str,
+        headers: Option<&BTreeMap<String, String>>,
+    ) -> Result<String, BridgeError> {
         if path.contains("..") {
             return Err(BridgeError::Protocol(
                 "save_file path contains path traversal".into(),
             ));
         }
+
+        let headers = headers
+            .map(serde_json::to_value)
+            .transpose()?
+            .unwrap_or_else(|| json!({}));
 
         let response = self
             .send_command(
@@ -360,6 +371,7 @@ impl BrowserBackend for ExtensionBridge {
                 json!({
                     "url": url,
                     "path": path,
+                    "headers": headers,
                 }),
             )
             .await?;

--- a/crates/browser/src/playwright/backend_impl.rs
+++ b/crates/browser/src/playwright/backend_impl.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use crate::browser_backend::{BrowserBackend, ScreenshotOptions};
 use crate::{ConsoleMessageEvent, NetworkRequestEvent, ObservationEvent, WebSocketFrameEvent};
 
@@ -162,8 +164,13 @@ impl BrowserBackend for PlaywrightBridge {
         PlaywrightBridge::list_resources(self).await
     }
 
-    async fn save_file(&mut self, url: &str, path: &str) -> Result<String, BridgeError> {
-        PlaywrightBridge::save_file(self, url, path).await
+    async fn save_file(
+        &mut self,
+        url: &str,
+        path: &str,
+        headers: Option<&BTreeMap<String, String>>,
+    ) -> Result<String, BridgeError> {
+        PlaywrightBridge::save_file(self, url, path, headers).await
     }
 
     async fn click(&mut self, selector: &str) -> Result<(), BridgeError> {

--- a/crates/browser/src/playwright/bridge.rs
+++ b/crates/browser/src/playwright/bridge.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Duration;
@@ -584,11 +585,20 @@ impl PlaywrightBridge {
         self.send_raw_command(&cmd).await
     }
 
-    pub async fn save_file(&mut self, url: &str, path: &str) -> Result<String, BridgeError> {
+    pub async fn save_file(
+        &mut self,
+        url: &str,
+        path: &str,
+        headers: Option<&BTreeMap<String, String>>,
+    ) -> Result<String, BridgeError> {
+        let headers_json = headers
+            .map(|map| serde_json::to_value(map).unwrap_or(serde_json::json!({})))
+            .unwrap_or(serde_json::json!({}));
         let cmd = serde_json::json!({
             "action": "save_file",
             "url": url,
             "path": path,
+            "headers": headers_json,
         });
         let result = self.send_raw_command(&cmd).await?;
         Ok(result

--- a/crates/browser/src/playwright/bridge_script.rs
+++ b/crates/browser/src/playwright/bridge_script.rs
@@ -1288,7 +1288,7 @@ async function bootstrap() {
       try {
         const fs = require('node:fs');
         const nodePath = require('node:path');
-        const response = await context.request.get(command.url, { timeout: 30000 });
+        const response = await context.request.get(command.url, { headers: command.headers || {}, timeout: 30000 });
         if (!response.ok()) {
           throw new Error(`HTTP ${response.status()} ${response.statusText()} for ${command.url}`);
         }

--- a/crates/browser/src/testing.rs
+++ b/crates/browser/src/testing.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use async_trait::async_trait;
 use serde_json::Value;
 
@@ -74,7 +76,12 @@ impl BrowserBackend for NopBridge {
     async fn list_resources(&mut self) -> Result<Value, BridgeError> {
         Err(BridgeError::Protocol("NopBridge".into()))
     }
-    async fn save_file(&mut self, _url: &str, _path: &str) -> Result<String, BridgeError> {
+    async fn save_file(
+        &mut self,
+        _url: &str,
+        _path: &str,
+        _headers: Option<&BTreeMap<String, String>>,
+    ) -> Result<String, BridgeError> {
         Err(BridgeError::Protocol("NopBridge".into()))
     }
     async fn click(&mut self, _selector: &str) -> Result<(), BridgeError> {

--- a/crates/browser/tests/public_api.rs
+++ b/crates/browser/tests/public_api.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -124,7 +125,12 @@ impl BrowserBackend for MockBrowserBackend {
         Ok(serde_json::json!({"links": [], "images": []}))
     }
 
-    async fn save_file(&mut self, _url: &str, _path: &str) -> Result<String, BridgeError> {
+    async fn save_file(
+        &mut self,
+        _url: &str,
+        _path: &str,
+        _headers: Option<&BTreeMap<String, String>>,
+    ) -> Result<String, BridgeError> {
         Ok("saved.txt".to_string())
     }
 

--- a/extension/commands/save_file.js
+++ b/extension/commands/save_file.js
@@ -2,41 +2,91 @@
 
 const SAVE_FILE_MAX_BYTES = 50 * 1024 * 1024; // 50 MB
 
+// Headers that fetch() cannot set; must be injected via declarativeNetRequest
+const RESTRICTED_FETCH_HEADERS = new Set([
+  'referer', 'origin', 'user-agent', 'host', 'cookie', 'cookie2',
+]);
+
 async function handleSaveFile(tabId, payload) {
   const { url, headers = {} } = payload;
   if (!url) throw new Error('save_file requires payload.url');
 
-  let response;
+  // Split: headers fetch can set vs browser-controlled headers it cannot
+  const fetchHeaders = {};
+  const restrictedHeaders = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (RESTRICTED_FETCH_HEADERS.has(key.toLowerCase())) {
+      restrictedHeaders[key] = value;
+    } else {
+      fetchHeaders[key] = value;
+    }
+  }
+
+  // Inject browser-restricted headers at the network layer via declarativeNetRequest
+  let ruleId = null;
+  if (Object.keys(restrictedHeaders).length > 0) {
+    ruleId = (Date.now() % 2147483647) + 1;
+    await chrome.declarativeNetRequest.updateDynamicRules({
+      addRules: [{
+        id: ruleId,
+        priority: 1,
+        action: {
+          type: 'modifyHeaders',
+          requestHeaders: Object.entries(restrictedHeaders).map(([header, value]) => ({
+            header,
+            operation: 'set',
+            value,
+          })),
+        },
+        condition: {
+          urlFilter: url,
+          resourceTypes: ['xmlhttprequest', 'other'],
+        },
+      }],
+      removeRuleIds: [],
+    });
+  }
+
   try {
-    response = await fetch(url, { credentials: 'include', headers });
-  } catch (e) {
-    throw new Error(`Failed to fetch ${url}: ${e.message}`);
-  }
+    let response;
+    try {
+      response = await fetch(url, { credentials: 'include', headers: fetchHeaders });
+    } catch (e) {
+      throw new Error(`Failed to fetch ${url}: ${e.message}`);
+    }
 
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status} fetching ${url}`);
-  }
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} fetching ${url}`);
+    }
 
-  const contentLength = response.headers.get('content-length');
-  if (contentLength && parseInt(contentLength, 10) > SAVE_FILE_MAX_BYTES) {
-    throw new Error(`File too large (${contentLength} bytes, max ${SAVE_FILE_MAX_BYTES})`);
-  }
+    const contentLength = response.headers.get('content-length');
+    if (contentLength && parseInt(contentLength, 10) > SAVE_FILE_MAX_BYTES) {
+      throw new Error(`File too large (${contentLength} bytes, max ${SAVE_FILE_MAX_BYTES})`);
+    }
 
-  const buffer = await response.arrayBuffer();
-  if (buffer.byteLength > SAVE_FILE_MAX_BYTES) {
-    throw new Error(`File too large (${buffer.byteLength} bytes, max ${SAVE_FILE_MAX_BYTES})`);
-  }
+    const buffer = await response.arrayBuffer();
+    if (buffer.byteLength > SAVE_FILE_MAX_BYTES) {
+      throw new Error(`File too large (${buffer.byteLength} bytes, max ${SAVE_FILE_MAX_BYTES})`);
+    }
 
-  const bytes = new Uint8Array(buffer);
-  let binary = '';
-  const CHUNK = 8192;
-  for (let i = 0; i < bytes.length; i += CHUNK) {
-    binary += String.fromCharCode(...bytes.slice(i, i + CHUNK));
-  }
-  const data_base64 = btoa(binary);
+    const bytes = new Uint8Array(buffer);
+    let binary = '';
+    const CHUNK = 8192;
+    for (let i = 0; i < bytes.length; i += CHUNK) {
+      binary += String.fromCharCode(...bytes.slice(i, i + CHUNK));
+    }
+    const data_base64 = btoa(binary);
 
-  return {
-    data_base64,
-    size_bytes: bytes.length,
-  };
+    return {
+      data_base64,
+      size_bytes: bytes.length,
+    };
+  } finally {
+    if (ruleId !== null) {
+      chrome.declarativeNetRequest.updateDynamicRules({
+        addRules: [],
+        removeRuleIds: [ruleId],
+      }).catch(() => {}); // best-effort cleanup
+    }
+  }
 }

--- a/extension/commands/save_file.js
+++ b/extension/commands/save_file.js
@@ -3,12 +3,12 @@
 const SAVE_FILE_MAX_BYTES = 50 * 1024 * 1024; // 50 MB
 
 async function handleSaveFile(tabId, payload) {
-  const { url } = payload;
+  const { url, headers = {} } = payload;
   if (!url) throw new Error('save_file requires payload.url');
 
   let response;
   try {
-    response = await fetch(url, { credentials: 'include' });
+    response = await fetch(url, { credentials: 'include', headers });
   } catch (e) {
     throw new Error(`Failed to fetch ${url}: ${e.message}`);
   }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -16,7 +16,7 @@
     },
     "default_title": "acrawl Bridge"
   },
-  "permissions": ["debugger", "tabs", "activeTab", "storage", "alarms"],
+  "permissions": ["debugger", "tabs", "activeTab", "storage", "alarms", "declarativeNetRequest"],
   "host_permissions": ["http://127.0.0.1/*", "https://*/*", "http://*/*"],
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'"


### PR DESCRIPTION
## Summary

Enriches two tools with new capabilities and fixes five issues identified in code review.

### list_network_activity — new filters & inline content type

- **ilter='media'** — selects audio/video responses only (not images)
- **method** — filter by HTTP verb, case-insensitive (e.g. \'GET'\, \'POST'\)
- **min_size_kb'/\max_size_kb'** — bound requests by response size; requests with unknown size are excluded when a size filter is active
- **\unique_urls=true\** — collapses duplicate URLs to the representative with the **largest** response size (so \inspect_request(@rN)\ and \size_kb\ describe the same request); returns \equest_count\
- **Inline \content_type\** — every row now includes a \content_type\ field (\
ull\ if no Content-Type header was received)

### save_file — custom request headers

- New \headers\ map parameter passes arbitrary HTTP request headers with the download request
- In the **Chrome-extension backend**, browser-restricted headers (\Referer\, \Origin\, \User-Agent\, etc.) that the Fetch API cannot set are injected at the network layer via \chrome.declarativeNetRequest.updateDynamicRules\ (with always-clean \inally\ teardown). Non-restricted headers go directly to \etch\
- Works across both CloakBrowser and Chrome-extension backends

## Post-review fixes

| # | Issue | Fix |
|---|-------|-----|
| 1 | Extension \save_file\ silently dropped \Referer\/\User-Agent\ | \declarativeNetRequest\ header injection + \declarativeNetRequest\ permission in manifest |
| 2 | \unique_urls\ representative was the *latest* event, not the *largest* | \deduplicate_by_url\ now keeps the event with the largest \size_bytes\ end-to-end |
| 3 | \min/max_size_kb\ parsed via \s_u64()\ silently truncating decimals; \None\-size requests incorrectly passing \max_size_kb\ | Parse via \s_f64()\; \within_size_bounds\ now returns \alse\ for unknown-size when any filter is active |
| 4 | \CHANGELOG.md\ Unreleased section empty | Added entries for both tool surfaces |
| 5 | \content_type\ not advertised in tool contract; schema types wrong | Description/instructions updated; \min/max_size_kb\ schema type corrected to \integer\ |

## Testing

- \cargo test -p agent\ — 557 tests, 0 failures
- \cargo clippy --workspace --all-targets -- -D warnings\ — 0 warnings
- \cargo fmt --check\ — clean
- E2E via acrawl MCP: all 6 live test scenarios pass (\ilter='media'\, \method='GET'\, size range, \unique_urls\, \inspect_request\ consistency, \save_file\ with \Referer\ + custom \User-Agent\)