### PR TITLE
fix: correlate MCP JSON-RPC responses by id

### DIFF
--- a/crates/runtime/src/mcp/process.rs
+++ b/crates/runtime/src/mcp/process.rs
@@ -4,7 +4,7 @@ use std::process::Stdio;
 
 use acrawl_core::child_stderr;
 use serde::de::DeserializeOwned;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
@@ -142,6 +142,10 @@ impl McpStdioProcess {
         self.write_frame(&body).await
     }
 
+    // Raw protocol primitives kept for tests that exercise framing directly
+    // (without id correlation); production callers go through `request()`,
+    // which uses `read_response_matching` instead.
+    #[allow(dead_code)]
     pub async fn read_jsonrpc_message<T: DeserializeOwned>(&mut self) -> io::Result<T> {
         let payload = self.read_frame().await?;
         serde_json::from_slice(&payload)
@@ -162,8 +166,41 @@ impl McpStdioProcess {
         self.write_jsonrpc_message(notification).await
     }
 
+    #[allow(dead_code)]
     pub async fn read_response<T: DeserializeOwned>(&mut self) -> io::Result<JsonRpcResponse<T>> {
         self.read_jsonrpc_message().await
+    }
+
+    /// Read response frames until one whose `id` matches `expected_id` is
+    /// found, discarding any that don't.
+    ///
+    /// A request that a caller previously gave up on (e.g. after a timeout)
+    /// may still get a response from the child process later — the request
+    /// bytes were already written to stdin before the timeout fired, so the
+    /// child has no idea its caller stopped listening. Without this loop,
+    /// the next unrelated `request()` call would read that stale frame and
+    /// return its contents as if they belonged to its own request,
+    /// permanently desyncing every subsequent call on this connection by
+    /// one frame.
+    async fn read_response_matching<T: DeserializeOwned>(
+        &mut self,
+        expected_id: &JsonRpcId,
+    ) -> io::Result<JsonRpcResponse<T>> {
+        #[derive(Deserialize)]
+        struct IdProbe {
+            id: JsonRpcId,
+        }
+
+        loop {
+            let payload = self.read_frame().await?;
+            let probe: IdProbe = serde_json::from_slice(&payload)
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+            if &probe.id != expected_id {
+                continue;
+            }
+            return serde_json::from_slice(&payload)
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error));
+        }
     }
 
     pub async fn request<TParams: Serialize, TResult: DeserializeOwned>(
@@ -172,9 +209,9 @@ impl McpStdioProcess {
         method: impl Into<String>,
         params: Option<TParams>,
     ) -> io::Result<JsonRpcResponse<TResult>> {
-        let request = JsonRpcRequest::new(id, method, params);
+        let request = JsonRpcRequest::new(id.clone(), method, params);
         self.send_request(&request).await?;
-        self.read_response().await
+        self.read_response_matching(&id).await
     }
 
     pub async fn initialize(
@@ -738,6 +775,79 @@ while True:
 
             let status = process.wait().await.expect("wait for exit");
             assert!(status.success());
+
+            cleanup_script(&script_path);
+        });
+    }
+
+    /// Server that first writes a "stale" response for an id that was never
+    /// requested (simulating a response left over in the pipe from a
+    /// previously timed-out request), then writes the real response for
+    /// whatever request it actually received.
+    fn write_stale_response_script() -> PathBuf {
+        let root = temp_dir();
+        fs::create_dir_all(&root).expect("temp dir");
+        let script_path = root.join("stale-response-mcp.py");
+        let script = [
+            "#!/usr/bin/env python3",
+            "import json, sys",
+            "",
+            "def read_message():",
+            "    header = b''",
+            r"    while not header.endswith(b'\r\n\r\n'):",
+            "        chunk = sys.stdin.buffer.read(1)",
+            "        if not chunk:",
+            "            return None",
+            "        header += chunk",
+            "    length = 0",
+            r"    for line in header.decode().split('\r\n'):",
+            r"        if line.lower().startswith('content-length:'):",
+            r"            length = int(line.split(':', 1)[1].strip())",
+            "    payload = sys.stdin.buffer.read(length)",
+            "    return json.loads(payload.decode())",
+            "",
+            "def send_message(message):",
+            "    payload = json.dumps(message).encode()",
+            r"    sys.stdout.buffer.write(f'Content-Length: {len(payload)}\r\n\r\n'.encode() + payload)",
+            "    sys.stdout.buffer.flush()",
+            "",
+            "request = read_message()",
+            "send_message({'jsonrpc': '2.0', 'id': 999999, 'result': {'tools': []}})",
+            "send_message({'jsonrpc': '2.0', 'id': request['id'], 'result': {'tools': [{",
+            "    'name': 'real',",
+            "    'description': 'the real response',",
+            "    'inputSchema': {'type': 'object'}",
+            "}]}})",
+            "",
+        ]
+        .join("\n");
+        fs::write(&script_path, script).expect("write script");
+        let mut permissions = fs::metadata(&script_path).expect("metadata").permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script_path, permissions).expect("chmod");
+        script_path
+    }
+
+    #[test]
+    fn request_skips_stale_response_and_returns_the_matching_one() {
+        let runtime = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        runtime.block_on(async {
+            let script_path = write_stale_response_script();
+            let transport = script_transport(&script_path);
+            let mut process = McpStdioProcess::spawn(&transport).expect("spawn transport directly");
+
+            let response = process
+                .list_tools(JsonRpcId::Number(42), None)
+                .await
+                .expect("list_tools should skip the stale frame and return the matching one");
+
+            assert_eq!(response.id, JsonRpcId::Number(42));
+            let result = response.result.expect("result present");
+            assert_eq!(result.tools.len(), 1);
+            assert_eq!(result.tools[0].name, "real");
 
             cleanup_script(&script_path);
         });

--- a/crates/runtime/src/mcp/server_manager.rs
+++ b/crates/runtime/src/mcp/server_manager.rs
@@ -1,7 +1,8 @@
 use std::collections::BTreeMap;
+use std::io;
 
 use serde_json::Value as JsonValue;
-use tokio::time::{timeout, Duration};
+use tokio::time::{error::Elapsed, timeout, Duration};
 
 use crate::config::{McpServerConfig, McpTransport, RuntimeConfig};
 
@@ -97,7 +98,7 @@ impl McpServerManager {
             let mut cursor = None;
             loop {
                 let request_id = self.take_request_id();
-                let response = {
+                let outcome = {
                     let server = self.server_mut(&server_name)?;
                     let process = server.process.as_mut().ok_or_else(|| {
                         McpServerManagerError::InvalidResponse {
@@ -119,12 +120,8 @@ impl McpServerManager {
                         ),
                     )
                     .await
-                    .map_err(|_| McpServerManagerError::Timeout {
-                        server_name: server_name.clone(),
-                        method: "tools/list",
-                        timeout: MCP_REQUEST_TIMEOUT,
-                    })??
                 };
+                let response = self.finish_timeout(&server_name, "tools/list", outcome)?;
 
                 if let Some(error) = response.error {
                     return Err(McpServerManagerError::JsonRpc {
@@ -185,7 +182,7 @@ impl McpServerManager {
 
         self.ensure_server_ready(&route.server_name).await?;
         let request_id = self.take_request_id();
-        let response =
+        let outcome =
             {
                 let server = self.server_mut(&route.server_name)?;
                 let process = server.process.as_mut().ok_or_else(|| {
@@ -207,12 +204,8 @@ impl McpServerManager {
                     ),
                 )
                 .await
-                .map_err(|_| McpServerManagerError::Timeout {
-                    server_name: route.server_name.clone(),
-                    method: "tools/call",
-                    timeout: MCP_REQUEST_TIMEOUT,
-                })??
             };
+        let response = self.finish_timeout(&route.server_name, "tools/call", outcome)?;
         Ok(response)
     }
 
@@ -256,6 +249,44 @@ impl McpServerManager {
         JsonRpcId::Number(id)
     }
 
+    /// Drop a server's process/connection state after an unrecoverable
+    /// failure (currently: a request timeout). The request bytes for a
+    /// timed-out call were already written to the child's stdin, so the
+    /// child may still write a response for it later. Rather than risk a
+    /// later, unrelated call reading that stale frame off the same stream,
+    /// kill the process (`McpStdioProcess`'s `Drop` impl kills the child)
+    /// and mark the server as needing a fresh spawn + handshake on its next
+    /// use.
+    fn invalidate_server(&mut self, server_name: &str) {
+        if let Some(server) = self.servers.get_mut(server_name) {
+            server.process = None;
+            server.initialized = false;
+        }
+    }
+
+    /// Resolve the result of a `timeout(...).await` call. On success,
+    /// unwraps the inner `io::Result`. On timeout, invalidates the server's
+    /// connection (see [`Self::invalidate_server`]) and returns
+    /// [`McpServerManagerError::Timeout`].
+    fn finish_timeout<T>(
+        &mut self,
+        server_name: &str,
+        method: &'static str,
+        outcome: Result<io::Result<T>, Elapsed>,
+    ) -> Result<T, McpServerManagerError> {
+        match outcome {
+            Ok(inner) => Ok(inner?),
+            Err(_elapsed) => {
+                self.invalidate_server(server_name);
+                Err(McpServerManagerError::Timeout {
+                    server_name: server_name.to_string(),
+                    method,
+                    timeout: MCP_REQUEST_TIMEOUT,
+                })
+            }
+        }
+    }
+
     async fn ensure_server_ready(
         &mut self,
         server_name: &str,
@@ -284,7 +315,7 @@ impl McpServerManager {
 
         if needs_initialize {
             let request_id = self.take_request_id();
-            let response = {
+            let outcome = {
                 let server = self.server_mut(server_name)?;
                 let process = server.process.as_mut().ok_or_else(|| {
                     McpServerManagerError::InvalidResponse {
@@ -301,12 +332,8 @@ impl McpServerManager {
                     process.initialize(request_id, default_initialize_params()),
                 )
                 .await
-                .map_err(|_| McpServerManagerError::Timeout {
-                    server_name: server_name.to_string(),
-                    method: "initialize",
-                    timeout: MCP_REQUEST_TIMEOUT,
-                })??
             };
+            let response = self.finish_timeout(server_name, "initialize", outcome)?;
 
             if let Some(error) = response.error {
                 return Err(McpServerManagerError::JsonRpc {
@@ -325,24 +352,21 @@ impl McpServerManager {
             }
 
             {
-                let server = self.server_mut(server_name)?;
-                let process = server.process.as_mut().ok_or_else(|| {
-                    McpServerManagerError::InvalidResponse {
-                        server_name: server_name.to_string(),
-                        method: "notifications/initialized",
-                        details: "MCP server process is gone after initialize but before \
+                let outcome = {
+                    let server = self.server_mut(server_name)?;
+                    let process = server.process.as_mut().ok_or_else(|| {
+                        McpServerManagerError::InvalidResponse {
+                            server_name: server_name.to_string(),
+                            method: "notifications/initialized",
+                            details: "MCP server process is gone after initialize but before \
                                   the initialized notification — the server probably exited mid-handshake; \
                                   check the server's stderr output above and retry"
-                            .to_string(),
-                    }
-                })?;
-                timeout(MCP_REQUEST_TIMEOUT, process.notify_initialized())
-                    .await
-                    .map_err(|_| McpServerManagerError::Timeout {
-                        server_name: server_name.to_string(),
-                        method: "notifications/initialized",
-                        timeout: MCP_REQUEST_TIMEOUT,
-                    })??;
+                                .to_string(),
+                        }
+                    })?;
+                    timeout(MCP_REQUEST_TIMEOUT, process.notify_initialized()).await
+                };
+                self.finish_timeout(server_name, "notifications/initialized", outcome)?;
             }
 
             let server = self.server_mut(server_name)?;


### PR DESCRIPTION
## Summary
- `McpStdioProcess::request` read whatever JSON-RPC frame came next on stdout without checking its `id` matched the outstanding request. `McpServerManager` wraps every call in a 30s `timeout(...)`, which drops the in-flight read future when it fires — but the request bytes were already written to the child's stdin, so the child still writes a response eventually. That stale frame sat in the pipe and was silently read as the response to the *next* call on that connection, permanently desyncing the stream by one frame from then on.
- `McpStdioProcess::request` now loops on `read_frame`, discarding any response whose `id` doesn't match the outstanding request, until it finds the matching one.
- `McpServerManager` now invalidates a server's connection (drops the process, which kills the child, and clears the `initialized` flag) whenever a request to it times out, forcing a fresh spawn + handshake on the next call instead of reusing a now-unreliable stream. Applied to `initialize`, `notifications/initialized`, `tools/list`, and `tools/call`.

## Test plan
- [x] `cargo fmt`
- [x] `cargo test -p runtime` (174 tests pass on Windows; added `request_skips_stale_response_and_returns_the_matching_one` in `crates/runtime/src/mcp/process.rs`, gated `#[cfg(all(test, unix))]` like the rest of the MCP stdio process tests, so it exercises id correlation against a fake stdio MCP server on unix CI)
- [x] `cargo clippy -p runtime --all-targets -- -D warnings` (clean)
- [x] `cargo check --workspace` (clean)