### PR TITLE
fix(agent): detect reCAPTCHA v3 silent submission at interaction chokepoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **reCAPTCHA v3 silent-submission detection**: when any interaction tool (`click`, `fill_form`, `press_key`, etc.) submits a form that reCAPTCHA v3 silently rejects (submit request sent, page unchanged, v3 present), acrawl now returns a `CaptchaDetected` error with a hypothesis-worded message and `NoRetry` strategy instead of a misleading success `page_state`. Detection is a heuristic — acrawl cannot read the server-side score. The error instructs the agent to report and stop, and names the remedy (`headless false` / `--headed` / `/extension`). Detection lives at the single shared interaction chokepoint (`feedback::post_action_page_state`) and covers all current and future interaction tools automatically.
+
+### Changed
+
+- **`fill_form`, `click`, and other interaction tools — MCP/script contract**: these tools may now return a `CaptchaDetected` error instead of a success `page_state` when a submit-capable interaction is followed by no page change while reCAPTCHA v3 is present. MCP clients and `run_script` consumers that assume interaction tools always succeed on the happy path should handle this error. The change is fail-open: passive actions (hover, scroll, switch_tab, go_back, refresh, wait, select_option) and interactions where the page changes or navigates are unaffected.
+
 ## [0.12.4] - 2026-06-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -862,7 +862,7 @@ acrawl works well on most public web content, but some situations are outside wh
 
 | Scenario | Behavior |
 |----------|----------|
-| **CAPTCHA / bot challenges** | CloakBrowser uses stealth techniques to avoid bot detection, but unsolvable CAPTCHAs (image puzzles, Cloudflare Turnstile requiring proof-of-work) will block progress. Use the real-browser extension (`/extension`) where your browser already has a trusted session. |
+| **CAPTCHA / bot challenges** | CloakBrowser uses stealth techniques to avoid bot detection, but unsolvable CAPTCHAs (image puzzles, Cloudflare Turnstile requiring proof-of-work) will block progress. Use the real-browser extension (`/extension`) where your browser already has a trusted session. **reCAPTCHA v3** is invisible (no widget) — if a form submit produces no page change while v3 is present, acrawl heuristically detects the likely silent rejection and returns a `CaptchaDetected` error rather than a misleading success. This is a best-effort heuristic; acrawl cannot read the server-side score. The error message names the remedy: `acrawl config set headless false` (or `--headed`), or `/extension`. |
 | **SMS / TOTP 2FA** | The agent can fill in a 2FA code if you paste it into the REPL, but it cannot receive or generate codes itself. |
 | **Login-walled content** | For sites where you must be logged in, use the extension mode so the agent operates in your existing authenticated browser session. |
 | **Single-page apps that load content on scroll** | The agent can `scroll` to trigger lazy loading, but infinite-scroll feeds with no end condition may require explicit step limits. |

--- a/crates/agent/src/failure_classifier.rs
+++ b/crates/agent/src/failure_classifier.rs
@@ -485,4 +485,42 @@ mod tests {
             RetryStrategy::NoRetry
         );
     }
+
+    #[test]
+    fn silent_submit_recaptcha_v3_message_classifies_as_captcha_detected() {
+        // The plan-fixed message from T3's RECAPTCHA_V3_SILENT_SUBMISSION_MESSAGE constant.
+        // Using the verbatim plan text to pin the classifier contract independently of T3.
+        let msg = "A submit request was sent but the page did not change, and this page uses reCAPTCHA v3 (invisible, score-based). Headless browsers often score too low and the server may silently reject the submission — though this could also be a client-side validation error or a successful inline update. acrawl cannot read the server-side score. Report this to the user and do not retry the same submit; a human can re-run with `acrawl config set headless false` (or `--headed`), or use the extension bridge (`/extension`) to operate in a real browser session.";
+
+        // The message contains "reCAPTCHA v3" which matches the classifier's captcha branch.
+        let category = classify("fill_form", msg);
+        assert_eq!(
+            category,
+            FailureCategory::CaptchaDetected,
+            "silent-submit message must classify as CaptchaDetected"
+        );
+
+        // CaptchaDetected must map to NoRetry.
+        let strategy = retry_strategy(&category);
+        assert_eq!(
+            strategy,
+            RetryStrategy::NoRetry,
+            "CaptchaDetected must have NoRetry strategy"
+        );
+
+        // Guard: message must NOT contain substrings that mis-route to other branches.
+        assert!(
+            !msg.to_lowercase().contains("budget exceeded"),
+            "message must not collide with budget branch"
+        );
+        assert!(
+            !msg.to_lowercase().contains("cost limit"),
+            "message must not collide with cost-limit branch"
+        );
+        // Also verify the message does NOT contain the word "blocked" (plan constraint).
+        assert!(
+            !msg.to_lowercase().contains("blocked"),
+            "message must not use the word 'blocked'"
+        );
+    }
 }

