### PR TITLE
fix: use JSON string escaping in fill_form submit JS

### DIFF
--- a/crates/agent/src/tools/fill_form.rs
+++ b/crates/agent/src/tools/fill_form.rs
@@ -8,6 +8,7 @@ use crate::BrowserContext;
 use crate::{CrawlError, ToolEffect, ToolExecutionError};
 
 use super::feedback::InteractionKind;
+use super::select_option::js_string;
 
 #[derive(Debug)]
 struct FillFormInput {
@@ -83,17 +84,17 @@ pub async fn execute(
     if params.submit {
         let pre_url = eval_str(browser, "window.location.href").await;
 
+        let form_selector_json = js_string(&resolved_form_selector)?;
         let js = format!(
             r#"(() => {{
-                const form = document.querySelector('{}');
+                const form = document.querySelector({form_selector_json});
                 if (!form) return 'form_not_found';
                 const btn = form.querySelector('button[type="submit"], input[type="submit"], button:not([type])');
                 if (btn) {{ btn.click(); return 'clicked'; }}
                 const evt = new Event('submit', {{ bubbles: true, cancelable: true }});
                 if (form.dispatchEvent(evt)) form.submit();
                 return 'dispatched';
-            }})()"#,
-            resolved_form_selector.replace('\'', "\\'")
+            }})()"#
         );
         let submit_result = browser
             .acquire_bridge()
@@ -374,6 +375,24 @@ mod tests {
         let result = parse_input(&input).unwrap();
         assert!(result.submit);
         assert_eq!(result.form_selector, "#search-form");
+    }
+
+    #[test]
+    fn submit_js_selector_uses_json_escaping_not_naive_quote_replace() {
+        // A selector containing a backslash immediately before what would
+        // become an escaped quote used to break out of the JS string
+        // literal when only single quotes were escaped via
+        // `.replace('\'', "\\'")`. js_string (serde_json) must escape it
+        // safely instead.
+        let selector = r"div[data-x='a\']";
+        let encoded = js_string(selector).expect("js_string should encode any string");
+
+        // Must be a valid JSON/JS string literal that decodes back to
+        // exactly the original selector.
+        let decoded: String =
+            serde_json::from_str(&encoded).expect("encoded value must be a valid JSON string");
+        assert_eq!(decoded, selector);
+        assert!(encoded.starts_with('"') && encoded.ends_with('"'));
     }
 
     #[test]

--- a/crates/agent/src/tools/select_option.rs
+++ b/crates/agent/src/tools/select_option.rs
@@ -991,7 +991,10 @@ fn evaluate_payload(value: &Value) -> &Value {
     value.get("value").unwrap_or(value)
 }
 
-fn js_string(value: &str) -> Result<String, ToolExecutionError> {
+/// Encode `value` as a JSON string literal suitable for splicing into a JS
+/// snippet (proper escaping of quotes, backslashes, control characters,
+/// etc.) — the safe alternative to ad hoc `.replace('\'', "\\'")` patching.
+pub(crate) fn js_string(value: &str) -> Result<String, ToolExecutionError> {
     serde_json::to_string(value).map_err(|e| ToolExecutionError::new(e.to_string()))
 }
 


### PR DESCRIPTION
## Summary
- `fill_form.rs`'s submit path built JS via `resolved_form_selector.replace('\'', "\\'")`, which escapes single quotes but not backslashes — a selector containing a backslash right before what becomes an escaped quote could break out of the string literal.
- Replaced with `select_option.rs`'s existing `js_string()` helper (now `pub(crate)`), which uses `serde_json::to_string` for correct JS/JSON string escaping — matching the pattern already used everywhere else in `select_option.rs`.

## Test plan
- [x] `cargo fmt --package agent`
- [x] `cargo test -p agent` (all existing `fill_form` tests pass, plus new regression test `submit_js_selector_uses_json_escaping_not_naive_quote_replace`)
- [x] `cargo clippy -p agent --all-targets -- -D warnings` (clean)