### PR TITLE
feat: add text_pattern support to wait tool

### DIFF
--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -126,16 +126,17 @@ fn navigation_tools() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: "wait",
-            description: "Wait for a DOM element to reach a specified state (visible, hidden, attached, detached) or pause for a fixed duration. Use after actions that trigger asynchronous page changes such as form submissions, AJAX requests, or animations. Returns post-action page_state showing the resulting URL, title, and structural diff once the condition is met or the timeout expires, unless `silent: true` is set for a time-only wait, in which case only the completion signal is returned.",
+            description: "Wait for a DOM element to reach a specified state (visible, hidden, attached, detached), wait for text content to match a pattern, or pause for a fixed duration. Use after actions that trigger asynchronous page changes such as form submissions, AJAX requests, or animations. Returns post-action page_state showing the resulting URL, title, and structural diff once the condition is met or the timeout expires, unless `silent: true` is set for a time-only wait, in which case only the completion signal is returned.",
             input_schema: json!({
                 "type": "object",
                 "properties": {
                     "selector": { "type": "string", "description": "CSS selector of the element to wait for (e.g. \".results-loaded\", \"#spinner\"). Mutually exclusive with 'seconds' — provide one or the other." },
                     "seconds": { "type": "number", "description": "Fixed number of seconds to wait (max 300). Use when no specific element signals completion. Mutually exclusive with 'selector'." },
+                    "text_pattern": { "type": "string", "description": "Substring to match in the element's text content. Polls every 250ms until found or timeout expires. Use with `selector` to target a specific element, or alone to scan the full page body text. Mutually exclusive with `state` — use one or the other." },
                     "state": {
                         "type": "string",
                         "enum": ["visible", "hidden", "attached", "detached"],
-                        "description": "Target state to wait for. 'attached' (default) = element exists in DOM; 'visible' = element is rendered and not hidden; 'hidden' = element is no longer visible; 'detached' = element removed from DOM. Use 'hidden' to wait for loading spinners to disappear."
+                        "description": "Target state to wait for. Requires `selector`. Mutually exclusive with `text_pattern` — use `state` for DOM state changes, `text_pattern` for text content matching."
                     },
                     "silent": {
                         "type": "boolean",
@@ -144,7 +145,7 @@ fn navigation_tools() -> Vec<ToolSpec> {
                 },
                 "additionalProperties": false
             }),
-            instructions: Some("Use after actions that trigger page changes (form submits, AJAX requests). Pass `selector` to wait for an element, or `seconds` for a fixed delay. Use `state: \"visible\"` to wait until the element is actually visible (not just in the DOM). Use `state: \"hidden\"` to wait for an element to disappear (e.g. a loading spinner). Set `silent: true` for simple timed pauses to suppress the page_state and save context tokens. Has no effect when a `selector` is provided."),
+            instructions: Some("Use after actions that trigger page changes (form submits, AJAX requests). Pass `selector` to wait for an element, or `seconds` for a fixed delay. Use `state: \"visible\"` to wait until the element is actually visible (not just in the DOM). Use `text_pattern` with or without `selector` to poll until specific text appears on the page (e.g., wait for a status badge to change from \"running\" to \"completed\"). Set `silent: true` for simple timed pauses to suppress the page_state and save context tokens. Has no effect when a `selector` is provided."),
         },
     ]
 }

--- a/crates/agent/src/tools/wait.rs
+++ b/crates/agent/src/tools/wait.rs
@@ -18,6 +18,7 @@ pub struct WaitInput {
     pub timeout_ms: u64,
     pub state: Option<String>,
     pub silent: bool,
+    pub text_pattern: Option<String>,
 }
 
 pub fn parse_input(input: &Value) -> Result<WaitInput, CrawlError> {
@@ -48,6 +49,17 @@ pub fn parse_input(input: &Value) -> Result<WaitInput, CrawlError> {
         ));
     }
 
