### PR TITLE
fix: resolve parallel tool-call completions in FIFO order

### DIFF
--- a/crates/tui/src/child_tabs.rs
+++ b/crates/tui/src/child_tabs.rs
@@ -171,7 +171,7 @@ impl ChildTabPanel {
                     }
                 };
 
-                let updated = tab.entries.iter_mut().rev().find_map(|entry| match entry {
+                let updated = tab.entries.iter_mut().find_map(|entry| match entry {
                     TranscriptEntry::ToolCall {
                         name: entry_name,
                         status: status @ ToolCallStatus::Running,
@@ -435,6 +435,70 @@ mod tests {
                 assert!(matches!(status, ToolCallStatus::Success { .. }));
             }
             _ => panic!("Expected ToolCall(Success) entry"),
+        }
+    }
+
+    #[test]
+    fn test_tool_call_complete_resolves_parallel_same_name_calls_fifo() {
+        let mut panel = ChildTabPanel::default();
+        // Two parallel `navigate` calls started in order A then B.
+        panel.apply_event(
+            "child-1",
+            "goal",
+            &ChildEventKind::ToolCallStart {
+                name: "navigate".to_string(),
+                input_summary: "a.example".to_string(),
+            },
+        );
+        panel.apply_event(
+            "child-1",
+            "goal",
+            &ChildEventKind::ToolCallStart {
+                name: "navigate".to_string(),
+                input_summary: "b.example".to_string(),
+            },
+        );
+
+        // A's completion arrives first; it must resolve the FIRST (A) entry, not the last (B).
+        panel.apply_event(
+            "child-1",
+            "goal",
+            &ChildEventKind::ToolCallComplete {
+                name: "navigate".to_string(),
+                output_summary: "loaded a.example".to_string(),
+                is_error: false,
+            },
+        );
+
+        let tab = &panel.tabs[0];
+        // entries[0] is the initial Parent entry; entries[1] and [2] are the two ToolCalls.
+        match &tab.entries[1] {
+            TranscriptEntry::ToolCall {
+                input_summary,
+                status,
+                ..
+            } => {
+                assert_eq!(input_summary, "a.example");
+                assert!(
+                    matches!(status, ToolCallStatus::Success { .. }),
+                    "first (A) entry should be resolved by the first completion"
+                );
+            }
+            _ => panic!("Expected ToolCall(Success) entry for A"),
+        }
+        match &tab.entries[2] {
+            TranscriptEntry::ToolCall {
+                input_summary,
+                status,
+                ..
+            } => {
+                assert_eq!(input_summary, "b.example");
+                assert!(
+                    matches!(status, ToolCallStatus::Running),
+                    "second (B) entry should still be Running"
+                );
+            }
+            _ => panic!("Expected ToolCall(Running) entry for B"),
         }
     }
 

--- a/crates/tui/src/repl_app/input_editor.rs
+++ b/crates/tui/src/repl_app/input_editor.rs
@@ -1061,7 +1061,6 @@ impl ReplTuiState {
         if let Some((_, _, entry_status)) =
             self.live_tool_calls
                 .iter_mut()
-                .rev()
                 .find(|(entry_name, _, entry_status)| {
                     entry_name == name && matches!(entry_status, ToolCallStatus::Running)
                 })

--- a/crates/tui/src/repl_app/tests.rs
+++ b/crates/tui/src/repl_app/tests.rs
@@ -1166,6 +1166,61 @@ fn tool_call_complete_updates_in_place_error() {
 }
 
 #[test]
+fn tool_call_complete_resolves_parallel_same_name_calls_fifo() {
+    let (tx, rx) = mpsc::channel::<ReplTuiEvent>();
+    let mut state = ReplTuiState::new();
+
+    // Two parallel `navigate` calls started in order A then B.
+    tx.send(ReplTuiEvent::ToolCallStart {
+        name: "navigate".to_string(),
+        input: r#"{"url":"https://a.example"}"#.to_string(),
+    })
+    .unwrap();
+    tx.send(ReplTuiEvent::ToolCallStart {
+        name: "navigate".to_string(),
+        input: r#"{"url":"https://b.example"}"#.to_string(),
+    })
+    .unwrap();
+    state.drain_events(&rx);
+    assert_eq!(state.live_tool_calls.len(), 2);
+
+    // A's completion arrives first; it must resolve the FIRST (A) entry, not the last (B).
+    tx.send(ReplTuiEvent::ToolCallComplete {
+        name: "navigate".to_string(),
+        output: "loaded a.example".to_string(),
+        is_error: false,
+    })
+    .unwrap();
+    state.drain_events(&rx);
+
+    assert!(
+        matches!(
+            state.live_tool_calls[0],
+            (_, _, ToolCallStatus::Success { .. })
+        ),
+        "first (A) entry should be resolved by the first completion"
+    );
+    assert!(
+        matches!(state.live_tool_calls[1], (_, _, ToolCallStatus::Running)),
+        "second (B) entry should still be Running"
+    );
+
+    // B's completion arrives second; it must resolve the remaining (B) entry.
+    tx.send(ReplTuiEvent::ToolCallComplete {
+        name: "navigate".to_string(),
+        output: "loaded b.example".to_string(),
+        is_error: false,
+    })
+    .unwrap();
+    state.drain_events(&rx);
+
+    assert!(matches!(
+        state.live_tool_calls[1],
+        (_, _, ToolCallStatus::Success { .. })
+    ));
+}
+
+#[test]
 fn goal_title_shows_reasoning_effort_for_reasoning_model() {
     let header = super::HeaderSnapshot {
         model: "gpt-5.3-codex".to_string(),


### PR DESCRIPTION
## Summary
- Two locations (`ReplTuiState::handle_tool_call_complete` in `crates/tui/src/repl_app/input_editor.rs` and `ChildTabPanel::apply_event`'s `ToolCallComplete` arm in `crates/tui/src/child_tabs.rs`) resolved live tool-call rows via `.iter_mut().rev().find(...)`, which matches the *last* still-`Running` entry with a matching name (LIFO) instead of the *first* (FIFO) as the surrounding doc comment claims.
- With two parallel same-name calls in flight (e.g. two `navigate` calls to different URLs, A started before B), A's completion would get attached to B's live row and vice versa, showing the wrong output/status next to the wrong tool-call line in the transcript.
- Fix: drop `.rev()` in both locations so the first still-`Running` matching entry (in original insertion order) is resolved first, matching the documented FIFO intent. No behavior change for the common case of a single in-flight call per tool name.

## Test plan
- [x] Added `tool_call_complete_resolves_parallel_same_name_calls_fifo` in `crates/tui/src/repl_app/tests.rs`, asserting the first-started `navigate` call is resolved by the first completion and the second stays `Running`.
- [x] Added `test_tool_call_complete_resolves_parallel_same_name_calls_fifo` in `crates/tui/src/child_tabs.rs`, same scenario through `ChildTabPanel::apply_event`.
- [x] `cargo fmt -p acrawl-tui`
- [x] `cargo test -p acrawl-tui` (all 169 tests pass)
- [x] `cargo clippy -p acrawl-tui --all-targets -- -D warnings` (clean)