### PR TITLE
chore: add Codex auto-review workflow for collaborator PRs

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,7 +1,13 @@
 name: Trigger Codex Review
 on:
-  pull_request:
+  pull_request_target: # secrets available for collaborator and fork PRs; no code checkout
     types: [opened, reopened] # synchronize intentionally excluded
+  workflow_dispatch: # manual fallback: trigger review on any open PR by number
+    inputs:
+      pr_number:
+        description: Pull request number
+        required: true
+        type: number
 
 jobs:
   trigger:
@@ -12,25 +18,34 @@ jobs:
         with:
           github-token: ${{ secrets.CODEX_TRIGGER_TOKEN }}
           script: |
+            const prNumber = context.eventName === 'workflow_dispatch'
+              ? parseInt(context.payload.inputs.pr_number, 10)
+              : context.payload.pull_request.number;
+
+            if (!prNumber || isNaN(prNumber)) {
+              core.setFailed(`Invalid PR number: ${context.payload.inputs?.pr_number}`);
+              return;
+            }
+
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
+              issue_number: prNumber,
+              per_page: 100,
             });
 
-            // Only post if no @codex review comment exists yet
             const alreadyTriggered = comments.some(c =>
-              c.body && c.body.toLowerCase().includes('@codex')
+              c.body && c.body.trim().toLowerCase() === '@codex review'
             );
 
             if (!alreadyTriggered) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
+                issue_number: prNumber,
                 body: '@codex review'
               });
-              console.log('Codex review triggered.');
+              console.log(`Codex review triggered on PR #${prNumber}.`);
             } else {
-              console.log('Codex already mentioned on this PR — skipping.');
+              console.log(`PR #${prNumber}: @codex review already posted — skipping.`);
             }

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,0 +1,36 @@
+name: Trigger Codex Review
+on:
+  pull_request:
+    types: [opened, reopened] # synchronize intentionally excluded
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CODEX_TRIGGER_TOKEN }}
+          script: |
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+
+            // Only post if no @codex review comment exists yet
+            const alreadyTriggered = comments.some(c =>
+              c.body && c.body.toLowerCase().includes('@codex')
+            );
+
+            if (!alreadyTriggered) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: '@codex review'
+              });
+              console.log('Codex review triggered.');
+            } else {
+              console.log('Codex already mentioned on this PR — skipping.');
+            }


### PR DESCRIPTION
## What

Adds \.github/workflows/codex-review.yml\ — a workflow that automatically posts \@codex review\ on every new PR as the repo owner.

## Why

Codex Cloud PLUS plan only auto-reviews the owner's own PRs. Collaborator PRs (e.g. from LuminDev) are silently skipped. This workflow bridges the gap without upgrading to PRO.

## How it works

- Triggers only on \pull_request: [opened, reopened]\ — \synchronize\ is intentionally excluded to avoid re-triggering on every commit push (quota protection)
- Before posting, checks whether \@codex\ has already been mentioned on the PR — prevents duplicate reviews on reruns or manual triggers
- Uses \CODEX_TRIGGER_TOKEN\ (a fine-grained PAT with PR read/write) stored as a repo secret

## Setup required

After merging, add a fine-grained PAT as a repo secret:

1. \github.com/settings/tokens\ → New fine-grained token → Repository: AgenticCrawler → Permission: **Pull requests: Read & Write**
2. Repo → Settings → Secrets and variables → Actions → New secret → Name: \CODEX_TRIGGER_TOKEN\

## Test plan

- [ ] Merge this PR
- [ ] Add \CODEX_TRIGGER_TOKEN\ secret
- [ ] Open a test PR → confirm workflow runs and posts \@codex review\ once
- [ ] Push a commit to that PR → confirm workflow does NOT re-trigger