### PR TITLE
fix: reject path traversal in PlaywrightBridge::save_file

### DIFF
--- a/crates/browser/src/playwright/bridge.rs
+++ b/crates/browser/src/playwright/bridge.rs
@@ -606,6 +606,12 @@ impl PlaywrightBridge {
         path: &str,
         headers: Option<&BTreeMap<String, String>>,
     ) -> Result<String, BridgeError> {
+        if path.contains("..") {
+            return Err(BridgeError::Protocol(
+                "save_file path contains path traversal".into(),
+            ));
+        }
+
         let headers_json = headers
             .map(|map| serde_json::to_value(map).unwrap_or(serde_json::json!({})))
             .unwrap_or(serde_json::json!({}));

--- a/crates/browser/src/playwright/bridge.rs
+++ b/crates/browser/src/playwright/bridge.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::path::{Component, Path};
 use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Duration;
@@ -606,7 +607,10 @@ impl PlaywrightBridge {
         path: &str,
         headers: Option<&BTreeMap<String, String>>,
     ) -> Result<String, BridgeError> {
-        if path.contains("..") {
+        if Path::new(path)
+            .components()
+            .any(|c| c == Component::ParentDir)
+        {
             return Err(BridgeError::Protocol(
                 "save_file path contains path traversal".into(),
             ));

--- a/crates/browser/src/playwright/tests.rs
+++ b/crates/browser/src/playwright/tests.rs
@@ -206,6 +206,52 @@ for line in sys.stdin:
 }
 
 #[tokio::test]
+async fn save_file_rejects_path_traversal() {
+    // Mirrors ExtensionBridge::save_file's ".." rejection so both
+    // BrowserBackend implementations enforce the same contract regardless
+    // of which backend a caller goes through. The fake bridge server only
+    // handles "close" — if save_file() ever sent a "save_file" command for
+    // a traversal path, this test would hang/fail rather than silently pass.
+    let script_path = write_python_script(
+        "save-file-guard",
+        r#"import json
+import sys
+print(json.dumps({"event": "bridge_bootstrap", "ok": True}), flush=True)
+for line in sys.stdin:
+    command = json.loads(line)
+    if command.get("action") == "close":
+        print(json.dumps({"event": "bridge_response", "ok": True}), flush=True)
+        break
+"#,
+    );
+
+    let mut bridge = PlaywrightBridge::new_with_invocation(
+        python_program(),
+        vec![script_path.to_string_lossy().into_owned()],
+        Duration::from_secs(2),
+    )
+    .await
+    .expect("bridge should bootstrap");
+
+    let result = bridge
+        .save_file("https://example.com/file", "../evil.txt", None)
+        .await;
+
+    match result {
+        Err(BridgeError::Protocol(message)) => {
+            assert!(
+                message.contains("path traversal"),
+                "unexpected message: {message}"
+            );
+        }
+        other => panic!("expected Protocol error for path traversal, got {other:?}"),
+    }
+
+    bridge.close().await.expect("close should succeed");
+    cleanup_temp_script(&script_path);
+}
+
+#[tokio::test]
 async fn command_timeout_does_not_desync_next_response() {
     // Regression test for issue #69: a command whose read times out client-side
     // still gets a response from the bridge process eventually (it's just late).


### PR DESCRIPTION
## Summary
- `PlaywrightBridge::save_file` (`crates/browser/src/playwright/bridge.rs`)
  had no path validation, while `ExtensionBridge::save_file`
  (`crates/browser/src/extension.rs`) already rejects `..` in the target
  path. Both implement the same `BrowserBackend` trait method with
  different contracts.
- The primary product-facing gate is
  `crates/agent/src/tools/save_file.rs`'s own canonicalization check
  (already solid, reviewed separately), so this is defense-in-depth, not
  the only guard. This closes the gap so both trait implementations enforce
  the same contract regardless of which backend a future caller (tests,
  script_executor, a new tool) goes through.
- Adds the same `..` rejection `ExtensionBridge::save_file` already has to
  `PlaywrightBridge::save_file`.

## Test plan
- [x] `cargo fmt -p browser`
- [x] `cargo test -p browser` (176 passed, including new
      `save_file_rejects_path_traversal` test that spins up a fake bridge
      subprocess and asserts `save_file()` rejects a traversal path before
      ever sending a `"save_file"` command over the wire)
- [x] `cargo clippy -p browser --all-targets -- -D warnings` (clean)