### PR TITLE
fix: build script executor tool registry once per run

### DIFF
--- a/crates/agent/src/registry.rs
+++ b/crates/agent/src/registry.rs
@@ -46,6 +46,18 @@ pub struct ToolRegistry {
     handlers: HashMap<String, ToolHandler>,
 }
 
+// Test-only build counter: incremented once per `new_with_core_tools()`
+// call, so tests can assert a registry was constructed exactly once per
+// script run rather than rebuilt on every node execution. Thread-local
+// (rather than a shared global) so it stays accurate under `cargo test`'s
+// default parallel test execution -- `#[tokio::test]` runs each test's
+// async work on the harness thread that invoked it.
+#[cfg(test)]
+thread_local! {
+    pub(crate) static NEW_WITH_CORE_TOOLS_CALLS: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+}
+
 impl ToolRegistry {
     #[must_use]
     pub fn new() -> Self {
@@ -54,6 +66,9 @@ impl ToolRegistry {
 
     #[must_use]
     pub fn new_with_core_tools() -> Self {
+        #[cfg(test)]
+        NEW_WITH_CORE_TOOLS_CALLS.with(|count| count.set(count.get() + 1));
+
         let mut registry = Self::new();
         for name in ASYNC_TOOLS {
             let tool_name = name.to_string();

--- a/crates/agent/src/script_executor/mod.rs
+++ b/crates/agent/src/script_executor/mod.rs
@@ -57,6 +57,12 @@ pub struct ScriptExecutor {
     start_time: Instant,
     step_counter: Arc<AtomicUsize>,
     cancel_token: CancellationToken,
+    /// Built once per script run and reused for every node execution
+    /// (including every iteration of `ForLoop`/`ForEach`/`WhileLoop`
+    /// bodies) instead of rebuilding the ~40-entry handler table on every
+    /// single `ToolCall`/`execute_js` node. `Arc` lets `Parallel` branch
+    /// executors (see `parallel.rs`) share the same registry cheaply.
+    registry: Arc<ToolRegistry>,
 }
 
 impl ScriptExecutor {
@@ -91,6 +97,7 @@ impl ScriptExecutor {
             start_time: Instant::now(),
             step_counter: Arc::new(AtomicUsize::new(0)),
             cancel_token,
+            registry: Arc::new(ToolRegistry::new_with_core_tools()),
         }
     }
 
@@ -222,7 +229,7 @@ impl ScriptExecutor {
             )));
         }
 
-        let registry = ToolRegistry::new_with_core_tools();
+        let registry = Arc::clone(&self.registry);
         let resolved_input = self.try_substitute_variables(input)?;
 
         let tool_effect = if let Some(handler) = registry.get(tool) {
@@ -321,8 +328,9 @@ impl ScriptExecutor {
     }
 
     async fn run_execute_js(&mut self, script: &str) -> Result<Value, ScriptExecutionError> {
+        let registry = Arc::clone(&self.registry);
         self.execute_async_tool(
-            &ToolRegistry::new_with_core_tools(),
+            &registry,
             "execute_js",
             &json!({
                 "script": script,

--- a/crates/agent/src/script_executor/parallel.rs
+++ b/crates/agent/src/script_executor/parallel.rs
@@ -1,4 +1,5 @@
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
 use std::{future::Future, pin::Pin};
 
 use script::grammar::ScriptNode;
@@ -67,6 +68,7 @@ impl ScriptExecutor {
                     start_time: self.start_time,
                     step_counter: self.step_counter.clone(),
                     cancel_token: self.cancel_token.clone(),
+                    registry: Arc::clone(&self.registry),
                 };
                 let branch_steps = branch.clone();
 

--- a/crates/agent/src/script_executor/tests.rs
+++ b/crates/agent/src/script_executor/tests.rs
@@ -513,6 +513,41 @@ async fn for_loop_correct_iterations() {
 }
 
 #[tokio::test]
+async fn for_loop_with_tool_calls_builds_registry_once() {
+    let before = crate::registry::NEW_WITH_CORE_TOOLS_CALLS.with(std::cell::Cell::get);
+
+    let mock = MockBridge::new();
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, default_limits());
+
+    let result = executor
+        .execute(script(vec![ScriptNode::ForLoop {
+            variable: "i".to_string(),
+            from: literal(json!(0)),
+            to: literal(json!(5)),
+            steps: vec![tool_call(
+                "scroll",
+                json!({"direction": "down", "pixels": 100}),
+                None,
+            )],
+        }]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Completed);
+    assert_eq!(result.steps_executed, 5);
+
+    let after = crate::registry::NEW_WITH_CORE_TOOLS_CALLS.with(std::cell::Cell::get);
+    // ToolRegistry::new_with_core_tools() must be called exactly once for
+    // the whole script run (in ScriptExecutor::new), not once per ForLoop
+    // iteration / ToolCall node execution.
+    assert_eq!(
+        after - before,
+        1,
+        "expected exactly one ToolRegistry build for a 5-iteration ForLoop with a ToolCall body"
+    );
+}
+
+#[tokio::test]
 async fn for_each_iterates_array() {
     let mock = MockBridge::new();
     let bridge = make_shared_bridge(mock);


### PR DESCRIPTION
## Summary
- `ToolRegistry::new_with_core_tools()` was rebuilt on every single `ToolCall`/`execute_js` node execution in `script_executor` rather than once per script run — for `ForLoop`/`ForEach`/`WhileLoop` bodies over many items, this rebuilt the ~40-entry handler table on every iteration.
- Built once in `ScriptExecutor::new`, stored behind an `Arc<ToolRegistry>` so `Parallel` branch executors (`parallel.rs`) can share it cheaply via `Arc::clone` instead of each branch rebuilding its own. `execute_tool_call`/`run_execute_js` now reuse `self.registry` instead of constructing a fresh one.
- Verified this composes cleanly with PR #112 (the output-byte-budget fix, also in `script_executor`) — rebuilt off current `main`, which already includes it.

## Test plan
- [x] `cargo fmt --package agent`
- [x] `cargo test -p agent` (629 passed, including new regression test `for_loop_with_tool_calls_builds_registry_once`, backed by a thread-local test-only build counter added to `ToolRegistry`)
- [x] `cargo clippy -p agent --all-targets -- -D warnings` (clean)