### PR TITLE
fix: return compact summary for page_state diffs by default (widen=false)

### DIFF
--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -84,7 +84,9 @@ fn navigation_tools() -> Vec<ToolSpec> {
             description: "Navigate the browser back to the previous page in history (equivalent to the browser back button). Returns the URL navigated to and a page_state object with headings, landmarks, and links of the resulting page. Use after clicking into a page to return to a listing or search results without re-navigating by URL.",
             input_schema: json!({
                 "type": "object",
-                "properties": {},
+                "properties": {
+                    "widen": { "type": "boolean", "description": "When true, return the full-page diff instead of scoping to the interacted container. Default: false." }
+                },
                 "additionalProperties": false
             }),
             instructions: Some("Returns the URL navigated to and a `page_state` object with headings, landmarks, and links of the resulting page. Use page_state to understand what you landed on after going back."),
@@ -94,7 +96,9 @@ fn navigation_tools() -> Vec<ToolSpec> {
             description: "Reload the current page. Returns page_state after reload. Use after setting intercept rules to replay the page with rules active. Seq increments for temporal observation queries.",
             input_schema: json!({
                 "type": "object",
-                "properties": {},
+                "properties": {
+                    "widen": { "type": "boolean", "description": "When true, return the full-page diff instead of scoping to the interacted container. Default: false." }
+                },
                 "additionalProperties": false
             }),
             instructions: Some("Reloads the current page and returns a `page_state` object with the updated page structure. Use after setting intercept rules to replay the page with rules active. The seq field increments for temporal observation queries."),
@@ -106,7 +110,8 @@ fn navigation_tools() -> Vec<ToolSpec> {
                 "type": "object",
                 "properties": {
                     "direction": { "type": "string", "enum": ["up", "down"], "description": "Scroll direction. 'down' reveals content below the viewport; 'up' scrolls back toward the top." },
-                    "pixels": { "type": "integer", "description": "Number of pixels to scroll (default: 500). Use 300–800 for a normal page scroll; larger values for quickly reaching page bottom." }
+                    "pixels": { "type": "integer", "description": "Number of pixels to scroll (default: 500). Use 300–800 for a normal page scroll; larger values for quickly reaching page bottom." },
+                    "widen": { "type": "boolean", "description": "When true, return the full-page diff instead of scoping to the interacted container. Default: false." }
                 },
                 "additionalProperties": false
             }),
@@ -118,7 +123,8 @@ fn navigation_tools() -> Vec<ToolSpec> {
             input_schema: json!({
                 "type": "object",
                 "properties": {
-                    "index": { "type": "integer", "description": "Zero-based tab index to switch to (0 = first tab). Use the tab count from previous responses to determine valid indices." }
+                    "index": { "type": "integer", "description": "Zero-based tab index to switch to (0 = first tab). Use the tab count from previous responses to determine valid indices." },
+                    "widen": { "type": "boolean", "description": "When true, return the full-page diff instead of scoping to the interacted container. Default: false." }
                 },
                 "additionalProperties": false
             }),
@@ -140,7 +146,8 @@ fn navigation_tools() -> Vec<ToolSpec> {
                     "silent": {
                         "type": "boolean",
                         "description": "When true, suppress the page_state payload from the response. Use for simple timed pauses where you don't need a structural diff — saves context tokens. Only effective for time-only waits (no selector). Default: false."
-                    }
+                    },
+                    "widen": { "type": "boolean", "description": "When true, return the full-page diff instead of scoping to the interacted container. Default: false." }
                 },
                 "additionalProperties": false
             }),
@@ -988,7 +995,8 @@ fn script_management_tools() -> Vec<ToolSpec> {
                     "hasTouch": {
                         "type": "boolean",
                         "description": "Enable touch event support. Cannot be used with 'device'."
-                    }
+                    },
+                    "widen": { "type": "boolean", "description": "When true, return the full-page diff instead of scoping to the interacted container. Default: false." }
                 },
                 "additionalProperties": false
             }),

