### PR TITLE
fix: surface bridge.set_seq failures instead of swallowing them

### DIFF
--- a/crates/agent/src/tools/seq.rs
+++ b/crates/agent/src/tools/seq.rs
@@ -4,12 +4,44 @@ use crate::BrowserContext;
 /// Atomically advances the global seq counter and pushes the new value to the
 /// bridge so the just-completed action's observations are tagged for temporal
 /// filtering. Returns the seq assigned to the action (the pre-advance value).
+///
+/// This is called by nearly every mutating tool, so a failed `set_seq` isn't
+/// treated as fatal to the calling tool (its own result is more valuable to
+/// the caller than a seq push failing) — but silently discarding the error
+/// would leave the bridge's temporal tagging desynced from `CrawlState`'s
+/// counter, corrupting `since`/`until` windowing used by `network_activity`,
+/// `websocket_activity`, and `page_logs`. Surface it to stderr instead.
 pub async fn increment_seq(state: &CrawlState, browser: &mut BrowserContext) -> u64 {
     let new_seq = state.seq_counter.next();
     let action_seq = new_seq.saturating_sub(1);
     {
         let mut bridge = browser.bridge().lock().await;
-        let _ = bridge.set_seq(new_seq).await;
+        if let Err(error) = bridge.set_seq(new_seq).await {
+            eprintln!(
+                "Warning: failed to set bridge seq to {new_seq}: {error} \
+                 (since/until windowing for network_activity/websocket_activity/page_logs may desync)"
+            );
+        }
     }
     action_seq
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn increment_seq_still_returns_action_seq_when_bridge_set_seq_fails() {
+        let mut browser = crate::tools::test_support::browser_with_failing_set_seq();
+        let state = CrawlState::default();
+
+        // A failing bridge.set_seq() must not panic or block the caller —
+        // the seq counter still advances and the assigned action_seq is
+        // still returned, even though the bridge-side push failed.
+        let first = increment_seq(&state, &mut browser).await;
+        let second = increment_seq(&state, &mut browser).await;
+
+        assert_eq!(first, 0);
+        assert_eq!(second, 1);
+    }
 }

--- a/crates/agent/src/tools/test_support.rs
+++ b/crates/agent/src/tools/test_support.rs
@@ -23,6 +23,9 @@ pub struct ObservationMockBackend {
     pub last_save_file_headers: Option<BTreeMap<String, String>>,
     pub save_file_headers_sink: Option<SaveFileHeadersRecord>,
     pub evaluate_scripts_sink: Option<EvaluateScriptsRecord>,
+    /// When set, `set_seq` returns this error instead of succeeding, so
+    /// tests can exercise the "bridge rejected the seq push" path.
+    pub fail_set_seq: bool,
 }
 
 #[async_trait]
@@ -31,6 +34,11 @@ impl BrowserBackend for ObservationMockBackend {
         Ok(std::mem::take(&mut self.observations))
     }
     async fn set_seq(&mut self, _seq: u64) -> Result<(), BridgeError> {
+        if self.fail_set_seq {
+            return Err(BridgeError::Protocol(
+                "simulated set_seq failure".to_string(),
+            ));
+        }
         Ok(())
     }
     async fn navigate(&mut self, _: &str) -> Result<PageInfo, BridgeError> {
@@ -155,6 +163,19 @@ pub fn browser_with_observations(observations: Vec<ObservationEvent>) -> Browser
         last_save_file_headers: None,
         save_file_headers_sink: None,
         evaluate_scripts_sink: None,
+        fail_set_seq: false,
+    }) as Box<dyn BrowserBackend + Send>));
+    BrowserContext::new(bridge)
+}
+
+#[must_use]
+pub fn browser_with_failing_set_seq() -> BrowserContext {
+    let bridge: SharedBridge = Arc::new(Mutex::new(Box::new(ObservationMockBackend {
+        observations: Vec::new(),
+        last_save_file_headers: None,
+        save_file_headers_sink: None,
+        evaluate_scripts_sink: None,
+        fail_set_seq: true,
     }) as Box<dyn BrowserBackend + Send>));
     BrowserContext::new(bridge)
 }
@@ -169,6 +190,7 @@ pub fn browser_with_save_file_header_recorder(
         last_save_file_headers: None,
         save_file_headers_sink: Some(sink.clone()),
         evaluate_scripts_sink: None,
+        fail_set_seq: false,
     }) as Box<dyn BrowserBackend + Send>));
     (BrowserContext::new(bridge), sink)
 }
@@ -187,6 +209,7 @@ pub fn browser_with_evaluate_recorder() -> (BrowserContext, EvaluateScriptsRecor
         last_save_file_headers: None,
         save_file_headers_sink: None,
         evaluate_scripts_sink: Some(sink.clone()),
+        fail_set_seq: false,
     }) as Box<dyn BrowserBackend + Send>));
     (BrowserContext::new(bridge), sink)
 }


### PR DESCRIPTION
## Summary
- `increment_seq` (called by nearly every mutating tool) discarded `bridge.set_seq()`'s result with `let _ = ...`. A failure here silently desyncs the bridge's temporal tagging from `CrawlState`'s seq counter, corrupting `since`/`until` windowing used by `network_activity`, `websocket_activity`, and `page_logs`, with zero diagnostic.
- Kept the failure non-fatal to the calling tool (consistent with the crate's existing "warn, don't fail" pattern for non-critical browser-state hiccups, e.g. `implementation/lifecycle.rs`), but now surface it via `eprintln!` instead of silently discarding it.
- Added a `fail_set_seq` toggle to the shared `ObservationMockBackend` test double so this path is exercisable in tests.

## Test plan
- [x] `cargo fmt --package agent`
- [x] `cargo test -p agent` (629 passed, including new regression test `increment_seq_still_returns_action_seq_when_bridge_set_seq_fails`)
- [x] `cargo clippy -p agent --all-targets -- -D warnings` (clean)