### PR TITLE
fix: normalize URLs before comparing/storing claims

### DIFF
--- a/crates/agent/src/url_claim.rs
+++ b/crates/agent/src/url_claim.rs
@@ -121,7 +121,7 @@ impl UrlClaimRegistry {
         match scope {
             CrawlScope::SinglePage { url } => {
                 let normalized = normalize_url(url).to_string();
-                check_and_insert_exact(&mut guard, &normalized, owner_id)?;
+                check_and_insert_exact(&mut guard, &normalized, Some(url), owner_id)?;
                 Ok(ClaimGuard {
                     registry: Arc::clone(&self.inner),
                     keys: vec![ClaimKey::Exact(normalized)],
@@ -139,7 +139,7 @@ impl UrlClaimRegistry {
 
                 // All-or-nothing: validate every URL before inserting any.
                 for url in &normalized_urls {
-                    check_exact(&guard, url, owner_id)?;
+                    check_exact(&guard, url, None, owner_id)?;
                 }
                 // Deduplicate within the submitted list; the LLM may
                 // accidentally list the same URL twice (or two URLs that
@@ -194,15 +194,20 @@ impl UrlClaimRegistry {
     }
 }
 
-fn check_exact(inner: &Inner, url: &str, _owner_id: &str) -> Result<(), ClaimConflict> {
+fn check_exact(
+    inner: &Inner,
+    normalized_url: &str,
+    raw_url: Option<&str>,
+    _owner_id: &str,
+) -> Result<(), ClaimConflict> {
     for entry in &inner.entries {
         match entry {
             Entry::Exact {
                 url: claimed,
                 owner,
-            } if claimed == url => {
+            } if claimed == normalized_url => {
                 return Err(ClaimConflict::ExactUrl {
-                    url: url.to_string(),
+                    url: normalized_url.to_string(),
                     owner: owner.clone(),
                 });
             }
@@ -210,14 +215,23 @@ fn check_exact(inner: &Inner, url: &str, _owner_id: &str) -> Result<(), ClaimCon
                 regex,
                 source,
                 owner,
-            } if regex.is_match(url) => {
-                return Err(ClaimConflict::PatternMatchesExact {
-                    regex: source.clone(),
-                    url: url.to_string(),
-                    owner: owner.clone(),
-                });
+            } => {
+                // Test the normalized URL against the pattern (the common
+                // case).  If that doesn't match, also test the raw
+                // pre-normalization URL — a pattern may include a fragment
+                // that `normalize_url` strips (e.g. `#section`), so the
+                // normalized URL no longer matches the regex.
+                let pattern_matches = regex.is_match(normalized_url)
+                    || raw_url.is_some_and(|raw| regex.is_match(raw));
+                if pattern_matches {
+                    return Err(ClaimConflict::PatternMatchesExact {
+                        regex: source.clone(),
+                        url: normalized_url.to_string(),
+                        owner: owner.clone(),
+                    });
+                }
             }
-            _ => {}
+            Entry::Exact { .. } => {}
         }
     }
     Ok(())
@@ -225,12 +239,13 @@ fn check_exact(inner: &Inner, url: &str, _owner_id: &str) -> Result<(), ClaimCon
 
 fn check_and_insert_exact(
     inner: &mut Inner,
-    url: &str,
+    normalized_url: &str,
+    raw_url: Option<&str>,
     owner_id: &str,
 ) -> Result<(), ClaimConflict> {
-    check_exact(inner, url, owner_id)?;
+    check_exact(inner, normalized_url, raw_url, owner_id)?;
     inner.entries.push(Entry::Exact {
-        url: url.to_string(),
+        url: normalized_url.to_string(),
         owner: owner_id.to_string(),
     });
     Ok(())
@@ -365,6 +380,34 @@ mod tests {
             ClaimConflict::ExactUrl { ref url, ref owner }
                 if url == "https://example.com/a" && owner == "child-1"
         ));
+    }
+
+    #[test]
+    fn exact_url_conflicts_with_existing_pattern_that_includes_fragment() {
+        // A pattern claimed with a fragment regex should block a later
+        // SinglePage claim whose normalized URL doesn't match the regex
+        // but whose raw URL does (because normalize_url strips fragments).
+        let registry = UrlClaimRegistry::new();
+        let _pat = registry
+            .try_claim(
+                &CrawlScope::UrlPattern {
+                    regex: r"^https://example\.com/a#section$".to_string(),
+                },
+                "child-1",
+            )
+            .unwrap();
+        let err = registry
+            .try_claim(
+                &CrawlScope::SinglePage {
+                    url: "https://example.com/a#section".to_string(),
+                },
+                "child-2",
+            )
+            .expect_err(
+                "raw URL with fragment should conflict with pattern \
+                 that includes the same fragment",
+            );
+        assert!(matches!(err, ClaimConflict::PatternMatchesExact { .. }));
     }
 
     #[test]

--- a/crates/agent/src/url_claim.rs
+++ b/crates/agent/src/url_claim.rs
@@ -8,7 +8,13 @@
 //! claim is released and another sibling may claim the same scope.
 //!
 //! Overlap policy:
-//! - exact-vs-exact: same URL string fails the second claim.
+//! - exact-vs-exact: same URL string fails the second claim. Exact URLs are
+//!   run through [`normalize_url`] (the same helper `page_map`/`navigate`
+//!   use for their own caching) before comparison and storage, so e.g.
+//!   `https://example.com/a` and `https://example.com/a#section` are
+//!   treated as the same claim rather than silently overlapping (see
+//!   `normalize_url` for exactly which fragment/URL forms collapse
+//!   together).
 //! - pattern-vs-pattern: identical regex source fails (conservative; subtly
 //!   different but semantically overlapping regexes are an accepted
 //!   footgun).
@@ -20,6 +26,7 @@ use std::sync::{Arc, Mutex};
 
 use regex::Regex;
 
+use crate::tools::page_map::normalize_url;
 use crate::CrawlScope;
 
 /// Reason a claim was rejected. Surfaced to the LLM so it can adjust scope.
@@ -113,28 +120,39 @@ impl UrlClaimRegistry {
 
         match scope {
             CrawlScope::SinglePage { url } => {
-                check_and_insert_exact(&mut guard, url, owner_id)?;
+                let normalized = normalize_url(url).to_string();
+                check_and_insert_exact(&mut guard, &normalized, owner_id)?;
                 Ok(ClaimGuard {
                     registry: Arc::clone(&self.inner),
-                    keys: vec![ClaimKey::Exact(url.clone())],
+                    keys: vec![ClaimKey::Exact(normalized)],
                 })
             }
             CrawlScope::UrlList { urls } => {
+                // Normalize up front so overlap checks, storage, and the
+                // intra-list dedup below all agree on the canonical form
+                // (e.g. a trailing slash or `#fragment` shouldn't let two
+                // URLs that resolve to the same page both get claimed).
+                let normalized_urls: Vec<String> = urls
+                    .iter()
+                    .map(|url| normalize_url(url).to_string())
+                    .collect();
+
                 // All-or-nothing: validate every URL before inserting any.
-                for url in urls {
+                for url in &normalized_urls {
                     check_exact(&guard, url, owner_id)?;
                 }
                 // Deduplicate within the submitted list; the LLM may
-                // accidentally list the same URL twice.
+                // accidentally list the same URL twice (or two URLs that
+                // normalize to the same one).
                 let mut seen = std::collections::HashSet::new();
                 let mut keys = Vec::new();
-                for url in urls {
-                    if seen.insert(url.as_str()) {
+                for url in normalized_urls {
+                    if seen.insert(url.clone()) {
                         guard.entries.push(Entry::Exact {
                             url: url.clone(),
                             owner: owner_id.to_string(),
                         });
-                        keys.push(ClaimKey::Exact(url.clone()));
+                        keys.push(ClaimKey::Exact(url));
                     }
                 }
                 Ok(ClaimGuard {
@@ -312,6 +330,36 @@ mod tests {
                 "child-2",
             )
             .expect_err("duplicate claim should fail");
+        assert!(matches!(
+            err,
+            ClaimConflict::ExactUrl { ref url, ref owner }
+                if url == "https://example.com/a" && owner == "child-1"
+        ));
+    }
+
+    #[test]
+    fn single_page_claim_blocks_fragment_only_variant_of_claimed_url() {
+        let registry = UrlClaimRegistry::new();
+        let _g = registry
+            .try_claim(
+                &CrawlScope::SinglePage {
+                    url: "https://example.com/a".to_string(),
+                },
+                "child-1",
+            )
+            .expect("first claim should succeed");
+
+        // Same page, differing only by a plain (non-route) fragment — this
+        // must normalize to the same claim as "https://example.com/a" so
+        // sibling forks can't be handed overlapping scope.
+        let err = registry
+            .try_claim(
+                &CrawlScope::SinglePage {
+                    url: "https://example.com/a#section".to_string(),
+                },
+                "child-2",
+            )
+            .expect_err("fragment-only variant should collide with the claimed url");
         assert!(matches!(
             err,
             ClaimConflict::ExactUrl { ref url, ref owner }


### PR DESCRIPTION
## Summary
- `UrlClaimRegistry` compared/stored exact-URL claims (`SinglePage`, `UrlList`) with raw `String` equality instead of the `normalize_url` helper `page_map.rs`/`navigate.rs` already use for their own caching.
- Two sibling forks claiming e.g. `https://example.com/a` and `https://example.com/a#section` could both succeed, defeating the "no overlapping scopes" guarantee.
- Fixed by normalizing both sides of exact-URL comparisons and storage (including the guard's release key, and the `UrlList` intra-list dedup) through `crate::tools::page_map::normalize_url`.

## Test plan
- [x] `cargo fmt --package agent`
- [x] `cargo test -p agent` (all existing `url_claim` tests pass, plus new regression test `single_page_claim_blocks_fragment_only_variant_of_claimed_url`)
- [x] `cargo clippy -p agent --all-targets -- -D warnings` (clean)