### PR TITLE
fix: add optional selector parameter to scroll tool for modal/overlay scrolling

### DIFF
--- a/crates/agent/src/implementation/mod.rs
+++ b/crates/agent/src/implementation/mod.rs
@@ -1257,7 +1257,12 @@ mod tests {
             Ok(())
         }
 
-        async fn scroll(&mut self, _direction: &str, _pixels: i64) -> Result<(), BridgeError> {
+        async fn scroll(
+            &mut self,
+            _direction: &str,
+            _pixels: i64,
+            _selector: Option<&str>,
+        ) -> Result<(), BridgeError> {
             Err(BridgeError::Protocol("unused".into()))
         }
 

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -106,7 +106,8 @@ fn navigation_tools() -> Vec<ToolSpec> {
                 "type": "object",
                 "properties": {
                     "direction": { "type": "string", "enum": ["up", "down"], "description": "Scroll direction. 'down' reveals content below the viewport; 'up' scrolls back toward the top." },
-                    "pixels": { "type": "integer", "description": "Number of pixels to scroll (default: 500). Use 300–800 for a normal page scroll; larger values for quickly reaching page bottom." }
+                    "pixels": { "type": "integer", "description": "Number of pixels to scroll (default: 500). Use 300–800 for a normal page scroll; larger values for quickly reaching page bottom." },
+                    "selector": { "type": "string", "description": "Optional CSS selector to scroll a specific element (e.g. a modal or sidebar) instead of the page viewport. Use when a modal, overlay, or internal scroll container is open and the page viewport is locked behind it." }
                 },
                 "additionalProperties": false
             }),

--- a/crates/agent/src/script_executor/tests.rs
+++ b/crates/agent/src/script_executor/tests.rs
@@ -109,7 +109,12 @@ impl BrowserBackend for MockBridge {
         Ok(())
     }
 
