### PR TITLE
fix: stop double-stopping coverage session on reset

### DIFF
--- a/crates/agent/src/tools/coverage.rs
+++ b/crates/agent/src/tools/coverage.rs
@@ -46,7 +46,13 @@ pub async fn execute(
         .map_err(|e| ToolExecutionError::new(e.to_string()))?;
 
     if reset {
+        // Discard whatever had accumulated so far and start a fresh
+        // session. The final stop_coverage() below then reports against
+        // this fresh session instead of running a second, unpaired
+        // stop_coverage() call against an already-stopped one (which would
+        // error and silently fall back to empty data via unwrap_or_else).
         let _ = bridge.stop_coverage().await;
+        let _ = bridge.start_coverage(do_js, do_css).await;
     }
 
     let coverage_data = bridge
@@ -190,5 +196,32 @@ mod tests {
         assert_eq!(deduped[0].url, "https://x/b.js");
         assert_eq!(deduped[0].used_bytes, 9);
         assert_eq!(deduped[1].url, "https://x/a.js");
+    }
+
+    #[tokio::test]
+    async fn reset_true_never_issues_two_consecutive_stops_without_a_start() {
+        let (mut browser, log) = crate::tools::test_support::browser_with_coverage_log();
+
+        execute(&serde_json::json!({"reset": true}), &mut browser)
+            .await
+            .expect("measure_coverage should succeed");
+
+        let calls = log.lock().await.clone();
+        // Must alternate: the pre-reset stop is immediately paired with a
+        // fresh start before the real capture-stop runs, so a stop is never
+        // followed directly by another stop.
+        assert_eq!(calls, vec!["stop", "start", "stop", "start"]);
+    }
+
+    #[tokio::test]
+    async fn reset_false_stops_once_and_restarts() {
+        let (mut browser, log) = crate::tools::test_support::browser_with_coverage_log();
+
+        execute(&serde_json::json!({}), &mut browser)
+            .await
+            .expect("measure_coverage should succeed");
+
+        let calls = log.lock().await.clone();
+        assert_eq!(calls, vec!["stop", "start"]);
     }
 }

--- a/crates/agent/src/tools/test_support.rs
+++ b/crates/agent/src/tools/test_support.rs
@@ -8,14 +8,15 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use browser::{
-    BridgeError, BrowserBackend, BrowserContext, BrowserState, ObservationEvent, PageInfo,
-    ScreenshotOptions, SharedBridge, StorageEntry, StorageType,
+    BridgeError, BrowserBackend, BrowserContext, BrowserState, CoverageData, ObservationEvent,
+    PageInfo, ScreenshotOptions, SharedBridge, StorageEntry, StorageType,
 };
 use serde_json::{json, Value};
 use tokio::sync::Mutex;
 
 pub type SaveFileHeadersRecord = Arc<Mutex<Option<BTreeMap<String, String>>>>;
 pub type EvaluateScriptsRecord = Arc<Mutex<Vec<String>>>;
+pub type CoverageCallLog = Arc<Mutex<Vec<&'static str>>>;
 
 #[derive(Debug, Default)]
 pub struct ObservationMockBackend {
@@ -23,6 +24,11 @@ pub struct ObservationMockBackend {
     pub last_save_file_headers: Option<BTreeMap<String, String>>,
     pub save_file_headers_sink: Option<SaveFileHeadersRecord>,
     pub evaluate_scripts_sink: Option<EvaluateScriptsRecord>,
+    /// Records "start"/"stop" in call order when `start_coverage`/
+    /// `stop_coverage` are invoked, so tests can assert on the exact
+    /// sequence (e.g. that a stop is never immediately followed by another
+    /// stop with no intervening start).
+    pub coverage_log: Option<CoverageCallLog>,
 }
 
 #[async_trait]
@@ -146,6 +152,34 @@ impl BrowserBackend for ObservationMockBackend {
     ) -> Result<(Vec<StorageEntry>, Vec<StorageEntry>), BridgeError> {
         Ok((Vec::new(), Vec::new()))
     }
+    async fn start_coverage(&mut self, _js: bool, _css: bool) -> Result<(), BridgeError> {
+        if let Some(sink) = &self.coverage_log {
+            sink.lock().await.push("start");
+        }
+        Ok(())
+    }
+    async fn stop_coverage(&mut self) -> Result<CoverageData, BridgeError> {
+        if let Some(sink) = &self.coverage_log {
+            sink.lock().await.push("stop");
+        }
+        Ok(CoverageData {
+            js_coverage: Vec::new(),
+            css_coverage: Vec::new(),
+        })
+    }
+}
+
+#[must_use]
+pub fn browser_with_coverage_log() -> (BrowserContext, CoverageCallLog) {
+    let sink = Arc::new(Mutex::new(Vec::new()));
+    let bridge: SharedBridge = Arc::new(Mutex::new(Box::new(ObservationMockBackend {
+        observations: Vec::new(),
+        last_save_file_headers: None,
+        save_file_headers_sink: None,
+        evaluate_scripts_sink: None,
+        coverage_log: Some(sink.clone()),
+    }) as Box<dyn BrowserBackend + Send>));
+    (BrowserContext::new(bridge), sink)
 }
 
 #[must_use]
@@ -155,6 +189,7 @@ pub fn browser_with_observations(observations: Vec<ObservationEvent>) -> Browser
         last_save_file_headers: None,
         save_file_headers_sink: None,
         evaluate_scripts_sink: None,
+        coverage_log: None,
     }) as Box<dyn BrowserBackend + Send>));
     BrowserContext::new(bridge)
 }
@@ -169,6 +204,7 @@ pub fn browser_with_save_file_header_recorder(
         last_save_file_headers: None,
         save_file_headers_sink: Some(sink.clone()),
         evaluate_scripts_sink: None,
+        coverage_log: None,
     }) as Box<dyn BrowserBackend + Send>));
     (BrowserContext::new(bridge), sink)
 }
@@ -187,6 +223,7 @@ pub fn browser_with_evaluate_recorder() -> (BrowserContext, EvaluateScriptsRecor
         last_save_file_headers: None,
         save_file_headers_sink: None,
         evaluate_scripts_sink: Some(sink.clone()),
+        coverage_log: None,
     }) as Box<dyn BrowserBackend + Send>));
     (BrowserContext::new(bridge), sink)
 }


### PR DESCRIPTION
## Summary
- `measure_coverage(reset=true)` called `bridge.stop_coverage()` to discard stale data, then called `stop_coverage()` again immediately with no intervening `start_coverage()`. The second call ran against an already-stopped session, its error was swallowed by `unwrap_or_else`, so `reset=true` requests silently returned empty coverage every time.
- Fixed by inserting a `start_coverage()` between the discard-stop and the real capture-stop, so the sequence is: stop (discard) → start (fresh) → stop (capture, real result) → start (fresh, for the next window) — the reset path now mirrors the non-reset path's stop→capture→restart shape instead of stopping twice.
- Added `coverage_log` tracking to the shared `ObservationMockBackend` test double so tests can assert on exact `start_coverage`/`stop_coverage` call order.

## Test plan
- [x] `cargo fmt --package agent`
- [x] `cargo test -p agent` (630 passed, including 2 new regression tests: `reset_true_never_issues_two_consecutive_stops_without_a_start`, `reset_false_stops_once_and_restarts`)
- [x] `cargo clippy -p agent --all-targets -- -D warnings` (clean)