### PR TITLE
fix: auto-descend click into container refs with single actionable child

### DIFF
--- a/crates/agent/src/aria/reconcile.rs
+++ b/crates/agent/src/aria/reconcile.rs
@@ -34,11 +34,12 @@ pub fn assign_refs(
     ref_map: &mut RefMap,
     frame_id: Option<&str>,
     ancestors: &mut Vec<(String, String)>,
+    parent_ref_id: Option<&str>,
 ) {
     let is_virtual = node.role == "document" && node.ref_id.is_none();
     if node.role == "text" || is_virtual {
         for child in &mut node.children {
-            assign_refs(child, ref_map, frame_id, ancestors);
+            assign_refs(child, ref_map, frame_id, ancestors, parent_ref_id);
         }
         return;
     }
@@ -47,16 +48,17 @@ pub fn assign_refs(
     let refs = ancestor_refs(ancestors);
     let stable_key = identity_key(&node.role, &name, &refs);
     let ref_id = match node.ref_id.as_deref() {
-        Some(existing) => ref_map.bind_existing(&stable_key, existing, &node.role, &name, frame_id),
+        Some(existing) => ref_map.bind_existing(&stable_key, existing, &node.role, &name, frame_id, parent_ref_id),
         None => ref_map.assign_by_identity(
             &stable_key,
             &node.role,
             &name,
             frame_id,
             Resolution::Attr(String::new()),
+            parent_ref_id,
         ),
     };
-    node.ref_id = Some(ref_id);
+    node.ref_id = Some(ref_id.clone());
 
     ancestors.push((node.role.clone(), name));
     let iframe_child_frame = node.frame_id.clone();
@@ -66,7 +68,7 @@ pub fn assign_refs(
         } else {
             frame_id
         };
-        assign_refs(child, ref_map, child_frame_id, ancestors);
+        assign_refs(child, ref_map, child_frame_id, ancestors, Some(&ref_id));
     }
     ancestors.pop();
 }