--- a/crates/agent/src/tools/feedback.rs
+++ b/crates/agent/src/tools/feedback.rs
@@ -375,10 +375,12 @@ pub fn build_diff_page_state(
             }
 
             let diff = diff_trees(prev, curr);
-            if should_fallback(&diff) {
-                full_snapshot_value(curr)
-            } else if widen {
-                Value::String(render_diff(&diff))
+            if widen {
+                if should_fallback(&diff) {
+                    full_snapshot_value(curr)
+                } else {
+                    Value::String(render_diff(&diff))
+                }
             } else {
                 diff_summary_value(&diff)
             }

--- a/crates/agent/src/tools/feedback.rs
+++ b/crates/agent/src/tools/feedback.rs
@@ -311,33 +311,76 @@ fn full_snapshot_value(root: &AriaNode) -> Value {
     Value::String(to_yaml(root, Some(FEEDBACK_TREE_DEPTH)))
 }
 
+fn diff_summary_value(diff: &AriaTreeDiff) -> Value {
+    let changed = !diff.added.is_empty() || !diff.removed.is_empty() || !diff.changed.is_empty();
+    json!({
+        "changed": changed,
+        "added": diff.added.len(),
+        "removed": diff.removed.len(),
+        "changed_states": diff.changed.len(),
+    })
+}
+
+fn page_replaced_summary_value() -> Value {
+    json!({
+        "changed": true,
+        "page_replaced": true,
+        "added": 0,
+        "removed": 0,
+        "changed_states": 0,
+    })
+}
+
 #[must_use]
-pub fn build_diff_page_state(prev: Option<&AriaNode>, curr: Option<&AriaNode>) -> Value {
+pub fn build_diff_page_state(
+    prev: Option<&AriaNode>,
+    curr: Option<&AriaNode>,
+    widen: bool,
+) -> Value {
     match (prev, curr) {
-        (None, None) => Value::String("no visible change".to_string()),
+        (None, None) => {
+            if widen {
+                Value::String("no visible change".to_string())
+            } else {
+                json!({"changed": false, "added": 0, "removed": 0, "changed_states": 0})
+            }
+        }
         (None, Some(curr)) => {
             let mut diff = AriaTreeDiff::default();
             push_added_subtree(&mut diff, curr, &[]);
-            Value::String(render_diff(&diff))
+            if widen {
+                Value::String(render_diff(&diff))
+            } else {
+                diff_summary_value(&diff)
+            }
         }
         (Some(prev), None) => {
             let mut diff = AriaTreeDiff::default();
             push_removed_subtree(&mut diff, prev, &[]);
-            Value::String(render_diff(&diff))
+            if widen {
+                Value::String(render_diff(&diff))
+            } else {
+                diff_summary_value(&diff)
+            }
         }
         (Some(prev), Some(curr)) => {
             if !same_identity(prev, curr, &[]) {
-                let mut diff = AriaTreeDiff::default();
-                push_removed_subtree(&mut diff, prev, &[]);
-                push_added_subtree(&mut diff, curr, &[]);
-                return Value::String(render_diff(&diff));
+                if widen {
+                    let mut diff = AriaTreeDiff::default();
+                    push_removed_subtree(&mut diff, prev, &[]);
+                    push_added_subtree(&mut diff, curr, &[]);
+                    return Value::String(render_diff(&diff));
+                }
+                return page_replaced_summary_value();
             }
 
             let diff = diff_trees(prev, curr);
             if should_fallback(&diff) {
                 full_snapshot_value(curr)
-            } else {
+            } else if widen {
                 Value::String(render_diff(&diff))
+            } else {
+                diff_summary_value(&diff)
             }
         }
     }
@@ -500,13 +543,19 @@ fn page_state_from_feedback_map(
         widen,
     );
 
-    let page_state = match previous_tree.as_ref() {
-        Some(previous_tree) => build_diff_page_state(
+    let page_state = if let Some(previous_tree) = previous_tree.as_ref() {
+        build_diff_page_state(
             scoped_tree(previous_tree, previous_snapshot.as_ref(), &scope),
             scoped_tree(&current_tree, Some(&pm), &scope),
-        ),
-        None => scoped_tree(&current_tree, Some(&pm), &scope)
-            .map_or_else(|| full_snapshot_value(&current_tree), full_snapshot_value),
+            widen,
+        )
+    } else {
+        let scoped = scoped_tree(&current_tree, Some(&pm), &scope);
+        if widen {
+            scoped.map_or_else(|| full_snapshot_value(&current_tree), full_snapshot_value)
+        } else {
+            json!({"changed": true, "first_snapshot": true, "added": 1, "removed": 0, "changed_states": 0})
+        }
     };
 
     browser.set_page_snapshot(&cache_key, None, pm);
@@ -565,7 +614,9 @@ async fn audit_silent_submission(
         return None;
     }
 
-    if page_state.as_str() != Some("no visible change") {
+    let unchanged = page_state.as_str() == Some("no visible change")
+        || page_state.get("changed").and_then(Value::as_bool) == Some(false);
+    if !unchanged {
         return None;
     }
 
@@ -1064,7 +1115,7 @@ mod tests {
             ),
         ]);
 
-        let result = build_diff_page_state(Some(&prev), Some(&curr));
+        let result = build_diff_page_state(Some(&prev), Some(&curr), true);
         let rendered = result.as_str().expect("tree diff should be a string");
 
         assert!(rendered.contains("added:"));
@@ -1084,7 +1135,7 @@ mod tests {
         ]);
         let curr = document(vec![node("main", Some(""), Some("e2"), vec![])]);
 
-        let result = build_diff_page_state(Some(&prev), Some(&curr));
+        let result = build_diff_page_state(Some(&prev), Some(&curr), true);
         let rendered = result.as_str().expect("tree diff should be a string");
 
         assert!(rendered.contains("removed:"));
@@ -1111,7 +1162,7 @@ mod tests {
             vec![],
         )]);
 
