### PR TITLE
fix: remove duplicate AuthModal title() inherent method

### DIFF
--- a/crates/tui/src/modals/auth/mod.rs
+++ b/crates/tui/src/modals/auth/mod.rs
@@ -521,25 +521,6 @@ impl AuthModal {
             _ => {}
         }
     }
-
-    fn title(&self) -> &str {
-        match &self.step {
-            AuthModalStep::ProviderSelect { .. } => " Auth ",
-            AuthModalStep::AuthMethodSelect { provider, .. }
-            | AuthModalStep::ApiKeyInput { provider, .. } => match provider {
-                ProviderKind::Anthropic => " Auth · Anthropic ",
-                ProviderKind::OpenAi => " Auth · OpenAI ",
-                ProviderKind::Other => " Auth · Other ",
-                ProviderKind::Preset(p) => p.display_name,
-            },
-            AuthModalStep::BaseUrlInput { .. } => " Auth · Base URL ",
-            AuthModalStep::OAuthWaiting { .. } => " Auth · Waiting ",
-            AuthModalStep::ModelFetchLoading { .. } => " Auth · Loading Models ",
-            AuthModalStep::ModelSelect { .. } => " Auth · Select Model ",
-            AuthModalStep::Success { .. } => " Auth · Success ",
-            AuthModalStep::Error { .. } => " Auth · Error ",
-        }
-    }
 }
 
 impl Modal for AuthModal {

--- a/crates/tui/src/modals/auth/tests.rs
+++ b/crates/tui/src/modals/auth/tests.rs
@@ -192,6 +192,26 @@ fn esc_from_auth_method_goes_back_to_provider_select() {
 }
 
 #[test]
+fn title_matches_through_direct_call_and_dyn_modal() {
+    let m = modal();
+    // Direct call resolves through the (sole) `Modal::title` impl.
+    assert_eq!(Modal::title(&m), " Auth ");
+    // Calling through `&dyn Modal` must produce the same title -- this is
+    // the scenario that broke when a private inherent `title` shadowed
+    // the trait method for direct calls but not for dyn dispatch.
+    let dyn_modal: &dyn Modal = &m;
+    assert_eq!(dyn_modal.title(), Modal::title(&m));
+
+    let openai_modal = modal_with_step(AuthModalStep::AuthMethodSelect {
+        provider: ProviderKind::OpenAi,
+        selected: 0,
+    });
+    assert_eq!(Modal::title(&openai_modal), " Auth · OpenAI ");
+    let dyn_openai: &dyn Modal = &openai_modal;
+    assert_eq!(dyn_openai.title(), Modal::title(&openai_modal));
+}
+
+#[test]
 fn esc_from_provider_select_closes_modal() {
     let mut modal = modal();
     assert_eq!(modal.handle_key(key(KeyCode::Esc)), ModalAction::Dismiss);

--- a/crates/tui/src/modals/auth/tests.rs
+++ b/crates/tui/src/modals/auth/tests.rs
@@ -195,7 +195,7 @@ fn esc_from_auth_method_goes_back_to_provider_select() {
 fn title_matches_through_direct_call_and_dyn_modal() {
     let m = modal();
     // Direct call resolves through the (sole) `Modal::title` impl.
-    assert_eq!(Modal::title(&m), " Auth ");
+    assert_eq!(m.title(), " Auth ");
     // Calling through `&dyn Modal` must produce the same title -- this is
     // the scenario that broke when a private inherent `title` shadowed
     // the trait method for direct calls but not for dyn dispatch.
@@ -206,7 +206,7 @@ fn title_matches_through_direct_call_and_dyn_modal() {
         provider: ProviderKind::OpenAi,
         selected: 0,
     });
-    assert_eq!(Modal::title(&openai_modal), " Auth · OpenAI ");
+    assert_eq!(openai_modal.title(), " Auth · OpenAI ");
     let dyn_openai: &dyn Modal = &openai_modal;
     assert_eq!(dyn_openai.title(), Modal::title(&openai_modal));
 }


### PR DESCRIPTION
## Summary
- `AuthModal` in `crates/tui/src/modals/auth/mod.rs` had two identical ~18-line `title()` implementations: a private inherent method and the `Modal` trait's `title()`.
- Rust resolves `self.title()` to the inherent method before the trait method, so `draw()` (which is defined inside `impl Modal for AuthModal`, but that doesn't change resolution) always used the private inherent copy, while any caller going through `&dyn Modal` (e.g. `ActiveModal::title()`) used the trait copy. The two were only kept in sync by coincidence, not by construction.
- Fix: delete the private inherent `title()` entirely. The two internal call sites inside `draw()` (`.title(self.title())` and `draw_modal_frame(frame, area, self.title(), ...)`) are unchanged in source and now resolve to the sole remaining `Modal::title()` impl.
- Added a test that calls `Modal::title()` directly and through `&dyn Modal` for two different modal steps and asserts they match, to guard against this class of shadowing bug regressing.

## Test plan
- [x] Added `title_matches_through_direct_call_and_dyn_modal` in `crates/tui/src/modals/auth/tests.rs`
- [x] `cargo build -p acrawl-tui` (compiles; `draw()`'s `self.title()` calls resolve cleanly to the trait method now that the inherent method is gone)
- [x] `cargo fmt -p acrawl-tui`
- [x] `cargo test -p acrawl-tui` (all tests pass, including the new one)
- [x] `cargo clippy -p acrawl-tui --all-targets -- -D warnings` (clean)