### PR TITLE
fix(mcp-server): install Claude Code MCP at user scope for global installs

### DIFF
--- a/crates/mcp-server/src/installer.rs
+++ b/crates/mcp-server/src/installer.rs
@@ -534,15 +534,26 @@ fn merge_json_config(
 
 fn install_claude_code_global(acrawl_path: &str) -> io::Result<String> {
     if command_exists("claude") {
-        // Always remove first (ignore errors — may not exist) to guarantee override.
+        // `--scope user` is required: `claude mcp add` defaults to `local`
+        // (current-directory-only) scope, which would silently downgrade a
+        // global install to per-directory. Remove from the same scope first.
         let _ = Command::new("claude")
-            .args(["mcp", "remove", "acrawl"])
+            .args(["mcp", "remove", "--scope", "user", "acrawl"])
             .output();
         let status = Command::new("claude")
-            .args(["mcp", "add", "acrawl", "--", acrawl_path, "mcp"])
+            .args([
+                "mcp",
+                "add",
+                "--scope",
+                "user",
+                "acrawl",
+                "--",
+                acrawl_path,
+                "mcp",
+            ])
             .status()?;
         if status.success() {
-            return Ok("configured via `claude mcp add`".to_string());
+            return Ok("configured via `claude mcp add --scope user`".to_string());
         }
     }
     let home = home_dir()
@@ -822,10 +833,10 @@ fn remove_json_config(path: &Path, root_key: &str, server_name: &str) -> io::Res
 fn uninstall_claude_code_global() -> io::Result<String> {
     if command_exists("claude") {
         let status = Command::new("claude")
-            .args(["mcp", "remove", "acrawl"])
+            .args(["mcp", "remove", "--scope", "user", "acrawl"])
             .status()?;
         if status.success() {
-            return Ok("removed via `claude mcp remove`".to_string());
+            return Ok("removed via `claude mcp remove --scope user`".to_string());
         }
     }
     let home = home_dir()


### PR DESCRIPTION
## Summary

`acrawl mcp install` → **Global** silently installed the Claude Code MCP server at **local** (per-directory) scope instead of the user-wide config, so the global Claude config was never updated.

## Root cause

`install_claude_code_global()` ran:

```
claude mcp add acrawl -- <path> mcp
```

with no `--scope` flag. Per `claude mcp add --help`, **scope defaults to `local`** — private to the current directory. So a "Global" selection:

- never wrote Claude Code's user-global config (`~/.claude.json` top-level `mcpServers`), and
- only registered a server entry for whatever directory the install happened to run from.

It also left the `claude` CLI path inconsistent with the no-CLI JSON fallback, which already targets user scope.

## Fix

Pass `--scope user` on both the install and uninstall `claude mcp` commands, so Global maps to Claude Code's user scope. Scoped to Claude Code only (Codex/Hermes have different scope semantics and are untouched).

## Verification

- `cargo test -p mcp-server` — 49 passed, 0 failed
- `cargo clippy -p mcp-server --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
