### PR TITLE
fix(clippy): remove needless hash from raw string in test

### DIFF
--- a/crates/agent/src/tools/fill_form.rs
+++ b/crates/agent/src/tools/fill_form.rs
@@ -429,7 +429,7 @@ mod tests {
             "Missing contenteditable selector"
         );
         assert!(
-            FIELD_DISCOVERY_JS.contains(r#"group.querySelector('textarea')"#),
+            FIELD_DISCOVERY_JS.contains(r"group.querySelector('textarea')"),
             "Missing sibling textarea label fallback"
         );
     }


### PR DESCRIPTION
## Summary
- `r#"group.querySelector('textarea')"#` → `r"group.querySelector('textarea')"` in `fill_form.rs` test
- The string contains no quotes so the `#` delimiters are unnecessary; clippy's `needless_raw_string_hashes` lint flagged it

## Test plan
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)