-    async fn scroll(&mut self, direction: &str, pixels: i64) -> Result<(), BridgeError> {
+    async fn scroll(
+        &mut self,
+        direction: &str,
+        pixels: i64,
+        _selector: Option<&str>,
+    ) -> Result<(), BridgeError> {
         self.log("scroll", json!({"direction": direction, "pixels": pixels}));
         Ok(())
     }

--- a/crates/agent/src/tools/execute_js.rs
+++ b/crates/agent/src/tools/execute_js.rs
@@ -272,7 +272,12 @@ mod tests {
             async fn close_page(&mut self, _page_index: usize) -> Result<(), BridgeError> {
                 Ok(())
             }
-            async fn scroll(&mut self, _direction: &str, _pixels: i64) -> Result<(), BridgeError> {
+            async fn scroll(
+                &mut self,
+                _direction: &str,
+                _pixels: i64,
+                _selector: Option<&str>,
+            ) -> Result<(), BridgeError> {
                 Ok(())
             }
             async fn page_map(

--- a/crates/agent/src/tools/feedback.rs
+++ b/crates/agent/src/tools/feedback.rs
@@ -671,7 +671,12 @@ mod tests {
             Ok(())
         }
 
-        async fn scroll(&mut self, _direction: &str, _pixels: i64) -> Result<(), BridgeError> {
+        async fn scroll(
+            &mut self,
+            _direction: &str,
+            _pixels: i64,
+            _selector: Option<&str>,
+        ) -> Result<(), BridgeError> {
             Ok(())
         }
 

--- a/crates/agent/src/tools/fill_form.rs
+++ b/crates/agent/src/tools/fill_form.rs
@@ -513,7 +513,7 @@ mod tests {
         async fn close_page(&mut self, _: usize) -> Result<(), BridgeError> {
             Ok(())
         }
-        async fn scroll(&mut self, _: &str, _: i64) -> Result<(), BridgeError> {
+        async fn scroll(&mut self, _: &str, _: i64, _: Option<&str>) -> Result<(), BridgeError> {
             Ok(())
         }
         async fn page_map(

--- a/crates/agent/src/tools/page_logs.rs
+++ b/crates/agent/src/tools/page_logs.rs
@@ -538,7 +538,7 @@ mod tests {
         async fn close_page(&mut self, _: usize) -> Result<(), BridgeError> {
             Ok(())
         }
-        async fn scroll(&mut self, _: &str, _: i64) -> Result<(), BridgeError> {
+        async fn scroll(&mut self, _: &str, _: i64, _: Option<&str>) -> Result<(), BridgeError> {
             Ok(())
         }
         async fn page_map(

--- a/crates/agent/src/tools/screenshot.rs
+++ b/crates/agent/src/tools/screenshot.rs
@@ -275,7 +275,7 @@ mod tests {
         async fn close_page(&mut self, _: usize) -> Result<(), BridgeError> {
             Ok(())
         }
-        async fn scroll(&mut self, _: &str, _: i64) -> Result<(), BridgeError> {
+        async fn scroll(&mut self, _: &str, _: i64, _: Option<&str>) -> Result<(), BridgeError> {
             Ok(())
         }
         async fn page_map(

--- a/crates/agent/src/tools/scroll.rs
+++ b/crates/agent/src/tools/scroll.rs
@@ -6,7 +6,7 @@ use crate::{CrawlError, ToolEffect, ToolExecutionError};
 
 use super::feedback::InteractionKind;
 
-pub fn parse_input(input: &Value) -> Result<(String, i64), CrawlError> {
+pub fn parse_input(input: &Value) -> Result<(String, i64, Option<String>), CrawlError> {
     let direction = input
         .get("direction")
         .and_then(|v| v.as_str())
@@ -25,7 +25,12 @@ pub fn parse_input(input: &Value) -> Result<(String, i64), CrawlError> {
         .and_then(serde_json::Value::as_i64)
         .unwrap_or(500);
 
-    Ok((direction, pixels))
+    let selector = input
+        .get("selector")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+
+    Ok((direction, pixels, selector))
 }
 
 pub async fn execute(
@@ -33,13 +38,13 @@ pub async fn execute(
     browser: &mut BrowserContext,
     crawl_state: &mut CrawlState,
 ) -> Result<ToolEffect, ToolExecutionError> {
-    let (direction, pixels) = parse_input(input)?;
+    let (direction, pixels, selector) = parse_input(input)?;
 
     browser
         .acquire_bridge()
         .await
         .map_err(|e| ToolExecutionError::new(e.to_string()))?
-        .scroll(&direction, pixels)
+        .scroll(&direction, pixels, selector.as_deref())
         .await
         .map_err(|e| ToolExecutionError::new(e.to_string()))?;
 
@@ -70,15 +75,16 @@ mod tests {
     #[test]
     fn parses_direction_and_pixels() {
         let input = json!({"direction": "down", "pixels": 300});
-        let (dir, px) = parse_input(&input).unwrap();
+        let (dir, px, selector) = parse_input(&input).unwrap();
         assert_eq!(dir, "down");
         assert_eq!(px, 300);
+        assert_eq!(selector, None);
     }
 
     #[test]
     fn accepts_legacy_amount_key() {
         let input = json!({"direction": "down", "amount": 200});
-        let (dir, px) = parse_input(&input).unwrap();
+        let (dir, px, _selector) = parse_input(&input).unwrap();
         assert_eq!(dir, "down");
         assert_eq!(px, 200);
     }
@@ -86,15 +92,16 @@ mod tests {
     #[test]
     fn defaults_to_down_500() {
         let input = json!({});
-        let (dir, px) = parse_input(&input).unwrap();
+        let (dir, px, selector) = parse_input(&input).unwrap();
         assert_eq!(dir, "down");
         assert_eq!(px, 500);
+        assert_eq!(selector, None);
     }
 
     #[test]
     fn accepts_pixels_key() {
         let input = json!({"direction": "up", "pixels": 200});
-        let (dir, px) = parse_input(&input).unwrap();
+        let (dir, px, _selector) = parse_input(&input).unwrap();
         assert_eq!(dir, "up");
         assert_eq!(px, 200);
     }
@@ -103,6 +110,22 @@ mod tests {
     fn rejects_invalid_direction() {
         let input = json!({"direction": "left"});
         assert!(parse_input(&input).is_err());
+    }
+
+    #[test]
+    fn parses_optional_selector() {
+        let input = json!({"direction": "down", "pixels": 300, "selector": "#modal-body"});
+        let (dir, px, selector) = parse_input(&input).unwrap();
+        assert_eq!(dir, "down");
+        assert_eq!(px, 300);
+        assert_eq!(selector.as_deref(), Some("#modal-body"));
+    }
+
+    #[test]
+    fn selector_defaults_to_none_when_absent() {
+        let input = json!({"direction": "down"});
+        let (_dir, _px, selector) = parse_input(&input).unwrap();
+        assert_eq!(selector, None);
     }
 
     #[test]

--- a/crates/agent/src/tools/scroll.rs
+++ b/crates/agent/src/tools/scroll.rs
@@ -40,11 +40,17 @@ pub async fn execute(
 ) -> Result<ToolEffect, ToolExecutionError> {
     let (direction, pixels, selector) = parse_input(input)?;
 
+    let resolved_selector: Option<String> = selector
+        .as_deref()
+        .map(|sel| super::ref_resolve::resolve_selector(sel, browser.ref_map()))
+        .transpose()
+        .map_err(ToolExecutionError::new)?;
+
     browser
         .acquire_bridge()
         .await
         .map_err(|e| ToolExecutionError::new(e.to_string()))?
-        .scroll(&direction, pixels, selector.as_deref())
+        .scroll(&direction, pixels, resolved_selector.as_deref())
         .await
         .map_err(|e| ToolExecutionError::new(e.to_string()))?;
 

--- a/crates/agent/src/tools/select_option.rs
+++ b/crates/agent/src/tools/select_option.rs
@@ -1060,7 +1060,12 @@ mod tests {
             Ok(())
         }
 
-        async fn scroll(&mut self, _direction: &str, _pixels: i64) -> Result<(), BridgeError> {
+        async fn scroll(
+            &mut self,
+            _direction: &str,
+            _pixels: i64,
+            _selector: Option<&str>,
+        ) -> Result<(), BridgeError> {
             Ok(())
         }
 

--- a/crates/agent/src/tools/test_support.rs
+++ b/crates/agent/src/tools/test_support.rs
@@ -42,7 +42,7 @@ impl BrowserBackend for ObservationMockBackend {
     async fn close_page(&mut self, _: usize) -> Result<(), BridgeError> {
         Ok(())
     }
-    async fn scroll(&mut self, _: &str, _: i64) -> Result<(), BridgeError> {
+    async fn scroll(&mut self, _: &str, _: i64, _: Option<&str>) -> Result<(), BridgeError> {
         Ok(())
     }
     async fn page_map(

--- a/crates/agent/tests/integration_test.rs
+++ b/crates/agent/tests/integration_test.rs
@@ -380,7 +380,12 @@ mod set_device_integration {
         async fn close_page(&mut self, _page_index: usize) -> Result<(), BridgeError> {
             unreachable!()
         }
-        async fn scroll(&mut self, _direction: &str, _pixels: i64) -> Result<(), BridgeError> {
+        async fn scroll(
+            &mut self,
+            _direction: &str,
+            _pixels: i64,
+            _selector: Option<&str>,
+        ) -> Result<(), BridgeError> {
             unreachable!()
         }
         async fn page_map(
@@ -499,7 +504,12 @@ mod set_device_integration {
         async fn close_page(&mut self, _page_index: usize) -> Result<(), BridgeError> {
             unreachable!()
         }
-        async fn scroll(&mut self, _direction: &str, _pixels: i64) -> Result<(), BridgeError> {
+        async fn scroll(
+            &mut self,
+            _direction: &str,
+            _pixels: i64,
+            _selector: Option<&str>,
+        ) -> Result<(), BridgeError> {
             unreachable!()
         }
         async fn page_map(

--- a/crates/browser/src/browser_backend.rs
+++ b/crates/browser/src/browser_backend.rs
@@ -81,7 +81,12 @@ pub trait BrowserBackend: Debug {
     async fn navigate(&mut self, url: &str) -> Result<PageInfo, BridgeError>;
     async fn new_page(&mut self, url: Option<&str>) -> Result<usize, BridgeError>;
     async fn close_page(&mut self, page_index: usize) -> Result<(), BridgeError>;
-    async fn scroll(&mut self, direction: &str, pixels: i64) -> Result<(), BridgeError>;
+    async fn scroll(
+        &mut self,
+        direction: &str,
+        pixels: i64,
+        selector: Option<&str>,
+    ) -> Result<(), BridgeError>;
     /// `depth` is the requested ARIA walk depth (schema: default 5, max 10);
     /// `None` lets the in-page walk apply its own default.
     async fn page_map(

--- a/crates/browser/src/extension.rs
+++ b/crates/browser/src/extension.rs
@@ -228,7 +228,7 @@ impl BrowserBackend for ExtensionBridge {
             let selector_json = serde_json::to_string(selector)
                 .map_err(|e| BridgeError::Protocol(format!("failed to encode selector: {e}")))?;
             let script = format!(
-                "(() => {{ const el = document.querySelector({selector_json}); if (el) {{ el.scrollBy(0, {delta}); }} }})()"
+                "(() => {{ const el = document.querySelector({selector_json}); if (!el) throw new Error('scroll selector not found: ' + {selector_json}); el.scrollBy(0, {delta}); }})()"
             );
             let response = self
                 .send_command("execute_js", json!({ "script": script }))

--- a/crates/browser/src/extension.rs
+++ b/crates/browser/src/extension.rs
@@ -217,7 +217,25 @@ impl BrowserBackend for ExtensionBridge {
             .await
     }
 
-    async fn scroll(&mut self, direction: &str, pixels: i64) -> Result<(), BridgeError> {
+    async fn scroll(
+        &mut self,
+        direction: &str,
+        pixels: i64,
+        selector: Option<&str>,
+    ) -> Result<(), BridgeError> {
+        if let Some(selector) = selector {
+            let delta = if direction == "up" { -pixels } else { pixels };
+            let selector_json = serde_json::to_string(selector)
+                .map_err(|e| BridgeError::Protocol(format!("failed to encode selector: {e}")))?;
+            let script = format!(
+                "(() => {{ const el = document.querySelector({selector_json}); if (el) {{ el.scrollBy(0, {delta}); }} }})()"
+            );
+            let response = self
+                .send_command("execute_js", json!({ "script": script }))
+                .await?;
+            Self::require_result(response, "execute_js")?;
+            return Ok(());
+        }
         self.expect_unit(
             "scroll",
             json!({

--- a/crates/browser/src/playwright/backend_impl.rs
+++ b/crates/browser/src/playwright/backend_impl.rs
@@ -86,8 +86,13 @@ impl BrowserBackend for PlaywrightBridge {
         PlaywrightBridge::close_page(self, page_index).await
     }
 
-    async fn scroll(&mut self, direction: &str, pixels: i64) -> Result<(), BridgeError> {
-        PlaywrightBridge::scroll(self, direction, pixels).await
+    async fn scroll(
+        &mut self,
+        direction: &str,
+        pixels: i64,
+        selector: Option<&str>,
+    ) -> Result<(), BridgeError> {
+        PlaywrightBridge::scroll(self, direction, pixels, selector).await
     }
 
     async fn page_map(

--- a/crates/browser/src/playwright/bridge.rs
+++ b/crates/browser/src/playwright/bridge.rs
@@ -283,12 +283,20 @@ impl PlaywrightBridge {
         )))
     }
 
-    pub async fn scroll(&mut self, direction: &str, pixels: i64) -> Result<(), BridgeError> {
-        let cmd = serde_json::json!({
+    pub async fn scroll(
+        &mut self,
+        direction: &str,
+        pixels: i64,
+        selector: Option<&str>,
+    ) -> Result<(), BridgeError> {
+        let mut cmd = serde_json::json!({
             "action": "scroll",
             "direction": direction,
             "pixels": pixels,
         });
+        if let Some(sel) = selector {
+            cmd["selector"] = serde_json::Value::String(sel.to_string());
+        }
         self.send_raw_command(&cmd).await?;
         Ok(())
     }

--- a/crates/browser/src/playwright/bridge_script.rs
+++ b/crates/browser/src/playwright/bridge_script.rs
@@ -915,17 +915,35 @@ async function bootstrap() {
     }
 
     if (command.action === 'scroll') {
-      try {
-        const dir = command.direction === 'up' ? -1 : 1;
-        const px = (command.pixels || 500) * dir;
-        if (command.selector) {
+      const dir = command.direction === 'up' ? -1 : 1;
+      const px = (command.pixels || 500) * dir;
+      if (command.selector) {
+        try {
           await page.locator(command.selector).first().evaluate((el, y) => el.scrollBy(0, y), px);
-        } else {
-          await page.evaluate((y) => window.scrollBy(0, y), px);
+          process.stdout.write(JSON.stringify({ event: 'bridge_response', ok: true, result: { scrolled: true } }) + '\n');
+        } catch (mainError) {
+          let scrolledInFrame = false;
+          for (const frame of page.frames()) {
+            if (frame === page.mainFrame()) continue;
+            try {
+              await frame.locator(command.selector).first().evaluate((el, y) => el.scrollBy(0, y), px);
+              scrolledInFrame = true;
+              break;
+            } catch (_) {}
+          }
+          if (scrolledInFrame) {
+            process.stdout.write(JSON.stringify({ event: 'bridge_response', ok: true, result: { scrolled: true, frame: true } }) + '\n');
+          } else {
+            process.stdout.write(JSON.stringify({ event: 'bridge_response', ok: false, error: { kind: 'scroll_failed', message: String(mainError) } }) + '\n');
+          }
         }
-        process.stdout.write(JSON.stringify({ event: 'bridge_response', ok: true, result: { scrolled: true } }) + '\n');
-      } catch (error) {
-        process.stdout.write(JSON.stringify({ event: 'bridge_response', ok: false, error: { kind: 'scroll_failed', message: String(error) } }) + '\n');
+      } else {
+        try {
+          await page.evaluate((y) => window.scrollBy(0, y), px);
+          process.stdout.write(JSON.stringify({ event: 'bridge_response', ok: true, result: { scrolled: true } }) + '\n');
+        } catch (error) {
+          process.stdout.write(JSON.stringify({ event: 'bridge_response', ok: false, error: { kind: 'scroll_failed', message: String(error) } }) + '\n');
+        }
       }
       continue;
     }

--- a/crates/browser/src/playwright/bridge_script.rs
+++ b/crates/browser/src/playwright/bridge_script.rs
@@ -918,7 +918,11 @@ async function bootstrap() {
       try {
         const dir = command.direction === 'up' ? -1 : 1;
         const px = (command.pixels || 500) * dir;
-        await page.evaluate((y) => window.scrollBy(0, y), px);
+        if (command.selector) {
+          await page.locator(command.selector).first().evaluate((el, y) => el.scrollBy(0, y), px);
+        } else {
+          await page.evaluate((y) => window.scrollBy(0, y), px);
+        }
         process.stdout.write(JSON.stringify({ event: 'bridge_response', ok: true, result: { scrolled: true } }) + '\n');
       } catch (error) {
         process.stdout.write(JSON.stringify({ event: 'bridge_response', ok: false, error: { kind: 'scroll_failed', message: String(error) } }) + '\n');

--- a/crates/browser/src/testing.rs
+++ b/crates/browser/src/testing.rs
@@ -19,7 +19,12 @@ impl BrowserBackend for NopBridge {
     async fn close_page(&mut self, _page_index: usize) -> Result<(), BridgeError> {
         Err(BridgeError::Protocol("NopBridge".into()))
     }
-    async fn scroll(&mut self, _direction: &str, _pixels: i64) -> Result<(), BridgeError> {
+    async fn scroll(
+        &mut self,
+        _direction: &str,
+        _pixels: i64,
+        _selector: Option<&str>,
+    ) -> Result<(), BridgeError> {
         Err(BridgeError::Protocol("NopBridge".into()))
     }
     async fn page_map(

--- a/crates/browser/tests/public_api.rs
+++ b/crates/browser/tests/public_api.rs
@@ -49,7 +49,12 @@ impl BrowserBackend for MockBrowserBackend {
         Ok(())
     }
 
-    async fn scroll(&mut self, _direction: &str, _pixels: i64) -> Result<(), BridgeError> {
+    async fn scroll(
+        &mut self,
+        _direction: &str,
+        _pixels: i64,
+        _selector: Option<&str>,
+    ) -> Result<(), BridgeError> {
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Adds an optional `selector` parameter to the `scroll` tool so it can target a specific element (such as a modal or overlay scroll container) instead of always scrolling the page viewport.

## Changes

- **Tool spec** (`lib.rs`): Added `selector` property (optional CSS selector string) to scroll input_schema
- **Tool handler** (`scroll.rs`): `parse_input()` now extracts optional `selector`; `execute()` passes it through
- **BrowserBackend trait**: `scroll()` signature extended with `Option<&str>` selector parameter
- **Playwright bridge**: Sends `selector` in JSON command to Node.js bridge; Node script uses `page.locator(selector).first().evaluate()` when selector is provided
- **Extension bridge**: Uses `execute_js` with `document.querySelector()` + `scrollBy()` when selector is provided
- **All test mocks**: Updated across 10+ files to match the new 4-parameter trait signature
- **New unit tests**: `parses_optional_selector` and `selector_defaults_to_none_when_absent`

## Before / After

**Before:** `scroll(direction="down", pixels=300)` always scrolled `window.scrollBy(0, px)` — targets the page viewport even when a modal is open.

**After:** `scroll(direction="down", pixels=300, selector=".modal-content")` scrolls the targeted element's internal scroll container via `el.scrollBy(0, px)`.

## Test Plan

- [x] `cargo test -p agent -- scroll` — all 7 scroll unit tests pass
- [x] `cargo test -p agent` — full agent crate tests pass (pre-existing obs_tools_integration failures unrelated)
- [x] `cargo test -p browser` — all 17 browser crate tests pass
- [x] `cargo clippy -p browser --lib -- -D warnings` — clean
- [x] `cargo clippy -p agent --lib -- -D warnings` — clean
- [x] `cargo build --release` — builds successfully

Closes #86