@@ -92,7 +94,7 @@ mod tests {
 
     fn assign_with_fresh_map(tree: &mut AriaNode) {
         let mut ref_map = RefMap::new();
-        assign_refs(tree, &mut ref_map, None, &mut vec![]);
+        assign_refs(tree, &mut ref_map, None, &mut vec![], None);
     }
 
     fn with_ref(mut node: AriaNode, ref_id: &str) -> AriaNode {

--- a/crates/agent/src/aria/reconcile.rs
+++ b/crates/agent/src/aria/reconcile.rs
@@ -48,7 +48,14 @@ pub fn assign_refs(
     let refs = ancestor_refs(ancestors);
     let stable_key = identity_key(&node.role, &name, &refs);
     let ref_id = match node.ref_id.as_deref() {
-        Some(existing) => ref_map.bind_existing(&stable_key, existing, &node.role, &name, frame_id, parent_ref_id),
+        Some(existing) => ref_map.bind_existing(
+            &stable_key,
+            existing,
+            &node.role,
+            &name,
+            frame_id,
+            parent_ref_id,
+        ),
         None => ref_map.assign_by_identity(
             &stable_key,
             &node.role,

--- a/crates/agent/src/aria/reconcile.rs
+++ b/crates/agent/src/aria/reconcile.rs
@@ -67,6 +67,13 @@ pub fn assign_refs(
     };
     node.ref_id = Some(ref_id.clone());
 
+    // Mark containers with omitted children (truncated by depth/child-count
+    // limits in the ARIA walk) so auto-descend won't pick a misleading single
+    // visible child when there are more hidden descendants.
+    if node.omitted_children > 0 {
+        ref_map.set_truncated(&ref_id, true);
+    }
+
     ancestors.push((node.role.clone(), name));
     let iframe_child_frame = node.frame_id.clone();
     for child in &mut node.children {

--- a/crates/agent/src/implementation/mod.rs
+++ b/crates/agent/src/implementation/mod.rs
@@ -2248,7 +2248,7 @@ mod tests {
             .as_mut()
             .expect("browser should exist")
             .ref_map_mut()
-            .assign_or_reuse("#old-submit", "button", "Submit");
+            .assign_or_reuse("#old-submit", "button", "Submit", None);
 
         let result = agent
             .execute("click", r#"{"selector":"@e1"}"#)
@@ -2294,7 +2294,7 @@ mod tests {
             .as_mut()
             .expect("browser should exist")
             .ref_map_mut()
-            .assign_or_reuse("#old-submit", "button", "Submit");
+            .assign_or_reuse("#old-submit", "button", "Submit", None);
 
         let err = agent
             .execute("click", r#"{"selector":"@e1"}"#)
@@ -2324,7 +2324,7 @@ mod tests {
             .as_mut()
             .expect("browser should exist")
             .ref_map_mut()
-            .assign_or_reuse("#old-submit", "button", "Submit");
+            .assign_or_reuse("#old-submit", "button", "Submit", None);
 
         let err = agent
             .execute("click", r#"{"selector":"@e1"}"#)
@@ -2354,7 +2354,7 @@ mod tests {
             .as_mut()
             .expect("browser should exist")
             .ref_map_mut()
-            .assign_or_reuse("#old-submit", "button", "Submit");
+            .assign_or_reuse("#old-submit", "button", "Submit", None);
 
         let err = agent
             .execute("click", r#"{"selector":"@e1"}"#)
@@ -2382,7 +2382,7 @@ mod tests {
             .as_mut()
             .expect("browser should exist")
             .ref_map_mut()
-            .assign_or_reuse("#old-submit", "button", "Submit");
+            .assign_or_reuse("#old-submit", "button", "Submit", None);
 
         let err = agent
             .execute("click", r#"{"selector":"@e1"}"#)

--- a/crates/agent/src/tools/click.rs
+++ b/crates/agent/src/tools/click.rs
@@ -190,7 +190,7 @@ pub async fn execute(
     let params = parse_input(input)?;
 
     let selector = if let Some(ref sel) = params.selector {
-        super::ref_resolve::resolve_selector(sel, browser.ref_map())
+        super::ref_resolve::resolve_selector(sel, browser.ref_map(), false)
             .map_err(ToolExecutionError::new)?
     } else {
         let text = params.text.as_deref().unwrap_or_default();

--- a/crates/agent/src/tools/execute_js.rs
+++ b/crates/agent/src/tools/execute_js.rs
@@ -61,8 +61,9 @@ pub async fn execute(
     let params = parse_input(input)?;
 
     if let Some(hover_selector) = &params.hover_selector {
-        let resolved = super::ref_resolve::resolve_selector(hover_selector, browser.ref_map())
-            .map_err(ToolExecutionError::new)?;
+        let resolved =
+            super::ref_resolve::resolve_selector(hover_selector, browser.ref_map(), false)
+                .map_err(ToolExecutionError::new)?;
 
         browser
             .acquire_bridge()

--- a/crates/agent/src/tools/feedback.rs
+++ b/crates/agent/src/tools/feedback.rs
@@ -471,6 +471,7 @@ fn page_state_from_feedback_map(
         browser.set_page_snapshot(&cache_key, None, pm);
         return page_state;
     };
+    browser.ref_map_mut().begin_snapshot();
     assign_refs(
         &mut current_tree,
         browser.ref_map_mut(),

--- a/crates/agent/src/tools/feedback.rs
+++ b/crates/agent/src/tools/feedback.rs
@@ -476,6 +476,7 @@ fn page_state_from_feedback_map(
         browser.ref_map_mut(),
         None,
         &mut Vec::new(),
+        None,
     );
 
     // Prefer the cached snapshot's tree, but when the snapshot lacks one

--- a/crates/agent/src/tools/fill_form.rs
+++ b/crates/agent/src/tools/fill_form.rs
@@ -68,14 +68,14 @@ pub async fn execute(
         .fields
         .iter()
         .map(|(sel, val)| {
-            let resolved = super::ref_resolve::resolve_selector(sel, browser.ref_map())
+            let resolved = super::ref_resolve::resolve_selector(sel, browser.ref_map(), false)
                 .map_err(ToolExecutionError::new)?;
             Ok::<_, ToolExecutionError>((resolved, val.clone()))
         })
         .collect::<Result<Vec<_>, _>>()?;
 
     let resolved_form_selector =
-        super::ref_resolve::resolve_selector(&params.form_selector, browser.ref_map())
+        super::ref_resolve::resolve_selector(&params.form_selector, browser.ref_map(), true)
             .map_err(ToolExecutionError::new)?;
 
     fill_fields(browser, &resolved_fields).await?;

--- a/crates/agent/src/tools/navigate.rs
+++ b/crates/agent/src/tools/navigate.rs
@@ -387,6 +387,7 @@ async fn build_structural_yaml(
     };
 
     if page.fetched_via_browser {
+        browser.ref_map_mut().begin_snapshot();
         assign_refs(
             &mut tree,
             browser.ref_map_mut(),

--- a/crates/agent/src/tools/navigate.rs
+++ b/crates/agent/src/tools/navigate.rs
@@ -387,7 +387,7 @@ async fn build_structural_yaml(
     };
 
     if page.fetched_via_browser {
-        assign_refs(&mut tree, browser.ref_map_mut(), None, &mut Vec::new());
+        assign_refs(&mut tree, browser.ref_map_mut(), None, &mut Vec::new(), None);
         let cache_key = normalize_url(&page.url).to_string();
         browser.set_page_snapshot(&cache_key, None, json!({ "meta": { "url": page.url } }));
     }

--- a/crates/agent/src/tools/navigate.rs
+++ b/crates/agent/src/tools/navigate.rs
@@ -387,7 +387,13 @@ async fn build_structural_yaml(
     };
 
     if page.fetched_via_browser {
-        assign_refs(&mut tree, browser.ref_map_mut(), None, &mut Vec::new(), None);
+        assign_refs(
+            &mut tree,
+            browser.ref_map_mut(),
+            None,
+            &mut Vec::new(),
+            None,
+        );
         let cache_key = normalize_url(&page.url).to_string();
         browser.set_page_snapshot(&cache_key, None, json!({ "meta": { "url": page.url } }));
     }

--- a/crates/agent/src/tools/page_map.rs
+++ b/crates/agent/src/tools/page_map.rs
@@ -66,7 +66,7 @@ pub fn annotate_refs(result: &mut Value, browser: &mut BrowserContext) {
                     .to_string();
                 let ref_id = browser
                     .ref_map_mut()
-                    .assign_or_reuse(&selector, &role, &name);
+                    .assign_or_reuse(&selector, &role, &name, None);
                 if let Some(obj) = el.as_object_mut() {
                     obj.insert("ref".to_string(), Value::String(format!("@{ref_id}")));
                 }
@@ -314,7 +314,7 @@ pub async fn execute(
         if url_changed {
             browser.ref_map_mut().clear();
         }
-        assign_refs(&mut tree, browser.ref_map_mut(), None, &mut Vec::new());
+        assign_refs(&mut tree, browser.ref_map_mut(), None, &mut Vec::new(), None);
         browser.set_page_snapshot(&cache_key, None, result.clone());
 
         // Only full-page snapshots may become the diff baseline and the
@@ -327,7 +327,7 @@ pub async fn execute(
         }
         crawl_state.last_aria_tree = Some(tree.clone());
     } else {
-        assign_refs(&mut tree, browser.ref_map_mut(), None, &mut Vec::new());
+        assign_refs(&mut tree, browser.ref_map_mut(), None, &mut Vec::new(), None);
     }
 
     // The walk already limited its own depth; the serializer depth is a cap on
@@ -711,6 +711,7 @@ mod tests {
             "Embedded panel",
             Some("f2"),
             Resolution::Attr(String::new()),
+            None,
         );
 
         assert_eq!(
@@ -811,13 +812,13 @@ mod tests {
 
         let mut ref_map = RefMap::new();
         // Assign twice for same selector → same ref
-        let r1 = ref_map.assign_or_reuse("#submit", "button", "Submit");
-        let r2 = ref_map.assign_or_reuse("#submit", "button", "Submit");
+        let r1 = ref_map.assign_or_reuse("#submit", "button", "Submit", None);
+        let r2 = ref_map.assign_or_reuse("#submit", "button", "Submit", None);
         assert_eq!(r1, r2);
         assert_eq!(r1, "e1");
 
         // Different selector → new ref
-        let r3 = ref_map.assign_or_reuse("#email", "textbox", "Email");
+        let r3 = ref_map.assign_or_reuse("#email", "textbox", "Email", None);
         assert_ne!(r1, r3);
         assert_eq!(r3, "e2");
     }
@@ -827,13 +828,13 @@ mod tests {
         use browser::RefMap;
 
         let mut ref_map = RefMap::new();
-        let r1 = ref_map.assign_or_reuse("#btn", "button", "Click me");
+        let r1 = ref_map.assign_or_reuse("#btn", "button", "Click me", None);
         assert_eq!(r1, "e1");
 
         ref_map.clear();
 
         // After clear, counter resets
-        let r2 = ref_map.assign_or_reuse("#other-btn", "button", "Other");
+        let r2 = ref_map.assign_or_reuse("#other-btn", "button", "Other", None);
         assert_eq!(r2, "e1");
         // Original ref no longer exists — e1 now points to #other-btn
         assert_eq!(
@@ -864,7 +865,7 @@ mod tests {
         use crate::tools::ref_resolve::resolve_selector;
 
         let mut map = RefMap::new();
-        map.assign_or_reuse("#email-input", "textbox", "Email");
+        map.assign_or_reuse("#email-input", "textbox", "Email", None);
         // Legacy selector-backed refs still resolve to the stored CSS selector.
         let resolved = resolve_selector("@e1", &map).unwrap();
         assert_eq!(resolved, "#email-input");
@@ -891,7 +892,7 @@ mod tests {
         use crate::tools::ref_resolve::resolve_selector;
 
         let mut map = RefMap::new();
-        map.assign_or_reuse("button.submit", "button", "Submit");
+        map.assign_or_reuse("button.submit", "button", "Submit", None);
 
         // @e1 resolves to CSS selector
         assert_eq!(resolve_selector("@e1", &map).unwrap(), "button.submit");
@@ -912,9 +913,9 @@ mod tests {
         let mut map_b = RefMap::new();
 
         // Assign to map_a
-        let ref_a = map_a.assign_or_reuse("#btn-a", "button", "A");
+        let ref_a = map_a.assign_or_reuse("#btn-a", "button", "A", None);
         // Assign different selector to map_b
-        let ref_b = map_b.assign_or_reuse("#btn-b", "button", "B");
+        let ref_b = map_b.assign_or_reuse("#btn-b", "button", "B", None);
 
         // Both start at e1 (independent counters)
         assert_eq!(ref_a, "e1");
@@ -1099,7 +1100,7 @@ mod tests {
 
         let mut tree = parse_raw_tree(&bridge_result["tree"]).expect("tree should parse");
         let mut ref_map = RefMap::new();
-        assign_refs(&mut tree, &mut ref_map, None, &mut Vec::new());
+        assign_refs(&mut tree, &mut ref_map, None, &mut Vec::new(), None);
 
         let yaml = to_yaml(&tree, Some(super::DEFAULT_TREE_DEPTH));
         assert!(yaml.starts_with("- button \"Submit\" [disabled] [ref=e1]:"));

--- a/crates/agent/src/tools/page_map.rs
+++ b/crates/agent/src/tools/page_map.rs
@@ -314,7 +314,13 @@ pub async fn execute(
         if url_changed {
             browser.ref_map_mut().clear();
         }
-        assign_refs(&mut tree, browser.ref_map_mut(), None, &mut Vec::new(), None);
+        assign_refs(
+            &mut tree,
+            browser.ref_map_mut(),
+            None,
+            &mut Vec::new(),
+            None,
+        );
         browser.set_page_snapshot(&cache_key, None, result.clone());
 
         // Only full-page snapshots may become the diff baseline and the
@@ -327,7 +333,13 @@ pub async fn execute(
         }
         crawl_state.last_aria_tree = Some(tree.clone());
     } else {
-        assign_refs(&mut tree, browser.ref_map_mut(), None, &mut Vec::new(), None);
+        assign_refs(
+            &mut tree,
+            browser.ref_map_mut(),
+            None,
+            &mut Vec::new(),
+            None,
+        );
     }
 
     // The walk already limited its own depth; the serializer depth is a cap on

--- a/crates/agent/src/tools/page_map.rs
+++ b/crates/agent/src/tools/page_map.rs
@@ -314,6 +314,7 @@ pub async fn execute(
         if url_changed {
             browser.ref_map_mut().clear();
         }
+        browser.ref_map_mut().begin_snapshot();
         assign_refs(
             &mut tree,
             browser.ref_map_mut(),
@@ -333,6 +334,7 @@ pub async fn execute(
         }
         crawl_state.last_aria_tree = Some(tree.clone());
     } else {
+        browser.ref_map_mut().begin_snapshot();
         assign_refs(
             &mut tree,
             browser.ref_map_mut(),
@@ -863,9 +865,9 @@ mod tests {
 
         let map = RefMap::new();
         // Pure CSS selectors pass through unchanged
-        assert_eq!(resolve_selector("#email", &map).unwrap(), "#email");
+        assert_eq!(resolve_selector("#email", &map, false).unwrap(), "#email");
         assert_eq!(
-            resolve_selector("input[name='q']", &map).unwrap(),
+            resolve_selector("input[name='q']", &map, false).unwrap(),
             "input[name='q']"
         );
     }
@@ -879,7 +881,7 @@ mod tests {
         let mut map = RefMap::new();
         map.assign_or_reuse("#email-input", "textbox", "Email", None);
         // Legacy selector-backed refs still resolve to the stored CSS selector.
-        let resolved = resolve_selector("@e1", &map).unwrap();
+        let resolved = resolve_selector("@e1", &map, false).unwrap();
         assert_eq!(resolved, "#email-input");
     }
 
@@ -890,7 +892,7 @@ mod tests {
         use crate::tools::ref_resolve::resolve_selector;
 
         let map = RefMap::new(); // empty map
-        let err = resolve_selector("@e999", &map).unwrap_err();
+        let err = resolve_selector("@e999", &map, false).unwrap_err();
         assert_eq!(
             err,
             "Ref '@e999' not found. The page may have changed. Call page_map to get fresh refs."
@@ -907,11 +909,14 @@ mod tests {
         map.assign_or_reuse("button.submit", "button", "Submit", None);
 
         // @e1 resolves to CSS selector
-        assert_eq!(resolve_selector("@e1", &map).unwrap(), "button.submit");
-        // Unrelated CSS selectors pass through unchanged
-        assert_eq!(resolve_selector("#other", &map).unwrap(), "#other");
         assert_eq!(
-            resolve_selector(".class-selector", &map).unwrap(),
+            resolve_selector("@e1", &map, false).unwrap(),
+            "button.submit"
+        );
+        // Unrelated CSS selectors pass through unchanged
+        assert_eq!(resolve_selector("#other", &map, false).unwrap(), "#other");
+        assert_eq!(
+            resolve_selector(".class-selector", &map, false).unwrap(),
             ".class-selector"
         );
     }
@@ -1036,11 +1041,14 @@ mod tests {
             }
         });
         annotate_refs(&mut value, &mut ctx);
-        assert_eq!(resolve_selector("@e1", ctx.ref_map()).unwrap(), "#old-btn");
+        assert_eq!(
+            resolve_selector("@e1", ctx.ref_map(), false).unwrap(),
+            "#old-btn"
+        );
 
         ctx.ref_map_mut().clear();
 
-        let err = resolve_selector("@e1", ctx.ref_map()).unwrap_err();
+        let err = resolve_selector("@e1", ctx.ref_map(), false).unwrap_err();
         assert_eq!(
             err,
             "Ref '@e1' not found. The page may have changed. Call page_map to get fresh refs."
@@ -1054,7 +1062,10 @@ mod tests {
             }
         });
         annotate_refs(&mut value2, &mut ctx);
-        assert_eq!(resolve_selector("@e1", ctx.ref_map()).unwrap(), "#new-btn");
+        assert_eq!(
+            resolve_selector("@e1", ctx.ref_map(), false).unwrap(),
+            "#new-btn"
+        );
     }
 
     #[test]

--- a/crates/agent/src/tools/ref_resolve.rs
+++ b/crates/agent/src/tools/ref_resolve.rs
@@ -127,9 +127,7 @@ pub fn resolve_selector(input: &str, ref_map: &RefMap) -> Result<String, String>
         let resolved_ref = validate_or_auto_descend(input, ref_map, &ref_id)?;
 
         let target_id = match resolved_ref {
-            Some(child_ref) => {
-                parse_ref(&child_ref).unwrap_or(child_ref)
-            }
+            Some(child_ref) => parse_ref(&child_ref).unwrap_or(child_ref),
             None => ref_id,
         };
 
@@ -336,8 +334,7 @@ mod tests {
         );
 
         // Resolving the container should auto-descend to the button
-        let result =
-            resolve_selector(&format!("@{container_id}"), &map).unwrap();
+        let result = resolve_selector(&format!("@{container_id}"), &map).unwrap();
         // Should resolve to the button's attr query
         assert!(result.contains("data-acrawl-ref='e2'"));
     }
@@ -374,9 +371,18 @@ mod tests {
         );
 
         let err = resolve_selector(&format!("@{container_id}"), &map).unwrap_err();
-        assert!(err.contains(&format!("@{child1}")), "error should mention child1: {err}");
-        assert!(err.contains(&format!("@{child2}")), "error should mention child2: {err}");
-        assert!(err.contains("2 clickable children"), "error should state count: {err}");
+        assert!(
+            err.contains(&format!("@{child1}")),
+            "error should mention child1: {err}"
+        );
+        assert!(
+            err.contains(&format!("@{child2}")),
+            "error should mention child2: {err}"
+        );
+        assert!(
+            err.contains("2 clickable children"),
+            "error should state count: {err}"
+        );
     }
 
     #[test]

--- a/crates/agent/src/tools/ref_resolve.rs
+++ b/crates/agent/src/tools/ref_resolve.rs
@@ -37,12 +37,56 @@ fn is_actionable_role(role: &str) -> bool {
     )
 }
 
-fn validate_actionable_ref(input: &str, ref_map: &RefMap, ref_id: &str) -> Result<(), String> {
+/// Validate that a ref is actionable or try to auto-descend into children.
+///
+/// Returns:
+/// - `Ok(None)`: ref is directly actionable — use it as-is.
+/// - `Ok(Some(child_ref_id))`: container with exactly one actionable
+///   descendant — auto-descend to this child ref.
+/// - `Err(msg)`: container with 0 or 2+ actionable children, or stale ref.
+fn validate_or_auto_descend(
+    input: &str,
+    ref_map: &RefMap,
+    ref_id: &str,
+) -> Result<Option<String>, String> {
     let entry = ref_map.get(ref_id).ok_or_else(|| stale_ref_error(input))?;
-    if matches!(entry.resolution, Resolution::Attr(_)) && !is_actionable_role(&entry.role) {
-        return Err(container_ref_error(input));
+
+    // Directly actionable ref — no auto-descend needed
+    if !matches!(entry.resolution, Resolution::Attr(_)) || is_actionable_role(&entry.role) {
+        return Ok(None);
     }
-    Ok(())
+
+    // Container ref — try to find actionable descendants
+    let descendants = ref_map.descendant_refs(ref_id);
+    let actionable: Vec<String> = descendants
+        .into_iter()
+        .filter(|d_id| {
+            ref_map
+                .get(d_id)
+                .is_some_and(|e| is_actionable_role(&e.role))
+        })
+        .collect();
+
+    match actionable.len() {
+        0 => Err(container_ref_error(input)),
+        1 => {
+            let child_ref = &actionable[0];
+            Ok(Some(format!("@{child_ref}")))
+        }
+        _ => {
+            let child_list = actionable
+                .iter()
+                .map(|id| format!("@{id}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            Err(format!(
+                "Ref '{}' is a container with {} clickable children ({}). Target one of them directly.",
+                canonical_ref(input),
+                actionable.len(),
+                child_list
+            ))
+        }
+    }
 }
 
 /// Resolve a ref string (e.g. "@e5" or "e5") to its action query.
@@ -56,9 +100,19 @@ pub fn resolve_to_action_query(
 ) -> Result<(Option<String>, String), String> {
     if let Some(ref_id) = parse_ref(ref_input) {
         let ref_map = context.ref_map();
-        validate_actionable_ref(ref_input, ref_map, &ref_id)?;
+        let resolved_ref = validate_or_auto_descend(ref_input, ref_map, &ref_id)?;
+
+        let target_id = match resolved_ref {
+            Some(child_ref) => {
+                // parse_ref strips the @ before the ref id
+                parse_ref(&child_ref).unwrap_or(child_ref)
+            }
+            None => ref_id,
+        };
+
         return ref_map
-            .resolve(&ref_id)
+            .resolve(&target_id)
+            .map(|(_, query)| (None, query))
             .ok_or_else(|| stale_ref_error(ref_input));
     }
 
@@ -70,9 +124,17 @@ pub fn resolve_to_action_query(
 /// Returns Err if input looks like a ref but is not found in the map.
 pub fn resolve_selector(input: &str, ref_map: &RefMap) -> Result<String, String> {
     if let Some(ref_id) = parse_ref(input) {
-        validate_actionable_ref(input, ref_map, &ref_id)?;
+        let resolved_ref = validate_or_auto_descend(input, ref_map, &ref_id)?;
+
+        let target_id = match resolved_ref {
+            Some(child_ref) => {
+                parse_ref(&child_ref).unwrap_or(child_ref)
+            }
+            None => ref_id,
+        };
+
         ref_map
-            .resolve(&ref_id)
+            .resolve(&target_id)
             .map(|(_, query)| query)
             .ok_or_else(|| stale_ref_error(input))
     } else {
@@ -175,7 +237,7 @@ mod tests {
     #[test]
     fn valid_ref_resolves_to_selector() {
         let mut map = RefMap::new();
-        map.assign_or_reuse("button.submit", "button", "Submit");
+        map.assign_or_reuse("button.submit", "button", "Submit", None);
         let result = resolve_selector("@e1", &map).unwrap();
         assert_eq!(result, "button.submit");
     }
@@ -183,7 +245,7 @@ mod tests {
     #[test]
     fn bare_ref_resolves() {
         let mut map = RefMap::new();
-        map.assign_or_reuse("input#email", "textbox", "Email");
+        map.assign_or_reuse("input#email", "textbox", "Email", None);
         let result = resolve_selector("e1", &map).unwrap();
         assert_eq!(result, "input#email");
     }
@@ -221,6 +283,7 @@ mod tests {
             "Submit",
             Some("f1"),
             Resolution::Attr(String::new()),
+            None,
         );
 
         let result = resolve_selector(&format!("@{ref_id}"), &map).unwrap();
@@ -236,6 +299,7 @@ mod tests {
             "Primary",
             None,
             Resolution::Attr(String::new()),
+            None,
         );
 
         let err = resolve_selector(&format!("@{ref_id}"), &map).unwrap_err();
@@ -248,6 +312,74 @@ mod tests {
     }
 
     #[test]
+    fn container_ref_auto_descends_to_single_actionable_child() {
+        let mut map = RefMap::new();
+
+        // Container (generic div wrapping a button)
+        let container_id = map.assign_by_identity(
+            "generic|Diagramma|",
+            "generic",
+            "Diagramma",
+            None,
+            Resolution::Attr(String::new()),
+            None,
+        );
+
+        // Single actionable child (button)
+        map.assign_by_identity(
+            "button|Settings|generic:Diagramma|",
+            "button",
+            "Settings",
+            None,
+            Resolution::Attr(String::new()),
+            Some(&container_id),
+        );
+
+        // Resolving the container should auto-descend to the button
+        let result =
+            resolve_selector(&format!("@{container_id}"), &map).unwrap();
+        // Should resolve to the button's attr query
+        assert!(result.contains("data-acrawl-ref='e2'"));
+    }
+
+    #[test]
+    fn container_ref_with_multiple_actionable_children_returns_hint() {
+        let mut map = RefMap::new();
+
+        let container_id = map.assign_by_identity(
+            "generic|Root|",
+            "generic",
+            "Root",
+            None,
+            Resolution::Attr(String::new()),
+            None,
+        );
+
+        let child1 = map.assign_by_identity(
+            "button|A|generic:Root|",
+            "button",
+            "A",
+            None,
+            Resolution::Attr(String::new()),
+            Some(&container_id),
+        );
+
+        let child2 = map.assign_by_identity(
+            "button|B|generic:Root|",
+            "button",
+            "B",
+            None,
+            Resolution::Attr(String::new()),
+            Some(&container_id),
+        );
+
+        let err = resolve_selector(&format!("@{container_id}"), &map).unwrap_err();
+        assert!(err.contains(&format!("@{child1}")), "error should mention child1: {err}");
+        assert!(err.contains(&format!("@{child2}")), "error should mention child2: {err}");
+        assert!(err.contains("2 clickable children"), "error should state count: {err}");
+    }
+
+    #[test]
     fn action_query_returns_frame_and_query() {
         let mut context = test_context();
         let ref_id = context.ref_map_mut().assign_by_identity(
@@ -256,6 +388,7 @@ mod tests {
             "Submit",
             Some("f7"),
             Resolution::Attr(String::new()),
+            None,
         );
 
         let (frame_id, query) = resolve_to_action_query(&format!("@{ref_id}"), &context).unwrap();
@@ -308,6 +441,7 @@ mod tests {
             "Confirm",
             Some("f1"),
             Resolution::Attr(String::new()),
+            None,
         );
 
         let expected = Some(format!("[data-acrawl-ref='{ref_id}']"));
@@ -331,6 +465,7 @@ mod tests {
             "Confirm",
             Some("f1"),
             Resolution::Attr(String::new()),
+            None,
         );
 
         let expected = Some(format!("[ref={ref_id}]"));

--- a/crates/agent/src/tools/ref_resolve.rs
+++ b/crates/agent/src/tools/ref_resolve.rs
@@ -48,12 +48,25 @@ fn validate_or_auto_descend(
     input: &str,
     ref_map: &RefMap,
     ref_id: &str,
+    skip_auto_descend: bool,
 ) -> Result<Option<String>, String> {
     let entry = ref_map.get(ref_id).ok_or_else(|| stale_ref_error(input))?;
 
     // Directly actionable ref — no auto-descend needed
     if !matches!(entry.resolution, Resolution::Attr(_)) || is_actionable_role(&entry.role) {
         return Ok(None);
+    }
+
+    // Container ref — skip auto-descend when caller explicitly opts out
+    // (e.g. fill_form's form_selector must stay on the <form> element)
+    if skip_auto_descend {
+        return Err(container_ref_error(input));
+    }
+
+    // Truncated container — children may have been omitted by depth/child-count
+    // limits in the ARIA walk; the single visible child may not be the only one
+    if entry.truncated {
+        return Err(container_ref_error(input));
     }
 
     // Container ref — try to find actionable descendants
@@ -100,7 +113,7 @@ pub fn resolve_to_action_query(
 ) -> Result<(Option<String>, String), String> {
     if let Some(ref_id) = parse_ref(ref_input) {
         let ref_map = context.ref_map();
-        let resolved_ref = validate_or_auto_descend(ref_input, ref_map, &ref_id)?;
+        let resolved_ref = validate_or_auto_descend(ref_input, ref_map, &ref_id, false)?;
 
         let target_id = match resolved_ref {
             Some(child_ref) => {
@@ -122,9 +135,18 @@ pub fn resolve_to_action_query(
 /// Resolve an @eN ref or bare eN ref to its DOM action query.
 /// If input is a CSS selector (not a ref), returns it unchanged.
 /// Returns Err if input looks like a ref but is not found in the map.
-pub fn resolve_selector(input: &str, ref_map: &RefMap) -> Result<String, String> {
+///
+/// When `skip_auto_descend` is true, container refs always produce an error
+/// instead of trying to auto-descend to a child. Use this for selectors that
+/// must stay on the container element (e.g. `fill_form`'s `form_selector`,
+/// which needs the actual `<form>` element for submission).
+pub fn resolve_selector(
+    input: &str,
+    ref_map: &RefMap,
+    skip_auto_descend: bool,
+) -> Result<String, String> {
     if let Some(ref_id) = parse_ref(input) {
-        let resolved_ref = validate_or_auto_descend(input, ref_map, &ref_id)?;
+        let resolved_ref = validate_or_auto_descend(input, ref_map, &ref_id, skip_auto_descend)?;
 
         let target_id = match resolved_ref {
             Some(child_ref) => parse_ref(&child_ref).unwrap_or(child_ref),
@@ -228,7 +250,7 @@ mod tests {
     #[test]
     fn css_selector_passes_through() {
         let map = RefMap::new();
-        let result = resolve_selector("#my-button", &map).unwrap();
+        let result = resolve_selector("#my-button", &map, false).unwrap();
         assert_eq!(result, "#my-button");
     }
 
@@ -236,7 +258,7 @@ mod tests {
     fn valid_ref_resolves_to_selector() {
         let mut map = RefMap::new();
         map.assign_or_reuse("button.submit", "button", "Submit", None);
-        let result = resolve_selector("@e1", &map).unwrap();
+        let result = resolve_selector("@e1", &map, false).unwrap();
         assert_eq!(result, "button.submit");
     }
 
@@ -244,14 +266,14 @@ mod tests {
     fn bare_ref_resolves() {
         let mut map = RefMap::new();
         map.assign_or_reuse("input#email", "textbox", "Email", None);
-        let result = resolve_selector("e1", &map).unwrap();
+        let result = resolve_selector("e1", &map, false).unwrap();
         assert_eq!(result, "input#email");
     }
 
     #[test]
     fn unknown_ref_returns_error() {
         let map = RefMap::new();
-        let err = resolve_selector("@e999", &map).unwrap_err();
+        let err = resolve_selector("@e999", &map, false).unwrap_err();
         assert_eq!(
             err,
             "Ref '@e999' not found. The page may have changed. Call page_map to get fresh refs."
@@ -261,14 +283,14 @@ mod tests {
     #[test]
     fn dot_selector_passes_through() {
         let map = RefMap::new();
-        let result = resolve_selector(".btn-primary", &map).unwrap();
+        let result = resolve_selector(".btn-primary", &map, false).unwrap();
         assert_eq!(result, ".btn-primary");
     }
 
     #[test]
     fn empty_string_passes_through() {
         let map = RefMap::new();
-        let result = resolve_selector("", &map).unwrap();
+        let result = resolve_selector("", &map, false).unwrap();
         assert_eq!(result, "");
     }
 
@@ -284,7 +306,7 @@ mod tests {
             None,
         );
 
-        let result = resolve_selector(&format!("@{ref_id}"), &map).unwrap();
+        let result = resolve_selector(&format!("@{ref_id}"), &map, false).unwrap();
         assert_eq!(result, format!("[data-acrawl-ref='{ref_id}']"));
     }
 
@@ -300,7 +322,7 @@ mod tests {
             None,
         );
 
-        let err = resolve_selector(&format!("@{ref_id}"), &map).unwrap_err();
+        let err = resolve_selector(&format!("@{ref_id}"), &map, false).unwrap_err();
         assert_eq!(
             err,
             format!(
@@ -334,7 +356,7 @@ mod tests {
         );
 
         // Resolving the container should auto-descend to the button
-        let result = resolve_selector(&format!("@{container_id}"), &map).unwrap();
+        let result = resolve_selector(&format!("@{container_id}"), &map, false).unwrap();
         // Should resolve to the button's attr query
         assert!(result.contains("data-acrawl-ref='e2'"));
     }
@@ -370,7 +392,7 @@ mod tests {
             Some(&container_id),
         );
 
-        let err = resolve_selector(&format!("@{container_id}"), &map).unwrap_err();
+        let err = resolve_selector(&format!("@{container_id}"), &map, false).unwrap_err();
         assert!(
             err.contains(&format!("@{child1}")),
             "error should mention child1: {err}"

--- a/crates/agent/tests/integration_test.rs
+++ b/crates/agent/tests/integration_test.rs
@@ -265,7 +265,7 @@ async fn example_com_page_map_refs_match_dom_stamps() {
 
     let mut tree = js_tree.clone();
     let mut ref_map = RefMap::new();
-    assign_refs(&mut tree, &mut ref_map, None, &mut Vec::new());
+    assign_refs(&mut tree, &mut ref_map, None, &mut Vec::new(), None);
 
     let yaml = to_yaml(&tree, Some(5));
     assert!(

--- a/crates/browser/src/ref_map.rs
+++ b/crates/browser/src/ref_map.rs
@@ -62,10 +62,7 @@ impl RefEntry {
             if parent_id == ancestor_ref_id {
                 return true;
             }
-            current = ref_map
-                .map
-                .get(parent_id)
-                .and_then(|p| p.parent.as_deref());
+            current = ref_map.map.get(parent_id).and_then(|p| p.parent.as_deref());
         }
         false
     }
@@ -257,7 +254,7 @@ impl RefMap {
         })
     }
 
-    /// Return all descendant ref_ids (direct children + grandchildren, etc.)
+    /// Return all descendant `ref_id`s (direct children + grandchildren, etc.)
     /// of the given ref. Walk the parent chain transitively.
     #[must_use]
     pub fn descendant_refs(&self, ancestor_ref_id: &str) -> Vec<String> {

--- a/crates/browser/src/ref_map.rs
+++ b/crates/browser/src/ref_map.rs
@@ -48,6 +48,27 @@ pub struct RefEntry {
     /// CSS selector fallback (for interactive nodes, kept for self-healing).
     /// `None` for stamped non-interactive/container nodes.
     pub fallback_selector: Option<String>,
+    /// The parent's `ref_id` (e.g. "e1"), if any. Used to walk the ancestor
+    /// chain for container auto-descend (`RefMap::descendant_refs`).
+    pub parent: Option<String>,
+}
+
+impl RefEntry {
+    /// Check whether this entry is a descendant of `ancestor_ref_id`.
+    /// Walks the parent chain transitively through the given `RefMap`.
+    fn has_ancestor(&self, ancestor_ref_id: &str, ref_map: &RefMap) -> bool {
+        let mut current = self.parent.as_deref();
+        while let Some(parent_id) = current {
+            if parent_id == ancestor_ref_id {
+                return true;
+            }
+            current = ref_map
+                .map
+                .get(parent_id)
+                .and_then(|p| p.parent.as_deref());
+        }
+        false
+    }
 }
 
 /// Maps element references (e.g. "e1", "e5") to their entries.
@@ -98,6 +119,7 @@ impl RefMap {
         name: &str,
         _frame_id: Option<&str>,
         resolution: Resolution,
+        parent_ref_id: Option<&str>,
     ) -> String {
         if let Some(existing) = self.key_to_ref.get(stable_key) {
             return existing.clone();
@@ -122,6 +144,7 @@ impl RefMap {
                 resolution,
                 selector,
                 fallback_selector,
+                parent: parent_ref_id.map(str::to_string),
             },
         );
         self.key_to_ref
@@ -144,6 +167,7 @@ impl RefMap {
         role: &str,
         name: &str,
         _frame_id: Option<&str>,
+        parent_ref_id: Option<&str>,
     ) -> String {
         self.map.insert(
             ref_id.to_string(),
@@ -155,6 +179,7 @@ impl RefMap {
                 resolution: Resolution::Attr(ref_id.to_string()),
                 selector: String::new(),
                 fallback_selector: None,
+                parent: parent_ref_id.map(str::to_string),
             },
         );
         self.key_to_ref
@@ -174,13 +199,20 @@ impl RefMap {
     /// Backward-compatible shim over [`RefMap::assign_by_identity`]: the
     /// selector doubles as the identity key and as a `Selector` resolution.
     /// Kept so existing call sites compile until T10 migrates them.
-    pub fn assign_or_reuse(&mut self, selector: &str, role: &str, name: &str) -> String {
+    pub fn assign_or_reuse(
+        &mut self,
+        selector: &str,
+        role: &str,
+        name: &str,
+        parent_ref_id: Option<&str>,
+    ) -> String {
         self.assign_by_identity(
             selector,
             role,
             name,
             None,
             Resolution::Selector(selector.to_string()),
+            parent_ref_id,
         )
     }
 
@@ -223,6 +255,22 @@ impl RefMap {
                 None
             }
         })
+    }
+
+    /// Return all descendant ref_ids (direct children + grandchildren, etc.)
+    /// of the given ref. Walk the parent chain transitively.
+    #[must_use]
+    pub fn descendant_refs(&self, ancestor_ref_id: &str) -> Vec<String> {
+        self.map
+            .iter()
+            .filter_map(|(ref_id, entry)| {
+                if entry.has_ancestor(ancestor_ref_id, self) {
+                    Some(ref_id.clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 
     /// Clear all refs and reset the counter to 1.
@@ -305,8 +353,8 @@ mod tests {
     #[test]
     fn assign_or_reuse_same_selector_twice() {
         let mut map = RefMap::new();
-        let ref1 = map.assign_or_reuse("button.submit", "button", "Submit");
-        let ref2 = map.assign_or_reuse("button.submit", "button", "Submit");
+        let ref1 = map.assign_or_reuse("button.submit", "button", "Submit", None);
+        let ref2 = map.assign_or_reuse("button.submit", "button", "Submit", None);
         assert_eq!(ref1, ref2);
         assert_eq!(ref1, "e1");
     }
@@ -314,8 +362,8 @@ mod tests {
     #[test]
     fn assign_or_reuse_different_selectors_increments() {
         let mut map = RefMap::new();
-        let ref1 = map.assign_or_reuse("button.submit", "button", "Submit");
-        let ref2 = map.assign_or_reuse("input.email", "textbox", "Email");
+        let ref1 = map.assign_or_reuse("button.submit", "button", "Submit", None);
+        let ref2 = map.assign_or_reuse("input.email", "textbox", "Email", None);
         assert_eq!(ref1, "e1");
         assert_eq!(ref2, "e2");
     }
@@ -323,10 +371,10 @@ mod tests {
     #[test]
     fn clear_resets_counter() {
         let mut map = RefMap::new();
-        let ref1 = map.assign_or_reuse("button.submit", "button", "Submit");
+        let ref1 = map.assign_or_reuse("button.submit", "button", "Submit", None);
         assert_eq!(ref1, "e1");
         map.clear();
-        let ref2 = map.assign_or_reuse("button.submit", "button", "Submit");
+        let ref2 = map.assign_or_reuse("button.submit", "button", "Submit", None);
         assert_eq!(ref2, "e1");
     }
 
@@ -341,6 +389,7 @@ mod tests {
             "Submit",
             None,
             Resolution::Attr(String::new()),
+            None,
         );
         assert_eq!(first, "e1");
         let again = map.assign_by_identity(
@@ -349,6 +398,7 @@ mod tests {
             "Submit",
             None,
             Resolution::Attr(String::new()),
+            None,
         );
         assert_eq!(again, "e1");
         let other = map.assign_by_identity(
@@ -357,6 +407,7 @@ mod tests {
             "Home",
             None,
             Resolution::Attr(String::new()),
+            None,
         );
         assert_eq!(other, "e2");
     }
@@ -370,6 +421,7 @@ mod tests {
             "Submit",
             None,
             Resolution::Attr(String::new()),
+            None,
         );
         assert_eq!(first, "e1");
         map.clear();
@@ -379,6 +431,7 @@ mod tests {
             "Submit",
             None,
             Resolution::Attr(String::new()),
+            None,
         );
         assert_eq!(after, "e1");
     }
@@ -392,6 +445,7 @@ mod tests {
             "Submit",
             Some("f2"),
             Resolution::Attr(String::new()),
+            None,
         );
         let (frame_id, query) = map.resolve(&ref_id).expect("ref should resolve");
         assert_eq!(frame_id, None);
@@ -411,6 +465,7 @@ mod tests {
             "Submit",
             None,
             Resolution::Selector("button.submit".to_string()),
+            None,
         );
         let (frame_id, query) = map.resolve(&ref_id).expect("ref should resolve");
         assert_eq!(frame_id, None);
@@ -440,7 +495,7 @@ mod tests {
     #[test]
     fn legacy_assign_or_reuse_populates_selector_and_resolution() {
         let mut map = RefMap::new();
-        let ref_id = map.assign_or_reuse("button.submit", "button", "Submit");
+        let ref_id = map.assign_or_reuse("button.submit", "button", "Submit", None);
         let entry = map.get(&ref_id).unwrap();
         assert_eq!(entry.selector, "button.submit");
         assert_eq!(entry.role, "button");
@@ -465,6 +520,7 @@ mod tests {
             "Home",
             None,
             Resolution::Attr(String::new()),
+            None,
         );
         let frame_ref = map.assign_by_identity(
             "k_frame",
@@ -472,6 +528,7 @@ mod tests {
             "Docs",
             Some("frame-7"),
             Resolution::Attr(String::new()),
+            None,
         );
         assert_eq!(map.resolve(&main_ref).unwrap().0, None);
         assert_eq!(map.resolve(&frame_ref).unwrap().0, None);
@@ -481,7 +538,7 @@ mod tests {
     #[test]
     fn bind_existing_registers_attr_resolution_and_advances_counter() {
         let mut map = RefMap::new();
-        let id = map.bind_existing("button|Submit|", "e5", "button", "Submit", Some("f1"));
+        let id = map.bind_existing("button|Submit|", "e5", "button", "Submit", Some("f1"), None);
         assert_eq!(id, "e5");
 
         let (frame_id, query) = map.resolve("e5").expect("bound ref should resolve");
@@ -494,6 +551,7 @@ mod tests {
             "Home",
             None,
             Resolution::Attr(String::new()),
+            None,
         );
         assert_eq!(minted, "e6");
     }
@@ -501,13 +559,65 @@ mod tests {
     #[test]
     fn bind_existing_keeps_distinct_ids_for_same_identity_key() {
         let mut map = RefMap::new();
-        let first = map.bind_existing("button|Action|main:", "e2", "button", "Action", None);
-        let second = map.bind_existing("button|Action|main:", "e3", "button", "Action", None);
+        let first = map.bind_existing("button|Action|main:", "e2", "button", "Action", None, None);
+        let second = map.bind_existing("button|Action|main:", "e3", "button", "Action", None, None);
 
         assert_eq!(first, "e2");
         assert_eq!(second, "e3");
         assert_ne!(first, second);
         assert_eq!(map.resolve("e2").unwrap().1, "[data-acrawl-ref='e2']");
         assert_eq!(map.resolve("e3").unwrap().1, "[data-acrawl-ref='e3']");
+    }
+
+    #[test]
+    fn descendant_refs_finds_children_and_grandchildren() {
+        let mut map = RefMap::new();
+        // e1 = parent container
+        let e1 = map.assign_by_identity(
+            "container|root|",
+            "generic",
+            "root",
+            None,
+            Resolution::Attr(String::new()),
+            None,
+        );
+        assert_eq!(e1, "e1");
+
+        // e2 = child of e1
+        let e2 = map.assign_by_identity(
+            "heading|Title|generic:root|",
+            "heading",
+            "Title",
+            None,
+            Resolution::Attr(String::new()),
+            Some("e1"),
+        );
+        assert_eq!(e2, "e2");
+
+        // e3 = grandchild of e1 (child of e2)
+        let e3 = map.assign_by_identity(
+            "button|Click|heading:Title|generic:root|",
+            "button",
+            "Click",
+            None,
+            Resolution::Attr(String::new()),
+            Some("e2"),
+        );
+        assert_eq!(e3, "e3");
+
+        // Should find both e2 and e3 as descendants of e1
+        let mut descendants = map.descendant_refs("e1");
+        descendants.sort();
+        assert_eq!(descendants, vec!["e2", "e3"]);
+
+        // e3 is a descendant of e2 (direct child only)
+        let descendants = map.descendant_refs("e2");
+        assert_eq!(descendants, vec!["e3"]);
+
+        // e1 has no descendants beyond e2/e3 (other refs have no parent)
+        // Create e4 with no parent — should NOT be found as e1 descendant
+        map.assign_or_reuse("button.independent", "button", "Independent", None);
+        let descendants = map.descendant_refs("e1");
+        assert_eq!(descendants.len(), 2);
     }
 }

--- a/crates/browser/src/ref_map.rs
+++ b/crates/browser/src/ref_map.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// How a ref is resolved to a DOM element within its owning frame.
 ///
@@ -51,16 +51,30 @@ pub struct RefEntry {
     /// The parent's `ref_id` (e.g. "e1"), if any. Used to walk the ancestor
     /// chain for container auto-descend (`RefMap::descendant_refs`).
     pub parent: Option<String>,
+    /// The snapshot generation this entry was last (re)assigned in. Used by
+    /// `RefMap::descendant_refs` to ignore stale refs from prior `page_map`
+    /// walks on same-URL DOM updates.
+    pub generation: u64,
+    /// Whether this container's children were truncated by the ARIA walker
+    /// (depth/child-count limits omitted some children). Truncated
+    /// containers are never auto-descended into, since the single retained
+    /// actionable child may not be the only actionable descendant.
+    pub truncated: bool,
 }
 
 impl RefEntry {
     /// Check whether this entry is a descendant of `ancestor_ref_id`.
-    /// Walks the parent chain transitively through the given `RefMap`.
+    /// Walks the parent chain transitively through the given `RefMap`,
+    /// tracking visited ids to break cycles from stale/duplicate parent data.
     fn has_ancestor(&self, ancestor_ref_id: &str, ref_map: &RefMap) -> bool {
+        let mut visited: HashSet<&str> = HashSet::new();
         let mut current = self.parent.as_deref();
         while let Some(parent_id) = current {
             if parent_id == ancestor_ref_id {
                 return true;
+            }
+            if !visited.insert(parent_id) {
+                break;
             }
             current = ref_map.map.get(parent_id).and_then(|p| p.parent.as_deref());
         }
@@ -83,6 +97,10 @@ pub struct RefMap {
     /// its identity key, so same-selector dedup still holds.
     key_to_ref: HashMap<String, String>,
     next_ref: usize,
+    /// Snapshot generation counter. Incremented by `begin_snapshot()` at the
+    /// start of each `page_map` walk so `descendant_refs` can ignore entries
+    /// left over from earlier snapshots on the same URL.
+    current_generation: u64,
 }
 
 impl RefMap {
@@ -93,7 +111,16 @@ impl RefMap {
             map: HashMap::new(),
             key_to_ref: HashMap::new(),
             next_ref: 1,
+            current_generation: 0,
         }
+    }
+
+    /// Begin a new snapshot generation. Call this when `page_map` starts a new
+    /// ARIA walk so refs assigned/rebound during the walk are tagged with the
+    /// new generation, letting `descendant_refs` ignore stale entries left
+    /// over from a prior walk on the same URL.
+    pub fn begin_snapshot(&mut self) {
+        self.current_generation += 1;
     }
 
     /// Assign a ref by identity key (stable across snapshots on the same URL).
@@ -118,8 +145,14 @@ impl RefMap {
         resolution: Resolution,
         parent_ref_id: Option<&str>,
     ) -> String {
-        if let Some(existing) = self.key_to_ref.get(stable_key) {
-            return existing.clone();
+        if let Some(existing) = self.key_to_ref.get(stable_key).cloned() {
+            // Re-walking an unchanged node never mints a new ref, but it does
+            // touch the entry in the current snapshot generation so
+            // `descendant_refs` doesn't treat it as stale.
+            if let Some(entry) = self.map.get_mut(&existing) {
+                entry.generation = self.current_generation;
+            }
+            return existing;
         }
         let ref_id = format!("e{}", self.next_ref);
         self.next_ref += 1;
@@ -142,6 +175,8 @@ impl RefMap {
                 selector,
                 fallback_selector,
                 parent: parent_ref_id.map(str::to_string),
+                generation: self.current_generation,
+                truncated: false,
             },
         );
         self.key_to_ref
@@ -157,6 +192,12 @@ impl RefMap {
     /// verbatim, so re-minting by identity would collapse duplicate-named
     /// siblings onto one id and desync the model's ref from the DOM. The mint
     /// counter is advanced past `ref_id` so later minted ids cannot collide.
+    ///
+    /// If an entry already exists for `ref_id` and has a parent set, that
+    /// parent is preserved rather than overwritten with `parent_ref_id`. This
+    /// keeps a scoped `page_map` re-walk (which has no ancestors above the
+    /// scope root) from detaching an already-mapped subtree from its real
+    /// ancestors and breaking container auto-descend.
     pub fn bind_existing(
         &mut self,
         stable_key: &str,
@@ -166,6 +207,11 @@ impl RefMap {
         _frame_id: Option<&str>,
         parent_ref_id: Option<&str>,
     ) -> String {
+        let parent = match self.map.get(ref_id) {
+            Some(existing) if existing.parent.is_some() => existing.parent.clone(),
+            _ => parent_ref_id.map(str::to_string),
+        };
+
         self.map.insert(
             ref_id.to_string(),
             RefEntry {
@@ -176,7 +222,9 @@ impl RefMap {
                 resolution: Resolution::Attr(ref_id.to_string()),
                 selector: String::new(),
                 fallback_selector: None,
-                parent: parent_ref_id.map(str::to_string),
+                parent,
+                generation: self.current_generation,
+                truncated: false,
             },
         );
         self.key_to_ref
@@ -256,12 +304,19 @@ impl RefMap {
 
     /// Return all descendant `ref_id`s (direct children + grandchildren, etc.)
     /// of the given ref. Walk the parent chain transitively.
+    ///
+    /// Only entries from the current snapshot generation are returned: on a
+    /// same-URL DOM update, `RefMap` keeps entries from prior `page_map`
+    /// walks, and a container's old child may have been removed or replaced.
+    /// Filtering by generation keeps auto-descend from picking a stale ref.
     #[must_use]
     pub fn descendant_refs(&self, ancestor_ref_id: &str) -> Vec<String> {
         self.map
             .iter()
             .filter_map(|(ref_id, entry)| {
-                if entry.has_ancestor(ancestor_ref_id, self) {
+                if entry.generation == self.current_generation
+                    && entry.has_ancestor(ancestor_ref_id, self)
+                {
                     Some(ref_id.clone())
                 } else {
                     None
@@ -279,6 +334,17 @@ impl RefMap {
         self.map.clear();
         self.key_to_ref.clear();
         self.next_ref = 1;
+        self.current_generation = 0;
+    }
+
+    /// Mark a ref's container as having omitted children during the ARIA
+    /// walk (depth/child-count limits truncated the subtree). Truncated
+    /// containers are skipped by auto-descend since the retained actionable
+    /// child may not be the container's only actionable descendant.
+    pub fn set_truncated(&mut self, ref_id: &str, truncated: bool) {
+        if let Some(entry) = self.map.get_mut(ref_id) {
+            entry.truncated = truncated;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #79: When clicking a container ref (`@eN`) pointing to a generic/navigation/etc. wrapper element, the tool now auto-descends into descendants to find actionable children instead of throwing an error.

## Behavior changes

- **Single actionable child** → auto-descends to that child and clicks it (saves a `page_map` round-trip)
- **Multiple actionable children** → returns a helpful error listing the clickable child refs (e.g. "Container @e5 has 2 clickable children (@e7, @e9). Target one of them directly.")
- **Zero actionable children** → returns the original container error

## Implementation

- Added `parent` field to `RefEntry` with parent-child tracking during ARIA tree reconciliation
- Added `descendant_refs()` and `has_ancestor()` helper methods on `RefMap`
- New `validate_or_auto_descend()` function replaces `validate_actionable_ref()`
- Three new unit tests covering single-child auto-descend, multi-child hints, and the existing container error fallback

## Test plan

- [x] `cargo test -p browser` — 171 passed
- [x] `cargo test -p agent` — all ref_resolve tests (19), reconcile tests (8) pass
- [x] `cargo build --release` — clean
- [x] E2E: navigate diverse pages (react.dev, example.com, Wikipedia)
- [x] E2E: autonomous agent `run_goal` completes successfully

Closes #79