### PR TITLE
feat(wait): add 'silent' parameter to suppress page_state on time-only waits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `wait` now accepts a `silent` boolean parameter (default `false`). When `true` and no `selector` is given, a time-only wait returns just `{ success, waited_ms }` instead of the full `page_state` diff, saving context tokens for simple timed pauses. `silent` has no effect when a `selector` is provided — `page_state` is still returned.
+
 ## [0.13.0] - 2026-07-02
 
 ### Added

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -126,7 +126,7 @@ fn navigation_tools() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: "wait",
-            description: "Wait for a DOM element to reach a specified state (visible, hidden, attached, detached) or pause for a fixed duration. Use after actions that trigger asynchronous page changes such as form submissions, AJAX requests, or animations. Returns post-action page_state showing the resulting URL, title, and structural diff once the condition is met or the timeout expires.",
+            description: "Wait for a DOM element to reach a specified state (visible, hidden, attached, detached) or pause for a fixed duration. Use after actions that trigger asynchronous page changes such as form submissions, AJAX requests, or animations. Returns post-action page_state showing the resulting URL, title, and structural diff once the condition is met or the timeout expires, unless `silent: true` is set for a time-only wait, in which case only the completion signal is returned.",
             input_schema: json!({
                 "type": "object",
                 "properties": {

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -136,11 +136,15 @@ fn navigation_tools() -> Vec<ToolSpec> {
                         "type": "string",
                         "enum": ["visible", "hidden", "attached", "detached"],
                         "description": "Target state to wait for. 'attached' (default) = element exists in DOM; 'visible' = element is rendered and not hidden; 'hidden' = element is no longer visible; 'detached' = element removed from DOM. Use 'hidden' to wait for loading spinners to disappear."
+                    },
+                    "silent": {
+                        "type": "boolean",
+                        "description": "When true, suppress the page_state payload from the response. Use for simple timed pauses where you don't need a structural diff — saves context tokens. Only effective for time-only waits (no selector). Default: false."
                     }
                 },
                 "additionalProperties": false
             }),
-            instructions: Some("Use after actions that trigger page changes (form submits, AJAX requests). Pass `selector` to wait for an element, or `seconds` for a fixed delay. Use `state: \"visible\"` to wait until the element is actually visible (not just in the DOM). Use `state: \"hidden\"` to wait for an element to disappear (e.g. a loading spinner). Returns post-action page_state (URL, title, and structural diff) so you can see what changed without a separate page_map call."),
+            instructions: Some("Use after actions that trigger page changes (form submits, AJAX requests). Pass `selector` to wait for an element, or `seconds` for a fixed delay. Use `state: \"visible\"` to wait until the element is actually visible (not just in the DOM). Use `state: \"hidden\"` to wait for an element to disappear (e.g. a loading spinner). Set `silent: true` for simple timed pauses to suppress the page_state and save context tokens. Has no effect when a `selector` is provided."),
         },
     ]
 }

--- a/crates/agent/src/tools/wait.rs
+++ b/crates/agent/src/tools/wait.rs
@@ -251,32 +251,10 @@ mod tests {
         assert!(parsed.silent);
     }
 
-    #[tokio::test]
-    async fn silent_time_only_wait_skips_page_state() {
-        let _guard = crate::test_async_env_lock().lock().await;
-        let (mut browser, mut crawl_state) = super::super::feedback::tests::test_context().await;
-
-        let input = json!({"timeout_ms": 0, "silent": true});
-        let effect = execute(&input, &mut browser, &mut crawl_state)
-            .await
-            .unwrap();
-        let value = effect.reply_json_value().unwrap();
-
-        assert_eq!(value["success"], json!(true));
-        assert!(value.get("page_state").is_none());
-    }
-
-    #[tokio::test]
-    async fn silent_with_selector_still_includes_page_state() {
-        let _guard = crate::test_async_env_lock().lock().await;
-        let (mut browser, mut crawl_state) = super::super::feedback::tests::test_context().await;
-
-        let input = json!({"selector": "body", "timeout_ms": 100, "silent": true});
-        let effect = execute(&input, &mut browser, &mut crawl_state)
-            .await
-            .unwrap();
-        let value = effect.reply_json_value().unwrap();
-
-        assert!(value.get("page_state").is_some());
+    #[test]
+    fn parses_silent_false_explicit() {
+        let input = json!({"seconds": 1, "silent": false});
+        let parsed = parse_input(&input).unwrap();
+        assert!(!parsed.silent);
     }
 }

--- a/crates/agent/src/tools/wait.rs
+++ b/crates/agent/src/tools/wait.rs
@@ -17,6 +17,7 @@ pub struct WaitInput {
     pub selector: Option<String>,
     pub timeout_ms: u64,
     pub state: Option<String>,
+    pub silent: bool,
 }
 
 pub fn parse_input(input: &Value) -> Result<WaitInput, CrawlError> {
@@ -53,10 +54,16 @@ pub fn parse_input(input: &Value) -> Result<WaitInput, CrawlError> {
         ));
     }
 
+    let silent = input
+        .get("silent")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+
     Ok(WaitInput {
         selector,
         timeout_ms,
         state,
+        silent,
     })
 }
 