-        let result = build_diff_page_state(Some(&prev), Some(&curr));
+        let result = build_diff_page_state(Some(&prev), Some(&curr), true);
         let rendered = result.as_str().expect("tree diff should be a string");
 
         assert!(rendered.contains("changed:"));
@@ -1124,9 +1175,10 @@ mod tests {
         let prev = document(vec![node("button", Some("Submit"), Some("e2"), vec![])]);
         let curr = document(vec![node("button", Some("Submit"), Some("e9"), vec![])]);
 
+        let result = build_diff_page_state(Some(&prev), Some(&curr), false);
         assert_eq!(
-            build_diff_page_state(Some(&prev), Some(&curr)),
-            Value::String("no visible change".to_string())
+            result,
+            json!({"changed": false, "added": 0, "removed": 0, "changed_states": 0})
         );
     }
 
@@ -1135,9 +1187,10 @@ mod tests {
         let prev = document(vec![node("button", Some("Save"), Some("e2"), vec![])]);
         let curr = document(vec![node("button", Some("Save"), Some("e99"), vec![])]);
 
+        let result = build_diff_page_state(Some(&prev), Some(&curr), false);
         assert_eq!(
-            build_diff_page_state(Some(&prev), Some(&curr)),
-            Value::String("no visible change".to_string())
+            result,
+            json!({"changed": false, "added": 0, "removed": 0, "changed_states": 0})
         );
     }
 
@@ -1158,7 +1211,7 @@ mod tests {
         );
 
         assert_eq!(
-            build_diff_page_state(Some(&prev), Some(&curr)),
+            build_diff_page_state(Some(&prev), Some(&curr), true),
             Value::String(to_yaml(&curr, Some(FEEDBACK_TREE_DEPTH)))
         );
     }
@@ -1178,7 +1231,7 @@ mod tests {
             vec![node("heading", Some("Welcome"), Some("e2"), vec![])],
         );
 