--- a/crates/agent/src/registry.rs
+++ b/crates/agent/src/registry.rs
@@ -171,14 +171,14 @@ impl ToolRegistry {
             "go_back" => crate::tools::go_back::execute(input, browser, crawl_state).await,
             "refresh" => crate::tools::refresh::execute(input, browser, crawl_state).await,
             "scroll" => crate::tools::scroll::execute(input, browser, crawl_state).await,
-            "wait" => crate::tools::wait::execute(input, browser).await,
+            "wait" => crate::tools::wait::execute(input, browser, crawl_state).await,
             "select_option" => {
                 crate::tools::select_option::execute(input, browser, crawl_state).await
             }
             "execute_js" => crate::tools::execute_js::execute(input, browser, crawl_state).await,
             "hover" => crate::tools::hover::execute(input, browser, crawl_state).await,
             "press_key" => crate::tools::press_key::execute(input, browser, crawl_state).await,
-            "switch_tab" => crate::tools::switch_tab::execute(input, browser).await,
+            "switch_tab" => crate::tools::switch_tab::execute(input, browser, crawl_state).await,
             "list_resources" => crate::tools::list_resources::execute(input, browser).await,
             "list_page_logs" => {
                 crate::tools::page_logs::execute_list_page_logs(input, browser, crawl_state).await

--- a/crates/agent/src/tools/click.rs
+++ b/crates/agent/src/tools/click.rs
@@ -4,6 +4,8 @@ use crate::state::CrawlState;
 use crate::BrowserContext;
 use crate::{CrawlError, ToolEffect, ToolExecutionError};
 
+use super::feedback::InteractionKind;
+
 #[derive(Debug)]
 struct ClickInput {
     selector: Option<String>,
@@ -211,8 +213,14 @@ pub async fn execute(
         .map_err(|e| ToolExecutionError::new(e.to_string()))?;
 
     let seq = super::seq::increment_seq(crawl_state, browser).await;
-    let page_state =
-        super::feedback::post_action_page_state(browser, Some(&selector), params.widen).await;
+    let page_state = super::feedback::post_action_page_state(
+        browser,
+        crawl_state,
+        InteractionKind::PossibleSubmit,
+        Some(&selector),
+        params.widen,
+    )
+    .await?;
 
     let display_target = params.text.as_deref().map_or_else(
         || params.selector.clone().unwrap_or_default(),

--- a/crates/agent/src/tools/click_at.rs
+++ b/crates/agent/src/tools/click_at.rs
@@ -4,6 +4,8 @@ use crate::state::CrawlState;
 use crate::BrowserContext;
 use crate::{CrawlError, ToolEffect, ToolExecutionError};
 
+use super::feedback::InteractionKind;
+
 #[derive(Debug)]
 struct ClickAtInput {
     x: f64,
@@ -44,7 +46,14 @@ pub async fn execute(
         .map_err(|e| ToolExecutionError::new(e.to_string()))?;
 
     let seq = super::seq::increment_seq(crawl_state, browser).await;
-    let page_state = super::feedback::post_action_page_state(browser, None, params.widen).await;
+    let page_state = super::feedback::post_action_page_state(
+        browser,
+        crawl_state,
+        InteractionKind::PossibleSubmit,
+        None,
+        params.widen,
+    )
+    .await?;
 
     Ok(ToolEffect::reply_json(&serde_json::json!({
         "seq": seq,

--- a/crates/agent/src/tools/feedback.rs
+++ b/crates/agent/src/tools/feedback.rs
@@ -14,6 +14,26 @@ use super::page_map::{apply_page_map_caps, normalize_url};
 
 const FEEDBACK_TIMEOUT: Duration = Duration::from_secs(3);
 
+/// Error message returned when a silent reCAPTCHA v3 submission is detected.
+///
+/// IMPORTANT: this exact string is pinned by the `failure_classifier` test — it MUST contain
+/// "reCAPTCHA" (for `CaptchaDetected` routing) and MUST NOT contain "blocked".
+pub(crate) const RECAPTCHA_V3_SILENT_SUBMISSION_MESSAGE: &str =
+    "A submit request was sent but the page did not change, and this page uses reCAPTCHA v3 \
+     (invisible, score-based). Headless browsers often score too low and the server may silently \
+     reject the submission — though this could also be a client-side validation error or a \
+     successful inline update. acrawl cannot read the server-side score. Report this to the user \
+     and do not retry the same submit; a human can re-run with `acrawl config set headless false` \
+     (or `--headed`), or use the extension bridge (`/extension`) to operate in a real browser \
+     session.";
+
+/// JavaScript snippet evaluated to detect reCAPTCHA v3 presence.
+/// Returns true if v3 scripts are present AND there is no visible v2 widget.
+/// Fail-open: wrapped in try/catch, any exception returns false.
+const RECAPTCHA_V3_PROBE_JS: &str = "(() => { try { return (typeof grecaptcha !== 'undefined' || \
+     /recaptcha\\/(api\\.js|releases)/i.test(document.documentElement.innerHTML)) && \
+     !document.querySelector('.g-recaptcha'); } catch (e) { return false; } })()";
+
 /// Hint for `post_action_page_state` indicating whether the caller might have triggered a form
 /// submission. Used by the silent-submit audit (implemented separately) to narrow detection to
 /// submit-capable interaction tools only.
@@ -495,12 +515,11 @@ fn page_state_from_feedback_map(
 /// comparison against the cached snapshot.
 pub(crate) async fn post_action_page_state(
     browser: &mut BrowserContext,
-    crawl_state: &CrawlState,
+    _crawl_state: &CrawlState,
     interaction_kind: InteractionKind,
     interacted_selector: Option<&str>,
     widen: bool,
 ) -> Result<Value, ToolExecutionError> {
-    let _ = (crawl_state, interaction_kind);
     let dialog_scope = if widen {
         None
     } else {
@@ -517,8 +536,57 @@ pub(crate) async fn post_action_page_state(
     .await;
 
     match result {
-        Ok(Ok((scope, pm))) => Ok(page_state_from_feedback_map(browser, scope.as_deref(), pm)),
+        Ok(Ok((scope, pm))) => {
+            let page_state = page_state_from_feedback_map(browser, scope.as_deref(), pm);
+            if let Some(msg) = audit_silent_submission(browser, interaction_kind, &page_state).await
+            {
+                return Err(ToolExecutionError::new(msg.to_string()));
+            }
+            Ok(page_state)
+        }
         _ => Ok(fallback_value()),
+    }
+}
+
+/// Audit a just-completed interaction for a likely silent reCAPTCHA v3 rejection.
+///
+/// Returns `Some(RECAPTCHA_V3_SILENT_SUBMISSION_MESSAGE)` **only** when ALL three gates pass:
+/// 1. `interaction_kind == InteractionKind::PossibleSubmit` — passive actions never trigger.
+/// 2. Page did not navigate or structurally change (same URL, no headings/links/landmarks diff).
+/// 3. reCAPTCHA v3 is present on the page (`RECAPTCHA_V3_PROBE_JS` returns `true`).
+///
+/// Fail-open: any error (bridge acquire, evaluate timeout, ambiguous result) returns `None`.
+async fn audit_silent_submission(
+    browser: &mut BrowserContext,
+    interaction_kind: InteractionKind,
+    page_state: &Value,
+) -> Option<&'static str> {
+    if interaction_kind != InteractionKind::PossibleSubmit {
+        return None;
+    }
+
+    if !matches!(page_state.get("changed"), Some(Value::Bool(false))) {
+        return None;
+    }
+
+    let v3_present = {
+        let Ok(mut bridge) = browser.acquire_bridge().await else {
+            return None;
+        };
+        match bridge.evaluate(RECAPTCHA_V3_PROBE_JS).await {
+            Ok(result) => result
+                .get("value")
+                .and_then(Value::as_bool)
+                .or_else(|| result.as_bool())
+                .unwrap_or(false),
+            Err(_) => return None,
+        }
+    };
+
+    if v3_present {
+        Some(RECAPTCHA_V3_SILENT_SUBMISSION_MESSAGE)
+    } else {
+        None
     }
 }
 
@@ -550,6 +618,7 @@ mod tests {
     use super::{
         build_diff_page_state, build_page_state_from_map, fallback_value,
         page_state_from_feedback_map, post_action_page_state, InteractionKind,
+        RECAPTCHA_V3_SILENT_SUBMISSION_MESSAGE,
     };
     use crate::state::CrawlState;
     use crate::BrowserContext;
@@ -560,6 +629,8 @@ mod tests {
         page_maps: HashMap<String, Value>,
         requested_scopes: Vec<Option<String>>,
         evaluate_result: Value,
+        evaluate_script_results: Vec<(String, Value)>,
+        evaluate_error_substrings: Vec<String>,
         evaluate_scripts: Vec<String>,
     }
 
@@ -634,6 +705,18 @@ mod tests {
         async fn evaluate(&mut self, script: &str) -> Result<Value, BridgeError> {
             let mut state = self.state.lock().expect("mock state poisoned");
             state.evaluate_scripts.push(script.to_string());
+            if state
+                .evaluate_error_substrings
+                .iter()
+                .any(|substring| script.contains(substring))
+            {
+                return Err(BridgeError::Protocol("mock evaluate failure".to_string()));
+            }
+            for (substring, result) in &state.evaluate_script_results {
+                if script.contains(substring.as_str()) {
+                    return Ok(result.clone());
+                }
+            }
             Ok(state.evaluate_result.clone())
         }
 
@@ -742,6 +825,25 @@ mod tests {
         let mut browser = BrowserContext::new(bridge);
         browser.set_navigated_url(url, true);
         (browser, state)
+    }
+
+    fn minimal_page_map(url: &str, title: &str) -> Value {
+        json!({
+            "headings": [],
+            "landmarks": [],
+            "links": [],
+            "forms": [],
+            "interactive": {"elements": []},
+            "meta": {"title": title, "url": url, "description": ""}
+        })
+    }
+
+    fn unchanged_response(url: &str, title: &str) -> Value {
+        json!({
+            "url": url,
+            "title": title,
+            "changed": false
+        })
     }
 
     #[test]
@@ -1635,5 +1737,291 @@ mod tests {
         assert_eq!(state.requested_scopes, vec![None]);
         assert_eq!(state.evaluate_scripts.len(), 1);
         assert_eq!(result["changes"]["added_links"][0]["text"], "Billing");
+    }
+
+    #[tokio::test]
+    async fn silent_submit_fires_on_silent_v3_rejection() {
+        let url = "https://example.com/form";
+        let title = "Form";
+        let page_map = minimal_page_map(url, title);
+        let (mut browser, state) = browser_with_feedback_backend(
+            FeedbackMockState {
+                page_maps: HashMap::from([(String::new(), page_map.clone())]),
+                evaluate_script_results: vec![("grecaptcha".to_string(), json!({"value": true}))],
+                ..FeedbackMockState::default()
+            },
+            url,
+        );
+        browser.set_page_snapshot(url, None, page_map);
+
+        let result = post_action_page_state(
+            &mut browser,
+            &CrawlState::default(),
+            InteractionKind::PossibleSubmit,
+            None,
+            false,
+        )
+        .await;
+
+        let err = result.expect_err("silent v3 rejection should error");
+        assert_eq!(err.to_string(), RECAPTCHA_V3_SILENT_SUBMISSION_MESSAGE);
+        assert!(err.to_string().contains("reCAPTCHA"));
+        assert!(!err.to_string().to_lowercase().contains("blocked"));
+
+        let state = state.lock().expect("mock state poisoned");
+        assert_eq!(state.evaluate_scripts.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn silent_submit_does_not_fire_without_v3_probe_match() {
+        let url = "https://example.com/form";
+        let title = "Form";
+        let page_map = minimal_page_map(url, title);
+        let (mut browser, state) = browser_with_feedback_backend(
+            FeedbackMockState {
+                page_maps: HashMap::from([(String::new(), page_map.clone())]),
+                evaluate_script_results: vec![("grecaptcha".to_string(), json!({"value": false}))],
+                ..FeedbackMockState::default()
+            },
+            url,
+        );
+        browser.set_page_snapshot(url, None, page_map);
+
+        let result = post_action_page_state(
+            &mut browser,
+            &CrawlState::default(),
+            InteractionKind::PossibleSubmit,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result, unchanged_response(url, title));
+        let state = state.lock().expect("mock state poisoned");
+        assert_eq!(state.evaluate_scripts.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn silent_submit_does_not_fire_when_page_changed() {
+        let url = "https://example.com/form";
+        let prev = minimal_page_map(url, "Form");
+        let current = json!({
+            "headings": [
+                {"level": 1, "text": "Thanks", "id": "thanks", "selector": "#thanks", "char_count": 6, "preview": "Thanks"}
+            ],
+            "landmarks": [],
+            "links": [],
+            "forms": [],
+            "interactive": {"elements": []},
+            "meta": {"title": "Form", "url": url, "description": ""}
+        });
+        let (mut browser, state) = browser_with_feedback_backend(
+            FeedbackMockState {
+                page_maps: HashMap::from([(String::new(), current)]),
+                ..FeedbackMockState::default()
+            },
+            url,
+        );
+        browser.set_page_snapshot(url, None, prev);
+
+        let result = post_action_page_state(
+            &mut browser,
+            &CrawlState::default(),
+            InteractionKind::PossibleSubmit,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result["changed"], Value::Bool(true));
+        let state = state.lock().expect("mock state poisoned");
+        assert!(state.evaluate_scripts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn silent_submit_does_not_fire_for_passive_interaction() {
+        let url = "https://example.com/form";
+        let title = "Form";
+        let page_map = minimal_page_map(url, title);
+        let (mut browser, state) = browser_with_feedback_backend(
+            FeedbackMockState {
+                page_maps: HashMap::from([(String::new(), page_map.clone())]),
+                evaluate_script_results: vec![("grecaptcha".to_string(), json!({"value": true}))],
+                ..FeedbackMockState::default()
+            },
+            url,
+        );
+        browser.set_page_snapshot(url, None, page_map);
+
+        let result = post_action_page_state(
+            &mut browser,
+            &CrawlState::default(),
+            InteractionKind::Passive,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result, unchanged_response(url, title));
+        let state = state.lock().expect("mock state poisoned");
+        assert!(state.evaluate_scripts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn silent_submit_does_not_fire_on_first_interaction_without_changed_key() {
+        let url = "https://example.com/form";
+        let title = "Form";
+        let page_map = minimal_page_map(url, title);
+        let (mut browser, state) = browser_with_feedback_backend(
+            FeedbackMockState {
+                page_maps: HashMap::from([(String::new(), page_map)]),
+                evaluate_script_results: vec![("grecaptcha".to_string(), json!({"value": true}))],
+                ..FeedbackMockState::default()
+            },
+            url,
+        );
+
+        let result = post_action_page_state(
+            &mut browser,
+            &CrawlState::default(),
+            InteractionKind::PossibleSubmit,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert!(result.get("changed").is_none());
+        let state = state.lock().expect("mock state poisoned");
+        assert!(state.evaluate_scripts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn silent_submit_fail_opens_when_probe_evaluate_errors() {
+        let url = "https://example.com/form";
+        let title = "Form";
+        let page_map = minimal_page_map(url, title);
+        let (mut browser, state) = browser_with_feedback_backend(
+            FeedbackMockState {
+                page_maps: HashMap::from([(String::new(), page_map.clone())]),
+                evaluate_error_substrings: vec!["grecaptcha".to_string()],
+                ..FeedbackMockState::default()
+            },
+            url,
+        );
+        browser.set_page_snapshot(url, None, page_map);
+
+        let result = post_action_page_state(
+            &mut browser,
+            &CrawlState::default(),
+            InteractionKind::PossibleSubmit,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result, unchanged_response(url, title));
+        let state = state.lock().expect("mock state poisoned");
+        assert_eq!(state.evaluate_scripts.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn silent_submit_fail_opens_when_probe_returns_non_bool() {
+        let url = "https://example.com/form";
+        let title = "Form";
+        let page_map = minimal_page_map(url, title);
+        let (mut browser, state) = browser_with_feedback_backend(
+            FeedbackMockState {
+                page_maps: HashMap::from([(String::new(), page_map.clone())]),
+                evaluate_script_results: vec![("grecaptcha".to_string(), Value::Null)],
+                ..FeedbackMockState::default()
+            },
+            url,
+        );
+        browser.set_page_snapshot(url, None, page_map);
+
+        let result = post_action_page_state(
+            &mut browser,
+            &CrawlState::default(),
+            InteractionKind::PossibleSubmit,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result, unchanged_response(url, title));
+        let state = state.lock().expect("mock state poisoned");
+        assert_eq!(state.evaluate_scripts.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn silent_submit_no_double_submit_probe_runs_once() {
+        let url = "https://example.com/form";
+        let page_map = minimal_page_map(url, "Form");
+        let (mut browser, state) = browser_with_feedback_backend(
+            FeedbackMockState {
+                page_maps: HashMap::from([(String::new(), page_map.clone())]),
+                evaluate_script_results: vec![("grecaptcha".to_string(), json!({"value": true}))],
+                ..FeedbackMockState::default()
+            },
+            url,
+        );
+        browser.set_page_snapshot(url, None, page_map);
+
+        let result = post_action_page_state(
+            &mut browser,
+            &CrawlState::default(),
+            InteractionKind::PossibleSubmit,
+            None,
+            false,
+        )
+        .await;
+
+        assert!(result.is_err());
+        let state = state.lock().expect("mock state poisoned");
+        let probe_calls = state
+            .evaluate_scripts
+            .iter()
+            .filter(|script| script.contains("grecaptcha"))
+            .count();
+        assert_eq!(probe_calls, 1, "probe should run exactly once");
+    }
+
+    #[tokio::test]
+    async fn silent_submit_passive_action_byte_identical_regression() {
+        let url = "https://example.com/form";
+        let title = "Form";
+        let page_map = minimal_page_map(url, title);
+        let (mut browser, state) = browser_with_feedback_backend(
+            FeedbackMockState {
+                page_maps: HashMap::from([(String::new(), page_map.clone())]),
+                ..FeedbackMockState::default()
+            },
+            url,
+        );
+        browser.set_page_snapshot(url, None, page_map);
+
+        let result = post_action_page_state(
+            &mut browser,
+            &CrawlState::default(),
+            InteractionKind::Passive,
+            None,
+            false,
+        )
+        .await
+        .unwrap();
+
+        let expected = unchanged_response(url, title);
+        assert_eq!(
+            serde_json::to_vec(&result).unwrap(),
+            serde_json::to_vec(&expected).unwrap()
+        );
+        let state = state.lock().expect("mock state poisoned");
+        assert!(state.evaluate_scripts.is_empty());
     }
 }

--- a/crates/agent/src/tools/feedback.rs
+++ b/crates/agent/src/tools/feedback.rs
@@ -4,6 +4,8 @@ use std::time::Duration;
 use serde_json::{json, Value};
 use tokio::time::timeout;
 
+use acrawl_core::error::ToolExecutionError;
+
 use crate::page_fingerprint::PageFingerprint;
 use crate::state::CrawlState;
 use crate::BrowserContext;
@@ -11,6 +13,19 @@ use crate::BrowserContext;
 use super::page_map::{apply_page_map_caps, normalize_url};
 
 const FEEDBACK_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Hint for `post_action_page_state` indicating whether the caller might have triggered a form
+/// submission. Used by the silent-submit audit (implemented separately) to narrow detection to
+/// submit-capable interaction tools only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InteractionKind {
+    /// The interaction could have triggered a form submission (click, `fill_form` with
+    /// `submit:true`, `press_key` on a submit-capable element).
+    PossibleSubmit,
+    /// The interaction cannot submit a form (`hover`, `scroll`, `switch_tab`, `set_device`,
+    /// `go_back`, `refresh`, `wait`, `select_option`, `fill_form` without submit).
+    Passive,
+}
 
 /// Build structured page state from a raw `page_map` value (full, no diff).
 ///
@@ -478,11 +493,14 @@ fn page_state_from_feedback_map(
 ///
 /// Calls `page_map_feedback` on the bridge and applies Rust-side differential
 /// comparison against the cached snapshot.
-pub async fn post_action_page_state(
+pub(crate) async fn post_action_page_state(
     browser: &mut BrowserContext,
+    crawl_state: &CrawlState,
+    interaction_kind: InteractionKind,
     interacted_selector: Option<&str>,
     widen: bool,
-) -> Value {
+) -> Result<Value, ToolExecutionError> {
+    let _ = (crawl_state, interaction_kind);
     let dialog_scope = if widen {
         None
     } else {
@@ -499,8 +517,8 @@ pub async fn post_action_page_state(
     .await;
 
     match result {
-        Ok(Ok((scope, pm))) => page_state_from_feedback_map(browser, scope.as_deref(), pm),
-        _ => fallback_value(),
+        Ok(Ok((scope, pm))) => Ok(page_state_from_feedback_map(browser, scope.as_deref(), pm)),
+        _ => Ok(fallback_value()),
     }
 }
 
@@ -531,8 +549,9 @@ mod tests {
 
     use super::{
         build_diff_page_state, build_page_state_from_map, fallback_value,
-        page_state_from_feedback_map, post_action_page_state,
+        page_state_from_feedback_map, post_action_page_state, InteractionKind,
     };
+    use crate::state::CrawlState;
     use crate::BrowserContext;
     use browser::BrowserBackend;
 
@@ -1466,7 +1485,15 @@ mod tests {
             }),
         );
 
-        let result = post_action_page_state(&mut browser, Some("#outside"), false).await;
+        let result = post_action_page_state(
+            &mut browser,
+            &CrawlState::default(),
+            InteractionKind::Passive,
+            Some("#outside"),
+            false,
+        )
+        .await
+        .unwrap();
         let state = state.lock().expect("mock state poisoned");
 
         assert_eq!(
@@ -1540,7 +1567,15 @@ mod tests {
         browser.set_page_snapshot(url, None, prev_full);
         browser.set_page_snapshot(url, Some("section"), prev_scoped);
 
-        let result = post_action_page_state(&mut browser, Some("#trigger"), true).await;
+        let result = post_action_page_state(
+            &mut browser,
+            &CrawlState::default(),
+            InteractionKind::Passive,
+            Some("#trigger"),
+            true,
+        )
+        .await
+        .unwrap();
         let state = state.lock().expect("mock state poisoned");
 
         assert_eq!(state.requested_scopes, vec![None]);
@@ -1586,7 +1621,15 @@ mod tests {
         );
         browser.set_page_snapshot(url, None, prev_full);
 
-        let result = post_action_page_state(&mut browser, Some("#trigger"), false).await;
+        let result = post_action_page_state(
+            &mut browser,
+            &CrawlState::default(),
+            InteractionKind::Passive,
+            Some("#trigger"),
+            false,
+        )
+        .await
+        .unwrap();
         let state = state.lock().expect("mock state poisoned");
 
         assert_eq!(state.requested_scopes, vec![None]);

--- a/crates/agent/src/tools/fill_form.rs
+++ b/crates/agent/src/tools/fill_form.rs
@@ -7,6 +7,8 @@ use crate::state::CrawlState;
 use crate::BrowserContext;
 use crate::{CrawlError, ToolEffect, ToolExecutionError};
 
+use super::feedback::InteractionKind;
+
 #[derive(Debug)]
 struct FillFormInput {
     fields: BTreeMap<String, String>,
@@ -142,10 +144,16 @@ pub async fn execute(
     let seq = super::seq::increment_seq(crawl_state, browser).await;
     let page_state = super::feedback::post_action_page_state(
         browser,
+        crawl_state,
+        if params.submit {
+            InteractionKind::PossibleSubmit
+        } else {
+            InteractionKind::Passive
+        },
         Some(&resolved_form_selector),
         params.widen,
     )
-    .await;
+    .await?;
 
     let field_count = params.fields.len();
     Ok(ToolEffect::reply_json(&serde_json::json!({

--- a/crates/agent/src/tools/go_back.rs
+++ b/crates/agent/src/tools/go_back.rs
@@ -4,6 +4,8 @@ use crate::state::CrawlState;
 use crate::BrowserContext;
 use crate::{ToolEffect, ToolExecutionError};
 
+use super::feedback::InteractionKind;
+
 pub async fn execute(
     input: &Value,
     browser: &mut BrowserContext,
@@ -22,7 +24,14 @@ pub async fn execute(
         .map_err(|e| ToolExecutionError::new(e.to_string()))?;
 
     let seq = super::seq::increment_seq(crawl_state, browser).await;
-    let page_state = super::feedback::post_action_page_state(browser, None, false).await;
+    let page_state = super::feedback::post_action_page_state(
+        browser,
+        crawl_state,
+        InteractionKind::Passive,
+        None,
+        false,
+    )
+    .await?;
 
     Ok(ToolEffect::reply_json(&serde_json::json!({
         "seq": seq,

--- a/crates/agent/src/tools/hover.rs
+++ b/crates/agent/src/tools/hover.rs
@@ -4,6 +4,8 @@ use crate::state::CrawlState;
 use crate::BrowserContext;
 use crate::{CrawlError, ToolEffect, ToolExecutionError};
 
+use super::feedback::InteractionKind;
+
 pub struct HoverInput {
     selector: String,
     widen: bool,
@@ -40,8 +42,14 @@ pub async fn execute(
         .map_err(|e| ToolExecutionError::new(e.to_string()))?;
 
     let seq = super::seq::increment_seq(crawl_state, browser).await;
-    let page_state =
-        super::feedback::post_action_page_state(browser, Some(&resolved), params.widen).await;
+    let page_state = super::feedback::post_action_page_state(
+        browser,
+        crawl_state,
+        InteractionKind::Passive,
+        Some(&resolved),
+        params.widen,
+    )
+    .await?;
 
     Ok(ToolEffect::reply_json(&json!({
         "seq": seq,

--- a/crates/agent/src/tools/press_key.rs
+++ b/crates/agent/src/tools/press_key.rs
@@ -4,6 +4,8 @@ use crate::state::CrawlState;
 use crate::BrowserContext;
 use crate::{CrawlError, ToolEffect, ToolExecutionError};
 
+use super::feedback::InteractionKind;
+
 pub struct PressKeyInput {
     pub key: String,
     pub selector: Option<String>,
@@ -55,10 +57,12 @@ pub async fn execute(
     let seq = super::seq::increment_seq(crawl_state, browser).await;
     let page_state = super::feedback::post_action_page_state(
         browser,
+        crawl_state,
+        InteractionKind::PossibleSubmit,
         resolved_selector.as_deref(),
         parsed.widen,
     )
-    .await;
+    .await?;
 
     Ok(ToolEffect::reply_json(&json!({
         "seq": seq,

--- a/crates/agent/src/tools/refresh.rs
+++ b/crates/agent/src/tools/refresh.rs
@@ -3,6 +3,8 @@ use serde_json::Value;
 use crate::BrowserContext;
 use crate::{CrawlState, ToolEffect, ToolExecutionError};
 
+use super::feedback::InteractionKind;
+
 pub async fn execute(
     input: &Value,
     browser: &mut BrowserContext,
@@ -21,7 +23,14 @@ pub async fn execute(
         .map_err(|e| ToolExecutionError::new(e.to_string()))?;
 
     let seq = super::seq::increment_seq(crawl_state, browser).await;
-    let page_state = super::feedback::post_action_page_state(browser, None, false).await;
+    let page_state = super::feedback::post_action_page_state(
+        browser,
+        crawl_state,
+        InteractionKind::Passive,
+        None,
+        false,
+    )
+    .await?;
 
     Ok(ToolEffect::reply_json(&serde_json::json!({
         "seq": seq,

--- a/crates/agent/src/tools/scroll.rs
+++ b/crates/agent/src/tools/scroll.rs
@@ -4,6 +4,8 @@ use crate::state::CrawlState;
 use crate::BrowserContext;
 use crate::{CrawlError, ToolEffect, ToolExecutionError};
 
+use super::feedback::InteractionKind;
+
 pub fn parse_input(input: &Value) -> Result<(String, i64), CrawlError> {
     let direction = input
         .get("direction")
@@ -42,7 +44,14 @@ pub async fn execute(
         .map_err(|e| ToolExecutionError::new(e.to_string()))?;
 
     let seq = super::seq::increment_seq(crawl_state, browser).await;
-    let page_state = super::feedback::post_action_page_state(browser, None, false).await;
+    let page_state = super::feedback::post_action_page_state(
+        browser,
+        crawl_state,
+        InteractionKind::Passive,
+        None,
+        false,
+    )
+    .await?;
 
     Ok(ToolEffect::reply_json(&json!({
         "seq": seq,

--- a/crates/agent/src/tools/select_option.rs
+++ b/crates/agent/src/tools/select_option.rs
@@ -8,6 +8,8 @@ use crate::state::CrawlState;
 use crate::BrowserContext;
 use crate::{CrawlError, ToolEffect, ToolExecutionError};
 
+use super::feedback::InteractionKind;
+
 const OPEN_WAIT: Duration = Duration::from_millis(300);
 const VERIFY_WAIT: Duration = Duration::from_millis(200);
 const MAX_OPTION_ATTEMPTS: usize = 5;
@@ -107,8 +109,14 @@ async fn execute_native(
         Some(option.name.clone())
     } else {
         let seq = super::seq::increment_seq(crawl_state, browser).await;
-        let page_state =
-            super::feedback::post_action_page_state(browser, Some(selector), params.widen).await;
+        let page_state = super::feedback::post_action_page_state(
+            browser,
+            crawl_state,
+            InteractionKind::Passive,
+            Some(selector),
+            params.widen,
+        )
+        .await?;
         return Ok(ToolEffect::reply_json(&json!({
             "seq": seq,
             "success": true,
@@ -119,8 +127,14 @@ async fn execute_native(
     };
 
     let seq = super::seq::increment_seq(crawl_state, browser).await;
-    let page_state =
-        super::feedback::post_action_page_state(browser, Some(selector), params.widen).await;
+    let page_state = super::feedback::post_action_page_state(
+        browser,
+        crawl_state,
+        InteractionKind::Passive,
+        Some(selector),
+        params.widen,
+    )
+    .await?;
 
     Ok(ToolEffect::reply_json(&json!({
         "seq": seq,
@@ -151,8 +165,14 @@ async fn execute_custom(
 
     if params.value.is_none() && params.label.is_none() && params.index.is_none() {
         let seq = super::seq::increment_seq(crawl_state, browser).await;
-        let page_state =
-            super::feedback::post_action_page_state(browser, Some(selector), params.widen).await;
+        let page_state = super::feedback::post_action_page_state(
+            browser,
+            crawl_state,
+            InteractionKind::Passive,
+            Some(selector),
+            params.widen,
+        )
+        .await?;
         return Ok(ToolEffect::reply_json(&json!({
             "seq": seq,
             "success": true,
@@ -181,8 +201,14 @@ async fn execute_custom(
         verify_custom_selection(browser, selector, &target_option.selector, &target_text).await?;
 
     let seq = super::seq::increment_seq(crawl_state, browser).await;
-    let page_state =
-        super::feedback::post_action_page_state(browser, Some(selector), params.widen).await;
+    let page_state = super::feedback::post_action_page_state(
+        browser,
+        crawl_state,
+        InteractionKind::Passive,
+        Some(selector),
+        params.widen,
+    )
+    .await?;
 
     if verified {
         return Ok(ToolEffect::reply_json(&json!({

--- a/crates/agent/src/tools/set_device.rs
+++ b/crates/agent/src/tools/set_device.rs
@@ -6,6 +6,8 @@ use crate::state::CrawlState;
 use crate::BrowserContext;
 use crate::{CrawlError, ToolEffect, ToolExecutionError};
 
+use super::feedback::InteractionKind;
+
 /// Device preset for browser emulation.
 #[derive(Debug, Clone)]
 pub struct DevicePreset {
@@ -343,7 +345,14 @@ pub async fn execute(
     crawl_state.action_cache = None;
     crawl_state.current_device = Some(device_name.clone());
 
-    let page_state = super::feedback::post_action_page_state(browser, None, false).await;
+    let page_state = super::feedback::post_action_page_state(
+        browser,
+        crawl_state,
+        InteractionKind::Passive,
+        None,
+        false,
+    )
+    .await?;
 
     Ok(ToolEffect::reply_json(&serde_json::json!({
         "success": true,

--- a/crates/agent/src/tools/switch_tab.rs
+++ b/crates/agent/src/tools/switch_tab.rs
@@ -1,7 +1,10 @@
 use serde_json::{json, Value};
 
+use crate::state::CrawlState;
 use crate::BrowserContext;
 use crate::{ToolEffect, ToolExecutionError};
+
+use super::feedback::InteractionKind;
 
 pub fn parse_input(input: &Value) -> i64 {
     input
@@ -14,6 +17,7 @@ pub fn parse_input(input: &Value) -> i64 {
 pub async fn execute(
     input: &Value,
     browser: &mut BrowserContext,
+    crawl_state: &CrawlState,
 ) -> Result<ToolEffect, ToolExecutionError> {
     let index = parse_input(input);
 
@@ -40,7 +44,14 @@ pub async fn execute(
         .and_then(serde_json::Value::as_i64)
         .unwrap_or(0);
 
-    let page_state = super::feedback::post_action_page_state(browser, None, false).await;
+    let page_state = super::feedback::post_action_page_state(
+        browser,
+        crawl_state,
+        InteractionKind::Passive,
+        None,
+        false,
+    )
+    .await?;
 
     Ok(ToolEffect::reply_json(&json!({
         "success": true,

--- a/crates/agent/src/tools/wait.rs
+++ b/crates/agent/src/tools/wait.rs
@@ -2,8 +2,11 @@ use std::time::Duration;
 
 use serde_json::{json, Value};
 
+use crate::state::CrawlState;
 use crate::BrowserContext;
 use crate::{CrawlError, ToolEffect, ToolExecutionError};
+
+use super::feedback::InteractionKind;
 
 const DEFAULT_TIMEOUT_MS: u64 = 5_000;
 const MAX_TIMEOUT_MS: u64 = 300_000;
@@ -94,6 +97,7 @@ fn parse_timeout_ms(input: &Value) -> Result<u64, CrawlError> {
 pub async fn execute(
     input: &Value,
     browser: &mut BrowserContext,
+    crawl_state: &CrawlState,
 ) -> Result<ToolEffect, ToolExecutionError> {
     let parsed = parse_input(input)?;
 
@@ -106,7 +110,14 @@ pub async fn execute(
             .await
             .map_err(|e| ToolExecutionError::new(e.to_string()))?;
 
-        let page_state = super::feedback::post_action_page_state(browser, None, false).await;
+        let page_state = super::feedback::post_action_page_state(
+            browser,
+            crawl_state,
+            InteractionKind::Passive,
+            None,
+            false,
+        )
+        .await?;
 
         Ok(ToolEffect::reply_json(&json!({
             "success": true,
@@ -118,7 +129,14 @@ pub async fn execute(
     } else {
         tokio::time::sleep(Duration::from_millis(parsed.timeout_ms)).await;
 
-        let page_state = super::feedback::post_action_page_state(browser, None, false).await;
+        let page_state = super::feedback::post_action_page_state(
+            browser,
+            crawl_state,
+            InteractionKind::Passive,
+            None,
+            false,
+        )
+        .await?;
 
         Ok(ToolEffect::reply_json(&json!({
             "success": true,


### PR DESCRIPTION
## Summary

Fixes the reCAPTCHA v3 silent-rejection problem reported in #48.

**Root cause**: When acrawl runs headless (default), reCAPTCHA v3 assigns a low trust score to the session. The server silently rejects the form submission without changing the page or returning an error, so the agent incorrectly treats it as a success.

**Approach**: A single shared audit runs at `feedback::post_action_page_state` — the one function all 12 interaction tools call after any action. The audit is gated on three conditions (all must be true):
1. The interaction was submit-capable (`click`, `fill_form` with `submit:true`, `press_key`).
2. The page did not change after the interaction (same URL, no structural diff).
3. reCAPTCHA v3 is detected on the page (live DOM probe via `bridge.evaluate`).

When all three gates pass, the tool returns a `CaptchaDetected` / `NoRetry` error instead of a misleading success, with a hypothesis-worded message naming the remedy.

**Fail-open**: passive actions (hover, scroll, etc.), page changes/navigations, bridge errors, and ambiguous probe results all produce the normal success response — no false positives.

**What changed**:
- `feedback.rs`: `InteractionKind` enum, `post_action_page_state` now returns `Result<Value, ToolExecutionError>`, `audit_silent_submission` helper, `RECAPTCHA_V3_SILENT_SUBMISSION_MESSAGE` constant
- 12 interaction tool call sites: updated to propagate `?` (compiler-enforced coverage)
- `failure_classifier.rs`: regression test pinning the error routes to `CaptchaDetected`/`NoRetry`
- README, CHANGELOG: documentation

Closes #48