@@ -128,6 +135,13 @@ pub async fn execute(
         })))
     } else {
         tokio::time::sleep(Duration::from_millis(parsed.timeout_ms)).await;
+
+        if parsed.silent {
+            return Ok(ToolEffect::reply_json(&json!({
+                "success": true,
+                "waited_ms": parsed.timeout_ms
+            })));
+        }
 
         let page_state = super::feedback::post_action_page_state(
             browser,
@@ -221,5 +235,48 @@ mod tests {
         let input = json!({"selector": "#btn"});
         let parsed = parse_input(&input).unwrap();
         assert!(parsed.state.is_none());
+    }
+
+    #[test]
+    fn silent_defaults_to_false() {
+        let input = json!({"seconds": 1});
+        let parsed = parse_input(&input).unwrap();
+        assert!(!parsed.silent);
+    }
+
+    #[test]
+    fn parses_silent_true() {
+        let input = json!({"seconds": 1, "silent": true});
+        let parsed = parse_input(&input).unwrap();
+        assert!(parsed.silent);
+    }
+
+    #[tokio::test]
+    async fn silent_time_only_wait_skips_page_state() {
+        let _guard = crate::test_async_env_lock().lock().await;
+        let (mut browser, mut crawl_state) = super::super::feedback::tests::test_context().await;
+
+        let input = json!({"timeout_ms": 0, "silent": true});
+        let effect = execute(&input, &mut browser, &mut crawl_state)
+            .await
+            .unwrap();
+        let value = effect.reply_json_value().unwrap();
+
+        assert_eq!(value["success"], json!(true));
+        assert!(value.get("page_state").is_none());
+    }
+
+    #[tokio::test]
+    async fn silent_with_selector_still_includes_page_state() {
+        let _guard = crate::test_async_env_lock().lock().await;
+        let (mut browser, mut crawl_state) = super::super::feedback::tests::test_context().await;
+
+        let input = json!({"selector": "body", "timeout_ms": 100, "silent": true});
+        let effect = execute(&input, &mut browser, &mut crawl_state)
+            .await
+            .unwrap();
+        let value = effect.reply_json_value().unwrap();
+
+        assert!(value.get("page_state").is_some());
     }
 }

--- a/crates/agent/src/tools/wait.rs
+++ b/crates/agent/src/tools/wait.rs
@@ -257,4 +257,65 @@ mod tests {
         let parsed = parse_input(&input).unwrap();
         assert!(!parsed.silent);
     }
+
+    fn effect_json(effect: ToolEffect) -> Value {
+        let ToolEffect::Reply(body) = effect else {
+            panic!("expected ToolEffect::Reply, got {effect:?}");
+        };
+        serde_json::from_str(&body).unwrap()
+    }
+
+    #[tokio::test]
+    async fn execute_silent_time_only_wait_omits_page_state() {
+        use crate::tools::test_support::browser_with_observations;
+
+        let mut browser = browser_with_observations(vec![]);
+        let mut state = CrawlState::default();
+
+        let effect = execute(
+            &json!({"timeout_ms": 1, "silent": true}),
+            &mut browser,
+            &mut state,
+        )
+        .await
+        .unwrap();
+        let response = effect_json(effect);
+
+        assert_eq!(response["waited_ms"], 1);
+        assert!(response.get("page_state").is_none());
+    }
+
+    #[tokio::test]
+    async fn execute_non_silent_time_only_wait_includes_page_state() {
+        use crate::tools::test_support::browser_with_observations;
+
+        let mut browser = browser_with_observations(vec![]);
+        let mut state = CrawlState::default();
+
+        let effect = execute(&json!({"timeout_ms": 1}), &mut browser, &mut state)
+            .await
+            .unwrap();
+        let response = effect_json(effect);
+
+        assert!(response.get("page_state").is_some());
+    }
+
+    #[tokio::test]
+    async fn execute_silent_with_selector_still_includes_page_state() {
+        use crate::tools::test_support::browser_with_observations;
+
+        let mut browser = browser_with_observations(vec![]);
+        let mut state = CrawlState::default();
+
+        let effect = execute(
+            &json!({"selector": "#btn", "silent": true}),
+            &mut browser,
+            &mut state,
+        )
+        .await
+        .unwrap();
+        let response = effect_json(effect);
+
+        assert!(response.get("page_state").is_some());
+    }
 }


### PR DESCRIPTION
## Summary

Adds a `silent` (bool) parameter to the `wait` tool. When `silent: true` and no selector is provided, the tool skips the `post_action_page_state` call and returns only `{success: true, waited_ms: <N>}` — saving context tokens for simple timed pauses where no structural diff is needed.

When `silent: true` with a selector, or when `silent: false` (default), behavior is unchanged — `page_state` is included as before.

## Changes

- **`crates/agent/src/tools/wait.rs`**: Added `silent: bool` to `WaitInput` struct, parse it in `parse_input()`, and return early in `execute()` when silent=true and no selector is used. Added parse-level unit tests.
- **`crates/agent/src/lib.rs`**: Added `silent` parameter to the wait tool spec with description. Updated instructions string.

## Test Plan

- [x] Unit tests pass (28 wait-related tests, 3 new)
- [x] `cargo build --release` succeeds
- [x] E2E tests: silent=false → page_state present; silent=true (time-only) → page_state absent; silent=true (with selector) → page_state still present

Closes #72