### PR TITLE
feat: add get_page_info tool for lightweight page identity checks

### DIFF
--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -80,6 +80,16 @@ fn navigation_tools() -> Vec<ToolSpec> {
             instructions: Some("Always use full URLs including the protocol (https://). Returns page content with an embedded page_map showing page structure. Use content_depth to control context size: 'main' (default) extracts article/main content only, 'full' returns everything, 'slim' gives first 2000 chars of main content, 'none' skips content (page_map only). Images are stripped by default (strip_images=true) since they waste context — set false only when you need image URLs. The page_map.links array lets you navigate to linked pages without clicking. The default format is fit_markdown which prunes boilerplate (ads, navs, sidebars) before conversion, saving tokens. Fall back to 'markdown' or 'text' only if content seems missing. page_map_depth controls structural data verbosity: 'slim' (default) strips CSS selectors from all elements to save tokens — use @eN refs for interaction instead. Set 'full' only when you need raw selectors, 'none' to omit page_map entirely."),
         },
         ToolSpec {
+            name: "get_page_info",
+            description: "Get the current page URL, title, and readyState without any DOM traversal or page refetch. Returns lightweight metadata ideal for confirming navigation or redirect outcomes between steps. Use this instead of navigate() or page_map() when you only need to verify the current page identity.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }),
+            instructions: Some("Use this for a cheap check of the current page's URL, title, and readyState — e.g. to confirm a redirect landed where expected — instead of a full navigate() or page_map() call."),
+        },
+        ToolSpec {
             name: "go_back",
             description: "Navigate the browser back to the previous page in history (equivalent to the browser back button). Returns the URL navigated to and a page_state object with headings, landmarks, and links of the resulting page. Use after clicking into a page to return to a listing or search results without re-navigating by URL.",
             input_schema: json!({
@@ -1053,12 +1063,12 @@ mod tests {
     use super::mvp_tool_specs;
 
     #[test]
-    fn mvp_tool_specs_contains_expected_42_tools() {
+    fn mvp_tool_specs_contains_expected_43_tools() {
         let specs = mvp_tool_specs();
-        assert_eq!(specs.len(), 42);
+        assert_eq!(specs.len(), 43);
 
         let names: BTreeSet<_> = specs.iter().map(|spec| spec.name).collect();
-        assert_eq!(names.len(), 42, "tool names should be unique");
+        assert_eq!(names.len(), 43, "tool names should be unique");
         assert!(names.contains("navigate"));
         assert!(names.contains("click_at"));
         assert!(names.contains("save_file"));

--- a/crates/agent/src/registry.rs
+++ b/crates/agent/src/registry.rs
@@ -7,7 +7,7 @@ use crate::{ToolEffect, ToolExecutionError};
 
 pub type ToolHandler = Box<dyn Fn(&Value) -> Result<ToolEffect, ToolExecutionError> + Send + Sync>;
 
-const ASYNC_TOOLS: [&str; 31] = [
+const ASYNC_TOOLS: [&str; 32] = [
     "navigate",
     "click",
     "click_at",
@@ -20,6 +20,7 @@ const ASYNC_TOOLS: [&str; 31] = [
     "inspect_websocket",
     "screenshot",
     "go_back",
+    "get_page_info",
     "refresh",
     "scroll",
     "wait",
@@ -169,6 +170,9 @@ impl ToolRegistry {
             }
             "screenshot" => crate::tools::screenshot::execute(input, browser).await,
             "go_back" => crate::tools::go_back::execute(input, browser, crawl_state).await,
+            "get_page_info" => {
+                crate::tools::get_page_info::execute(input, browser, crawl_state).await
+            }
             "refresh" => crate::tools::refresh::execute(input, browser, crawl_state).await,
             "scroll" => crate::tools::scroll::execute(input, browser, crawl_state).await,
             "wait" => crate::tools::wait::execute(input, browser, crawl_state).await,
@@ -214,7 +218,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn new_with_core_tools_registers_all_forty_two() {
+    fn new_with_core_tools_registers_all_forty_three() {
         let registry = ToolRegistry::new_with_core_tools();
         let effect_tools = [
             "fork",
@@ -231,7 +235,7 @@ mod tests {
             "wait_for_scripts",
             "cancel_script",
         ];
-        assert_eq!(registry.len(), 42);
+        assert_eq!(registry.len(), 43);
         for &name in ASYNC_TOOLS
             .iter()
             .chain(effect_tools.iter())
@@ -244,7 +248,7 @@ mod tests {
     #[test]
     fn new_for_child_same_as_parent() {
         let registry = ToolRegistry::new_for_child();
-        assert_eq!(registry.len(), 42);
+        assert_eq!(registry.len(), 43);
         assert!(registry.contains("fork"));
         assert!(registry.contains("navigate"));
         assert!(registry.contains("list_scripts"));

--- a/crates/agent/src/tools/get_page_info.rs
+++ b/crates/agent/src/tools/get_page_info.rs
@@ -1,0 +1,74 @@
+use serde_json::Value;
+
+use crate::state::CrawlState;
+use crate::BrowserContext;
+use crate::{ToolEffect, ToolExecutionError};
+
+pub async fn execute(
+    input: &Value,
+    browser: &mut BrowserContext,
+    crawl_state: &mut CrawlState,
+) -> Result<ToolEffect, ToolExecutionError> {
+    let _ = input;
+
+    let url = browser
+        .current_url()
+        .map(ToString::to_string)
+        .ok_or_else(|| ToolExecutionError::new("no page loaded; call navigate first"))?;
+
+    let mut bridge = browser
+        .acquire_bridge()
+        .await
+        .map_err(|e| ToolExecutionError::new(e.to_string()))?;
+
+    let title = bridge
+        .evaluate("document.title")
+        .await
+        .ok()
+        .and_then(|v| {
+            v.get("value")
+                .and_then(Value::as_str)
+                .map(ToString::to_string)
+        })
+        .unwrap_or_default();
+
+    let ready_state = bridge
+        .evaluate("document.readyState")
+        .await
+        .ok()
+        .and_then(|v| {
+            v.get("value")
+                .and_then(Value::as_str)
+                .map(ToString::to_string)
+        })
+        .unwrap_or_default();
+
+    drop(bridge);
+
+    let seq = super::seq::increment_seq(crawl_state, browser).await;
+
+    Ok(ToolEffect::reply_json(&serde_json::json!({
+        "seq": seq,
+        "success": true,
+        "url": url,
+        "title": title,
+        "ready_state": ready_state
+    })))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    #[test]
+    fn empty_input_is_valid_json_object() {
+        let input = json!({});
+        assert!(input.is_object());
+    }
+
+    #[test]
+    fn null_input_is_accepted() {
+        let input = serde_json::Value::Null;
+        assert!(input.is_null());
+    }
+}

--- a/crates/agent/src/tools/get_page_info.rs
+++ b/crates/agent/src/tools/get_page_info.rs
@@ -10,45 +10,71 @@ pub async fn execute(
     crawl_state: &mut CrawlState,
 ) -> Result<ToolEffect, ToolExecutionError> {
     let _ = input;
+    let _ = crawl_state;
+
+    if !browser.is_browser_loaded() {
+        let url = browser
+            .current_url()
+            .map(ToString::to_string)
+            .ok_or_else(|| ToolExecutionError::new("no page loaded; call navigate first"))?;
+
+        return Ok(ToolEffect::reply_json(&serde_json::json!({
+            "seq": 0,
+            "success": true,
+            "url": url,
+            "title": "",
+            "ready_state": ""
+        })));
+    }
 
     let mut bridge = browser
         .acquire_bridge()
         .await
         .map_err(|e| ToolExecutionError::new(e.to_string()))?;
 
-    let live_url = bridge
-        .evaluate("window.location.href")
-        .await
-        .ok()
-        .and_then(|v| {
-            v.get("value")
-                .and_then(Value::as_str)
-                .map(ToString::to_string)
-        });
-
-    let title = bridge
-        .evaluate("document.title")
-        .await
-        .ok()
-        .and_then(|v| {
-            v.get("value")
-                .and_then(Value::as_str)
-                .map(ToString::to_string)
-        })
-        .unwrap_or_default();
-
-    let ready_state = bridge
-        .evaluate("document.readyState")
-        .await
-        .ok()
-        .and_then(|v| {
-            v.get("value")
-                .and_then(Value::as_str)
-                .map(ToString::to_string)
-        })
-        .unwrap_or_default();
+    let live_url_result = bridge.evaluate("window.location.href").await;
+    let title_result = bridge.evaluate("document.title").await;
+    let ready_state_result = bridge.evaluate("document.readyState").await;
 
     drop(bridge);
+
+    let mut live_url_error = None;
+    let live_url = match live_url_result {
+        Ok(v) => v
+            .get("value")
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+        Err(e) => {
+            live_url_error = Some(e.to_string());
+            None
+        }
+    };
+
+    let mut title_error = None;
+    let title = match title_result {
+        Ok(v) => v
+            .get("value")
+            .and_then(Value::as_str)
+            .map(ToString::to_string)
+            .unwrap_or_default(),
+        Err(e) => {
+            title_error = Some(e.to_string());
+            String::new()
+        }
+    };
+
+    let mut ready_state_error = None;
+    let ready_state = match ready_state_result {
+        Ok(v) => v
+            .get("value")
+            .and_then(Value::as_str)
+            .map(ToString::to_string)
+            .unwrap_or_default(),
+        Err(e) => {
+            ready_state_error = Some(e.to_string());
+            String::new()
+        }
+    };
 
     let url = match live_url {
         Some(url) => url,
@@ -58,15 +84,25 @@ pub async fn execute(
             .ok_or_else(|| ToolExecutionError::new("no page loaded; call navigate first"))?,
     };
 
-    let seq = super::seq::increment_seq(crawl_state, browser).await;
-
-    Ok(ToolEffect::reply_json(&serde_json::json!({
-        "seq": seq,
+    let mut reply = serde_json::json!({
+        "seq": 0,
         "success": true,
         "url": url,
         "title": title,
         "ready_state": ready_state
-    })))
+    });
+
+    if let Some(err) = title_error {
+        reply["title_error"] = serde_json::Value::String(err);
+    }
+    if let Some(err) = ready_state_error {
+        reply["ready_state_error"] = serde_json::Value::String(err);
+    }
+    if let Some(err) = live_url_error {
+        reply["live_url_error"] = serde_json::Value::String(err);
+    }
+
+    Ok(ToolEffect::reply_json(&reply))
 }
 
 #[cfg(test)]

--- a/crates/agent/src/tools/get_page_info.rs
+++ b/crates/agent/src/tools/get_page_info.rs
@@ -11,15 +11,20 @@ pub async fn execute(
 ) -> Result<ToolEffect, ToolExecutionError> {
     let _ = input;
 
-    let url = browser
-        .current_url()
-        .map(ToString::to_string)
-        .ok_or_else(|| ToolExecutionError::new("no page loaded; call navigate first"))?;
-
     let mut bridge = browser
         .acquire_bridge()
         .await
         .map_err(|e| ToolExecutionError::new(e.to_string()))?;
+
+    let live_url = bridge
+        .evaluate("window.location.href")
+        .await
+        .ok()
+        .and_then(|v| {
+            v.get("value")
+                .and_then(Value::as_str)
+                .map(ToString::to_string)
+        });
 
     let title = bridge
         .evaluate("document.title")
@@ -44,6 +49,14 @@ pub async fn execute(
         .unwrap_or_default();
 
     drop(bridge);
+
+    let url = match live_url {
+        Some(url) => url,
+        None => browser
+            .current_url()
+            .map(ToString::to_string)
+            .ok_or_else(|| ToolExecutionError::new("no page loaded; call navigate first"))?,
+    };
 
     let seq = super::seq::increment_seq(crawl_state, browser).await;
 

--- a/crates/agent/src/tools/mod.rs
+++ b/crates/agent/src/tools/mod.rs
@@ -6,6 +6,7 @@ pub mod coverage;
 pub mod feedback;
 pub mod fill_form;
 pub mod fork;
+pub mod get_page_info;
 pub mod go_back;
 pub mod html_diff;
 pub mod intercept_network;

--- a/crates/browser/src/context.rs
+++ b/crates/browser/src/context.rs
@@ -99,6 +99,11 @@ impl BrowserContext {
         self.current_url.as_deref()
     }
 
+    #[must_use]
+    pub fn is_browser_loaded(&self) -> bool {
+        self.browser_has_url.is_some()
+    }
+
     pub fn set_page_index(&mut self, page_index: usize) {
         self.page_index = page_index;
     }

--- a/crates/cli/tests/mcp_stdio.rs
+++ b/crates/cli/tests/mcp_stdio.rs
@@ -160,7 +160,7 @@ fn stdio_server_handles_initialize_list_and_tool_call() {
     assert!(names.contains(&"run_goal"));
     assert!(!names.contains(&"fork"));
     assert!(!names.contains(&"list_builtin_tools"));
-    assert_eq!(names.len(), 39);
+    assert_eq!(names.len(), 40);
 
     server.send(&json!({
         "jsonrpc": "2.0",
@@ -354,7 +354,7 @@ fn stdio_server_supports_line_delimited_jsonrpc() {
     assert_eq!(response["id"], 21);
     assert!(names.contains(&"navigate"));
     assert!(names.contains(&"run_goal"));
-    assert_eq!(names.len(), 39);
+    assert_eq!(names.len(), 40);
 
     server.shutdown();
 }

--- a/crates/mcp-server/src/server.rs
+++ b/crates/mcp-server/src/server.rs
@@ -1189,7 +1189,7 @@ mod tests {
             .into_iter()
             .filter(|spec| !EXCLUDED_TOOLS.contains(&spec.name))
             .collect();
-        assert_eq!(browser_specs.len(), 38);
+        assert_eq!(browser_specs.len(), 39);
         let names: BTreeSet<&str> = browser_specs.iter().map(|s| s.name).collect();
         assert!(names.contains("navigate"));
         assert!(names.contains("click"));


### PR DESCRIPTION
## Summary

Adds a new `get_page_info` browser tool that returns the current page URL, title, and `readyState` without any DOM traversal or page refetch.

## Motivation

There was no lightweight way to confirm page identity between steps. The only options were:
- `navigate(url=current_url)` — re-fetches the entire page
- `page_map()` — returns the full accessibility tree (expensive)
- `execute_js("window.location.href")` — works but indirect

This new tool provides a near-zero-cost sanity check for:
- Confirming form submissions redirected to the expected page
- Verifying login succeeded (URL changed)
- Checking current URL before deciding whether to navigate
- Asserting the page didn't change unexpectedly

## Changes

- **New file:** `crates/agent/src/tools/get_page_info.rs` — tool handler
- `crates/agent/src/lib.rs` — added tool spec to `navigation_tools()`
- `crates/agent/src/tools/mod.rs` — module declaration
- `crates/agent/src/registry.rs` — async dispatch + test counts
- `crates/mcp-server/src/server.rs` — browser spec count

## Example

```json
// Request
{"jsonrpc":"2.0","method":"tools/call","params":{"name":"get_page_info","arguments":{}}}

// Response
{
  "seq": 1,
  "success": true,
  "url": "https://example.com/",
  "title": "Example Domain",
  "ready_state": "complete"
}
```

If no page is loaded, returns an error: "no page loaded; call navigate first"

Closes #91
