### PR TITLE
fix: repair mojibake in user-facing strings and comments

### DIFF
--- a/crates/tui/src/child_tabs.rs
+++ b/crates/tui/src/child_tabs.rs
@@ -224,9 +224,9 @@ impl ChildTabPanel {
                 }
 
                 let message = if *success {
-                    format!("鉁?Done -- {items_extracted} items extracted")
+                    format!("✓ Done -- {items_extracted} items extracted")
                 } else {
-                    format!("鉁?Error: {}", error.as_deref().unwrap_or("unknown error"))
+                    format!("✗ Error: {}", error.as_deref().unwrap_or("unknown error"))
                 };
                 tab.entries.push(TranscriptEntry::System(message));
             }
@@ -499,7 +499,7 @@ mod tests {
                 input_summary: "url".to_string(),
             },
         );
-        // Don't complete the tool 鈥?let Finished interrupt it
+        // Don't complete the tool — let Finished interrupt it
         panel.apply_event(
             "child-1",
             "goal",

--- a/crates/ui/src/app/turn.rs
+++ b/crates/ui/src/app/turn.rs
@@ -38,7 +38,7 @@ impl LiveCli {
         let mut spinner = Spinner::new();
         let mut stdout = io::stdout();
         spinner.tick(
-            "馃暦锔廡hinking...",
+            "🕷️Thinking...",
             TerminalRenderer::new().color_theme(),
             &mut stdout,
         )?;
@@ -46,11 +46,7 @@ impl LiveCli {
         match result {
             Ok(summary) => {
                 self.capture_child_sessions();
-                spinner.finish(
-                    "鉁匘one",
-                    TerminalRenderer::new().color_theme(),
-                    &mut stdout,
-                )?;
+                spinner.finish("✅Done", TerminalRenderer::new().color_theme(), &mut stdout)?;
                 println!();
                 if let Some(event) = summary.auto_compaction {
                     println!(
@@ -63,7 +59,7 @@ impl LiveCli {
             }
             Err(error) => {
                 spinner.fail(
-                    "鉂孯equest failed",
+                    "❌Request failed",
                     TerminalRenderer::new().color_theme(),
                     &mut stdout,
                 )?;

--- a/crates/ui/src/auth/mod.rs
+++ b/crates/ui/src/auth/mod.rs
@@ -49,7 +49,7 @@ pub fn bind_oauth_listener(preferred_port: u16) -> io::Result<(TcpListener, u16)
                     io::ErrorKind::AddrInUse,
                     format!(
                         "Port {preferred_port} is already in use. \
-                         A previous auth session may still be running 鈥?\
+                         A previous auth session may still be running — \
                          close it or kill the process using the port, then retry."
                     ),
                 ));
@@ -60,7 +60,7 @@ pub fn bind_oauth_listener(preferred_port: u16) -> io::Result<(TcpListener, u16)
     unreachable!()
 }
 
-/// Result of provider selection 鈥?either a legacy enum variant or a preset provider.
+/// Result of provider selection — either a legacy enum variant or a preset provider.
 #[derive(Debug, Clone)]
 pub enum ProviderChoice {
     Legacy(Provider),
@@ -85,7 +85,7 @@ pub fn run_auth_cli(provider: Option<&str>) -> Result<(), Box<dyn std::error::Er
         ProviderChoice::Legacy(target) => run_auth_for_provider(target)?,
         ProviderChoice::Preset(ref preset) => run_preset_auth(preset)?,
     }
-    eprintln!("鉁?{label} credentials configured successfully.");
+    eprintln!("✓ {label} credentials configured successfully.");
     Ok(())
 }
 
@@ -354,7 +354,7 @@ pub fn interactive_login_prompt(choice: &ProviderChoice) -> Result<(), Box<dyn s
             io::stdin().read_line(&mut answer)?;
             let answer = answer.trim();
             if !answer.is_empty() && !answer.eq_ignore_ascii_case("y") {
-                return Err("authentication required 鈥?run `acrawl auth anthropic`".into());
+                return Err("authentication required — run `acrawl auth anthropic`".into());
             }
             run_auth_for_provider(Provider::Anthropic)
         }
@@ -369,7 +369,7 @@ pub fn interactive_login_prompt(choice: &ProviderChoice) -> Result<(), Box<dyn s
             io::stdin().read_line(&mut answer)?;
             let answer = answer.trim();
             if !answer.is_empty() && !answer.eq_ignore_ascii_case("y") {
-                return Err("authentication required 鈥?run `acrawl auth other`".into());
+                return Err("authentication required — run `acrawl auth other`".into());
             }
             run_auth_for_provider(Provider::Other)
         }
@@ -384,7 +384,7 @@ pub fn interactive_login_prompt(choice: &ProviderChoice) -> Result<(), Box<dyn s
             let answer = answer.trim();
             if !answer.is_empty() && !answer.eq_ignore_ascii_case("y") {
                 return Err(
-                    format!("authentication required 鈥?run `acrawl auth {}`", preset.id).into(),
+                    format!("authentication required — run `acrawl auth {}`", preset.id).into(),
                 );
             }
             run_preset_auth(preset)
@@ -679,7 +679,7 @@ mod tests {
         let presets = api::builtin_presets();
         assert!(!presets.is_empty(), "should have presets");
         for p in &presets {
-            // Every preset has some category 鈥?verify it compiles and returns a value
+            // Every preset has some category — verify it compiles and returns a value
             let _ = format!("{:?}", p.category);
         }
     }

--- a/crates/ui/src/output_sink.rs
+++ b/crates/ui/src/output_sink.rs
@@ -1,4 +1,4 @@
-//! `ChannelSink` 鈥?bridges runtime events to the TUI via channel.
+//! `ChannelSink` — bridges runtime events to the TUI via channel.
 
 use std::sync::mpsc;
 


### PR DESCRIPTION
## Summary
- Several string literals and comments in `crates/tui` and `crates/ui` were corrupted by a UTF-8<->GBK encoding round-trip at some point, rendering as garbled CJK-looking characters followed by artifacts (e.g. `"鉁?Done"` where `"✓ Done"` was clearly intended).
- Restored the correctly-encoded UTF-8 text in the 4 files called out in the review, inferring intent from context (status/error symbols, em dashes) and cross-checking against an already-correct sibling code path (`draw_child_view` in `repl_render.rs` already uses `"✓ Done"` / `"✗ Error"` for the same status, confirming the intended fix for `child_tabs.rs`):
  - `crates/tui/src/child_tabs.rs`: child-goal success/error status messages (`✓ Done ...` / `✗ Error: ...`) and a test comment (em dash)
  - `crates/ui/src/output_sink.rs`: module doc comment (em dash)
  - `crates/ui/src/auth/mod.rs`: several user-facing error/confirmation messages and doc/test comments (em dashes, `✓` confirmation)
  - `crates/ui/src/app/turn.rs`: CLI spinner tick/finish/fail messages (`🕷️Thinking...`, `✅Done`, `❌Request failed`)
- Also grepped both crate trees for any other mojibake byte patterns and confirmed no other instances exist outside these 4 files.
- Diff is strictly limited to fixing corrupted string/comment literals; one line was mechanically re-joined by `cargo fmt` as a side effect of a string getting shorter, no logic changed.

## Test plan
- [x] `grep`-style search across `crates/tui` and `crates/ui` confirms no remaining mojibake byte sequences
- [x] `cargo fmt -p acrawl-tui -p acrawl-ui`
- [x] `cargo test -p acrawl-tui` (all tests pass)
- [x] `cargo test -p acrawl-ui` (all tests pass)
- [x] `cargo clippy -p acrawl-tui -p acrawl-ui --all-targets -- -D warnings` (clean)