+    let text_pattern = input
+        .get("text_pattern")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    if text_pattern.is_some() && state.is_some() {
+        return Err(CrawlError::new(
+            "wait text_pattern and state are mutually exclusive",
+        ));
+    }
+
     if selector.is_none() && timeout_ms == 0 {
         return Err(CrawlError::new(
             "wait requires either a selector or a positive timeout",
@@ -64,6 +76,7 @@ pub fn parse_input(input: &Value) -> Result<WaitInput, CrawlError> {
         timeout_ms,
         state,
         silent,
+        text_pattern,
     })
 }
 
@@ -108,7 +121,33 @@ pub async fn execute(
 ) -> Result<ToolEffect, ToolExecutionError> {
     let parsed = parse_input(input)?;
 
-    if let Some(ref selector) = parsed.selector {
+    if let Some(ref text_pattern) = parsed.text_pattern {
+        let found = browser
+            .acquire_bridge()
+            .await
+            .map_err(|e| ToolExecutionError::new(e.to_string()))?
+            .wait_for_text(parsed.selector.as_deref(), text_pattern, parsed.timeout_ms)
+            .await
+            .map_err(|e| ToolExecutionError::new(e.to_string()))?;
+
+        let page_state = super::feedback::post_action_page_state(
+            browser,
+            crawl_state,
+            InteractionKind::Passive,
+            None,
+            false,
+        )
+        .await?;
+
+        Ok(ToolEffect::reply_json(&json!({
+            "success": true,
+            "found": found,
+            "text_pattern": text_pattern,
+            "selector": parsed.selector,
+            "timeout_ms": parsed.timeout_ms,
+            "page_state": page_state
+        })))
+    } else if let Some(ref selector) = parsed.selector {
         let found = browser
             .acquire_bridge()
             .await
@@ -256,6 +295,38 @@ mod tests {
         let input = json!({"seconds": 1, "silent": false});
         let parsed = parse_input(&input).unwrap();
         assert!(!parsed.silent);
+    }
+
+    #[test]
+    fn parses_text_pattern_with_selector() {
+        let input =
+            json!({"selector": "#status", "text_pattern": "completed", "timeout_ms": 10000});
+        let parsed = parse_input(&input).unwrap();
+        assert_eq!(parsed.text_pattern.as_deref(), Some("completed"));
+        assert_eq!(parsed.selector.as_deref(), Some("#status"));
+        assert_eq!(parsed.timeout_ms, 10000);
+    }
+
+    #[test]
+    fn parses_text_pattern_without_selector() {
+        let input = json!({"text_pattern": "success", "seconds": 5});
+        let parsed = parse_input(&input).unwrap();
+        assert_eq!(parsed.text_pattern.as_deref(), Some("success"));
+        assert!(parsed.selector.is_none());
+    }
+
+    #[test]
+    fn rejects_text_pattern_with_state() {
+        let input = json!({"selector": "#btn", "text_pattern": "done", "state": "visible"});
+        let err = parse_input(&input).unwrap_err();
+        assert!(err.to_string().contains("mutually exclusive"));
+    }
+
+    #[test]
+    fn text_pattern_none_when_omitted() {
+        let input = json!({"selector": "#btn"});
+        let parsed = parse_input(&input).unwrap();
+        assert!(parsed.text_pattern.is_none());
     }
 
     fn effect_json(effect: ToolEffect) -> Value {

--- a/crates/browser/src/browser_backend.rs
+++ b/crates/browser/src/browser_backend.rs
@@ -208,4 +208,33 @@ pub trait BrowserBackend: Debug {
             "clear_intercept_rules not implemented for this backend".into(),
         ))
     }
+
+    async fn wait_for_text(
+        &mut self,
+        selector: Option<&str>,
+        text_pattern: &str,
+        timeout_ms: u64,
+    ) -> Result<bool, BridgeError> {
+        let start = std::time::Instant::now();
+        let poll_interval = std::time::Duration::from_millis(250);
+        loop {
+            let script = if let Some(sel) = selector {
+                format!(
+                    "document.querySelector('{}')?.textContent?.trim() || ''",
+                    sel.replace('\'', "\\'")
+                )
+            } else {
+                "document.body?.textContent?.trim() || ''".to_string()
+            };
+            let result = self.evaluate(&script).await?;
+            let text = result.get("value").and_then(|v| v.as_str()).unwrap_or("");
+            if text.contains(text_pattern) {
+                return Ok(true);
+            }
+            if start.elapsed() >= std::time::Duration::from_millis(timeout_ms) {
+                return Ok(false);
+            }
+            tokio::time::sleep(poll_interval).await;
+        }
+    }
 }

--- a/crates/browser/src/browser_backend.rs
+++ b/crates/browser/src/browser_backend.rs
@@ -221,7 +221,7 @@ pub trait BrowserBackend: Debug {
             let script = if let Some(sel) = selector {
                 format!(
                     "document.querySelector('{}')?.textContent?.trim() || ''",
-                    sel.replace('\'', "\\'")
+                    sel.replace('\\', "\\\\").replace('\'', "\\'")
                 )
             } else {
                 "document.body?.textContent?.trim() || ''".to_string()

--- a/crates/browser/src/playwright/backend_impl.rs
+++ b/crates/browser/src/playwright/backend_impl.rs
@@ -125,6 +125,15 @@ impl BrowserBackend for PlaywrightBridge {
         PlaywrightBridge::wait_for_selector(self, selector, timeout_ms, state).await
     }
 
+    async fn wait_for_text(
+        &mut self,
+        selector: Option<&str>,
+        text_pattern: &str,
+        timeout_ms: u64,
+    ) -> Result<bool, BridgeError> {
+        PlaywrightBridge::wait_for_text(self, selector, text_pattern, timeout_ms).await
+    }
+
     async fn select_option(&mut self, selector: &str, value: &str) -> Result<(), BridgeError> {
         PlaywrightBridge::select_option(self, selector, value).await
     }

--- a/crates/browser/src/playwright/bridge.rs
+++ b/crates/browser/src/playwright/bridge.rs
@@ -352,6 +352,27 @@ impl PlaywrightBridge {
             .unwrap_or(false))
     }
 
+    pub async fn wait_for_text(
+        &mut self,
+        selector: Option<&str>,
+        text_pattern: &str,
+        timeout_ms: u64,
+    ) -> Result<bool, BridgeError> {
+        let mut cmd = serde_json::json!({
+            "action": "wait_for_text",
+            "text_pattern": text_pattern,
+            "timeout_ms": timeout_ms,
+        });
+        if let Some(sel) = selector {
+            cmd["selector"] = serde_json::Value::String(sel.to_string());
+        }
+        let result = self.send_raw_command(&cmd).await?;
+        Ok(result
+            .get("found")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false))
+    }
+
     pub async fn select_option(&mut self, selector: &str, value: &str) -> Result<(), BridgeError> {
         let cmd = serde_json::json!({
             "action": "select_option",

--- a/crates/browser/src/playwright/bridge.rs
+++ b/crates/browser/src/playwright/bridge.rs
@@ -260,9 +260,18 @@ impl PlaywrightBridge {
         &mut self,
         command: &serde_json::Value,
     ) -> Result<serde_json::Value, BridgeError> {
+        self.send_raw_command_with_timeout(command, DEFAULT_COMMAND_TIMEOUT)
+            .await
+    }
+
+    pub async fn send_raw_command_with_timeout(
+        &mut self,
+        command: &serde_json::Value,
+        command_timeout: Duration,
+    ) -> Result<serde_json::Value, BridgeError> {
         let payload = serde_json::to_string(command)?;
         let line = self
-            .write_command_and_read_line(&payload, DEFAULT_COMMAND_TIMEOUT)
+            .write_command_and_read_line(&payload, command_timeout)
             .await?;
         let response: GenericBridgeResponseMessage = serde_json::from_str(&line)?;
         if response.event != "bridge_response" {
@@ -345,7 +354,12 @@ impl PlaywrightBridge {
         if let Some(s) = state {
             cmd["state"] = serde_json::Value::String(s.to_string());
         }
-        let result = self.send_raw_command(&cmd).await?;
+        let result = self
+            .send_raw_command_with_timeout(
+                &cmd,
+                Duration::from_millis(timeout_ms) + Duration::from_secs(5),
+            )
+            .await?;
         Ok(result
             .get("found")
             .and_then(serde_json::Value::as_bool)
@@ -366,7 +380,12 @@ impl PlaywrightBridge {
         if let Some(sel) = selector {
             cmd["selector"] = serde_json::Value::String(sel.to_string());
         }
-        let result = self.send_raw_command(&cmd).await?;
+        let result = self
+            .send_raw_command_with_timeout(
+                &cmd,
+                Duration::from_millis(timeout_ms) + Duration::from_secs(5),
+            )
+            .await?;
         Ok(result
             .get("found")
             .and_then(serde_json::Value::as_bool)

--- a/crates/browser/src/playwright/bridge_script.rs
+++ b/crates/browser/src/playwright/bridge_script.rs
@@ -1165,6 +1165,44 @@ const PLAYWRIGHT_BRIDGE_NODE_SCRIPT_SUFFIX: &str = r#"
       continue;
     }
 
+    if (command.action === 'wait_for_text') {
+      try {
+        const timeout = command.timeout_ms || 5000;
+        const pattern = command.text_pattern;
+        const selector = command.selector;
+        const start = Date.now();
+        let found = false;
+        while (Date.now() - start < timeout) {
+          let text;
+          if (selector) {
+            try {
+              text = await page.evaluate((sel) => {
+                const el = document.querySelector(sel);
+                return el ? (el.textContent || '').trim() : '';
+              }, selector);
+            } catch (e) {
+              text = '';
+            }
+          } else {
+            try {
+              text = await page.evaluate(() => (document.body?.textContent || '').trim());
+            } catch (e) {
+              text = '';
+            }
+          }
+          if (text && text.includes(pattern)) {
+            found = true;
+            break;
+          }
+          await new Promise(r => setTimeout(r, 250));
+        }
+        process.stdout.write(JSON.stringify({ event: 'bridge_response', ok: true, result: { found } }) + '\n');
+      } catch (error) {
+        process.stdout.write(JSON.stringify({ event: 'bridge_response', ok: false, error: { kind: 'wait_for_text_failed', message: String(error) } }) + '\n');
+      }
+      continue;
+    }
+
     if (command.action === 'select_option') {
       try {
         await page.selectOption(command.selector, command.value);

--- a/crates/browser/src/playwright/bridge_script.rs
+++ b/crates/browser/src/playwright/bridge_script.rs
@@ -1185,7 +1185,31 @@ const PLAYWRIGHT_BRIDGE_NODE_SCRIPT_SUFFIX: &str = r#"
             }
           } else {
             try {
-              text = await page.evaluate(() => (document.body?.textContent || '').trim());
+              text = await page.evaluate(() => {
+                if (!document.body) return '';
+                const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
+                  acceptNode: function(node) {
+                    const el = node.parentElement;
+                    if (!el) return NodeFilter.FILTER_REJECT;
+                    const tag = el.tagName;
+                    if (tag === 'SCRIPT' || tag === 'STYLE' || tag === 'TEMPLATE' || tag === 'NOSCRIPT') return NodeFilter.FILTER_REJECT;
+                    const style = window.getComputedStyle(el);
+                    if (style.display === 'none' || style.visibility === 'hidden') return NodeFilter.FILTER_REJECT;
+                    let parent = el.parentElement;
+                    while (parent && parent !== document.body) {
+                      const ps = window.getComputedStyle(parent);
+                      if (ps.display === 'none' || ps.visibility === 'hidden') return NodeFilter.FILTER_REJECT;
+                      parent = parent.parentElement;
+                    }
+                    return NodeFilter.FILTER_ACCEPT;
+                  }
+                });
+                let result = '';
+                while (walker.nextNode()) {
+                  result += walker.currentNode.textContent;
+                }
+                return result.trim();
+              });
             } catch (e) {
               text = '';
             }

--- a/crates/browser/src/playwright/bridge_script.rs
+++ b/crates/browser/src/playwright/bridge_script.rs
@@ -1177,8 +1177,8 @@ const PLAYWRIGHT_BRIDGE_NODE_SCRIPT_SUFFIX: &str = r#"
           if (selector) {
             try {
               text = await page.evaluate((sel) => {
-                const el = document.querySelector(sel);
-                return el ? (el.textContent || '').trim() : '';
+                const els = document.querySelectorAll(sel);
+                return Array.from(els).map((el) => (el.textContent || '').trim()).join(' ');
               }, selector);
             } catch (e) {
               text = '';


### PR DESCRIPTION
## Summary

Adds `text_pattern` parameter to the `wait` tool, enabling the agent to poll an element's text content until a substring match is found. This addresses the common use case of waiting for status badges to change (e.g. from "running" to "completed") without requiring a manual polling loop of `wait(seconds=N)` + `execute_js(...)` pairs.

## Changes

- **`crates/agent/src/tools/wait.rs`**: New `text_pattern` field in `WaitInput`, validation (mutually exclusive with `state`), execution via `wait_for_text()` bridge method, and 4 new parse-level tests
- **`crates/browser/src/browser_backend.rs`**: New `wait_for_text()` trait method with default polling implementation using `evaluate()` in a loop
- **`crates/browser/src/playwright/bridge.rs`**: Sends `wait_for_text` action to Node.js bridge script
- **`crates/browser/src/playwright/backend_impl.rs`**: Delegates to `PlaywrightBridge::wait_for_text`
- **`crates/browser/src/playwright/bridge_script.rs`**: JavaScript handler that polls `page.evaluate()` every 250ms until substring match or timeout
- **`crates/agent/src/lib.rs`**: Updated tool spec with `text_pattern` parameter and revised descriptions

## API

```json
wait({ "text_pattern": "completed", "selector": "#status", "timeout_ms": 10000 })
wait({ "text_pattern": "success", "seconds": 5 })  // scans full page body text
```

Returns `found: true/false` with the matched text pattern.

## Test Plan

- [x] Unit tests: 4 new parse tests + all 19 existing wait tests pass
- [x] Clippy + fmt: clean on browser and agent crates
- [x] `cargo build --release`: passes
- [x] E2E: `wait({ text_pattern: "Example" })` on example.com returns `found: true`
- [x] Standard E2E regression (navigate, page_map, click, observation tools): all pass

Closes #83