-        let result = build_diff_page_state(Some(&prev), Some(&curr));
+        let result = build_diff_page_state(Some(&prev), Some(&curr), true);
 
         let expected = [
             "+ [ref=e1] added:",
@@ -1191,6 +1244,29 @@ mod tests {
         .join("\n");
 
         assert_eq!(result, Value::String(expected));
+    }
+
+    #[test]
+    fn tree_diff_root_identity_change_summary_marks_page_replaced() {
+        let prev = node(
+            "dialog",
+            Some("Login"),
+            Some("e1"),
+            vec![node("button", Some("Sign in"), Some("e2"), vec![])],
+        );
+        let curr = node(
+            "main",
+            Some(""),
+            Some("e1"),
+            vec![node("heading", Some("Welcome"), Some("e2"), vec![])],
+        );
+
+        let result = build_diff_page_state(Some(&prev), Some(&curr), false);
+
+        assert_eq!(
+            result,
+            json!({"changed": true, "page_replaced": true, "added": 0, "removed": 0, "changed_states": 0})
+        );
     }
 
     #[test]
@@ -1247,10 +1323,8 @@ mod tests {
         .await
         .unwrap();
 
-        let rendered = result.as_str().expect("page state should be a string");
-        println!("{rendered}");
-        assert!(rendered.contains("added:"));
-        assert!(rendered.contains("dialog \"Confirm delete\""));
+        assert_eq!(result["changed"], true);
+        assert_eq!(result["added"], 1);
 
         let state = state.lock().expect("mock state poisoned");
         assert_eq!(state.requested_scopes, vec![None]);
@@ -1290,7 +1364,7 @@ mod tests {
             &mut crawl_state,
             InteractionKind::Passive,
             None,
-            false,
+            true,
         )
         .await
         .unwrap();
@@ -1423,8 +1497,10 @@ mod tests {
         .await
         .unwrap();
 
-        let rendered = result.as_str().expect("page state should be a string");
-        assert_ne!(rendered, "no visible change");
+        let changed = result["changed"]
+            .as_bool()
+            .expect("summary should have changed field");
+        assert!(changed, "page should have changed");
 
         let state = state.lock().expect("mock state poisoned");
         assert!(state.evaluate_scripts.is_empty());

--- a/crates/agent/src/tools/feedback.rs
+++ b/crates/agent/src/tools/feedback.rs
@@ -556,7 +556,7 @@ fn page_state_from_feedback_map(
         if widen {
             scoped.map_or_else(|| full_snapshot_value(&current_tree), full_snapshot_value)
         } else {
-            json!({"changed": true, "first_snapshot": true, "added": 1, "removed": 0, "changed_states": 0})
+            json!({"changed": true, "first_snapshot": true, "url": full_url, "added": 1, "removed": 0, "changed_states": 0})
         }
     };
 

--- a/crates/agent/src/tools/go_back.rs
+++ b/crates/agent/src/tools/go_back.rs
@@ -11,7 +11,10 @@ pub async fn execute(
     browser: &mut BrowserContext,
     crawl_state: &mut CrawlState,
 ) -> Result<ToolEffect, ToolExecutionError> {
-    let _ = input;
+    let widen = input
+        .get("widen")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
 
     browser.ref_map_mut().clear();
 
@@ -29,7 +32,7 @@ pub async fn execute(
         crawl_state,
         InteractionKind::Passive,
         None,
-        false,
+        widen,
     )
     .await?;
 

--- a/crates/agent/src/tools/refresh.rs
+++ b/crates/agent/src/tools/refresh.rs
@@ -10,7 +10,10 @@ pub async fn execute(
     browser: &mut BrowserContext,
     crawl_state: &mut CrawlState,
 ) -> Result<ToolEffect, ToolExecutionError> {
-    let _ = input;
+    let widen = input
+        .get("widen")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
 
     browser.ref_map_mut().clear();
 
@@ -28,7 +31,7 @@ pub async fn execute(
         crawl_state,
         InteractionKind::Passive,
         None,
-        false,
+        widen,
     )
     .await?;
 

--- a/crates/agent/src/tools/scroll.rs
+++ b/crates/agent/src/tools/scroll.rs
@@ -34,6 +34,10 @@ pub async fn execute(
     crawl_state: &mut CrawlState,
 ) -> Result<ToolEffect, ToolExecutionError> {
     let (direction, pixels) = parse_input(input)?;
+    let widen = input
+        .get("widen")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
 
     browser
         .acquire_bridge()
@@ -49,7 +53,7 @@ pub async fn execute(
         crawl_state,
         InteractionKind::Passive,
         None,
-        false,
+        widen,
     )
     .await?;
 

--- a/crates/agent/src/tools/set_device.rs
+++ b/crates/agent/src/tools/set_device.rs
@@ -307,6 +307,10 @@ pub async fn execute(
     crawl_state: &mut CrawlState,
 ) -> Result<ToolEffect, ToolExecutionError> {
     let device_input = parse_input(input)?;
+    let widen = input
+        .get("widen")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
     let (device_name, options) = resolve_to_options(device_input)?;
     let display_name = if device_name.starts_with("custom:") {
         "custom".to_string()
@@ -350,7 +354,7 @@ pub async fn execute(
         crawl_state,
         InteractionKind::Passive,
         None,
-        false,
+        widen,
     )
     .await?;
 

--- a/crates/agent/src/tools/switch_tab.rs
+++ b/crates/agent/src/tools/switch_tab.rs
@@ -20,6 +20,10 @@ pub async fn execute(
     crawl_state: &mut CrawlState,
 ) -> Result<ToolEffect, ToolExecutionError> {
     let index = parse_input(input);
+    let widen = input
+        .get("widen")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
 
     browser.ref_map_mut().clear();
 
@@ -49,7 +53,7 @@ pub async fn execute(
         crawl_state,
         InteractionKind::Passive,
         None,
-        false,
+        widen,
     )
     .await?;
 

--- a/crates/agent/src/tools/wait.rs
+++ b/crates/agent/src/tools/wait.rs
@@ -18,6 +18,7 @@ pub struct WaitInput {
     pub timeout_ms: u64,
     pub state: Option<String>,
     pub silent: bool,
+    pub widen: bool,
 }
 
 pub fn parse_input(input: &Value) -> Result<WaitInput, CrawlError> {
@@ -59,11 +60,17 @@ pub fn parse_input(input: &Value) -> Result<WaitInput, CrawlError> {
         .and_then(serde_json::Value::as_bool)
         .unwrap_or(false);
 
+    let widen = input
+        .get("widen")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+
     Ok(WaitInput {
         selector,
         timeout_ms,
         state,
         silent,
+        widen,
     })
 }
 
@@ -122,7 +129,7 @@ pub async fn execute(
             crawl_state,
             InteractionKind::Passive,
             None,
-            false,
+            parsed.widen,
         )
         .await?;
 
@@ -148,7 +155,7 @@ pub async fn execute(
             crawl_state,
             InteractionKind::Passive,
             None,
-            false,
+            parsed.widen,
         )
         .await?;
 


### PR DESCRIPTION
## Summary

Action tool responses (`click`, `hover`, `fill_form`, etc.) now return a compact JSON summary by default instead of the full YAML tree diff. This dramatically reduces token consumption during multi-step automation sessions.

### Before

A single button click returns the entire page tree twice (as added and removed subtrees), consuming thousands of tokens per action.

### After (widen=false, default)

```json
{"changed": true, "added": 1, "removed": 1, "changed_states": 0}
```

For full-page replacements (navigation), the response is:
```json
{"changed": true, "page_replaced": true, "added": 0, "removed": 0, "changed_states": 0}
```

### widen=true (opt-in)

The existing verbose YAML diff is preserved behind the `widen=true` flag for cases where full structural diffs are needed.

## Changes

- `build_diff_page_state()` now takes a `widen: bool` parameter
- Added `diff_summary_value()` and `page_replaced_summary_value()` helpers
- All test callers updated; new test for page_replaced summary
- `audit_silent_submission` updated to handle both string and JSON page_states

## Test Plan

- [x] All 16 feedback unit tests pass
- [x] E2E verified: click on example.com returns compact summary
- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo build --release` clean

Closes #89
