### PR TITLE
fix: resolve clippy lint drift from newer stable toolchain

### DIFF
--- a/crates/browser/src/ws_server/mod.rs
+++ b/crates/browser/src/ws_server/mod.rs
@@ -367,7 +367,7 @@ mod tests {
 
     #[test]
     fn constant_time_eq_same() {
-        assert!(auth::generate_bridge_token().len() == 64);
+        assert_eq!(auth::generate_bridge_token().len(), 64);
     }
 
     #[test]

--- a/crates/runtime/src/compact/tests.rs
+++ b/crates/runtime/src/compact/tests.rs
@@ -1000,7 +1000,7 @@ fn qa_multiple_compaction_rounds() {
     assert!(
         has_previously,
         "second compaction must reference prior compacted context, got: {}",
-        &result2.formatted_summary
+        result2.formatted_summary
     );
 
     // Round 3: Append more, compact a third time

--- a/crates/runtime/src/conversation/tests.rs
+++ b/crates/runtime/src/conversation/tests.rs
@@ -614,7 +614,7 @@ async fn vision_capable_model_produces_tool_result_image() {
                 && !is_error
         ),
         "expected ToolResultImage block, got: {:?}",
-        &tool_result_msg.blocks[0]
+        tool_result_msg.blocks[0]
     );
 }
 
@@ -690,6 +690,6 @@ async fn non_vision_model_produces_plain_tool_result_with_caption() {
                 && !is_error
         ),
         "expected plain ToolResult block with caption, got: {:?}",
-        &tool_result_msg.blocks[0]
+        tool_result_msg.blocks[0]
     );
 }


### PR DESCRIPTION
## Summary
- CI's `cargo clippy --workspace --all-targets -- -D warnings` started failing after the runner's `dtolnay/rust-toolchain@stable` floated to a newer stable Rust, which added two new lints that now fire against pre-existing code.
- `clippy::manual_assert_eq` in `crates/browser/src/ws_server/mod.rs` — replaced `assert!(a == b)` with `assert_eq!(a, b)`.
- `clippy::useless_borrows_in_formatting` in `crates/runtime/src/compact/tests.rs` and `crates/runtime/src/conversation/tests.rs` (2 occurrences) — removed redundant `&` on format-arg expressions inside `assert!` messages.
- No behavior change — test-only and test-assertion-style fixes.

## Test plan
- [x] `cargo fmt` — no additional reformatting needed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — all tests pass (two known pre-existing flaky tests unrelated to this diff, `acrawl-core::config::tests::set_tui_active_toggles_flag` and `acrawl-ui::auth::configure::tests::vertex_requires_project_region_and_api_key`, were observed to intermittently fail on unmodified `main` too, due to shared global state races across parallel test threads — not touched by this change)
