### PR TITLE
fix: detect colliding MCP server tool-name prefixes

### DIFF
--- a/crates/runtime/src/mcp/server_manager.rs
+++ b/crates/runtime/src/mcp/server_manager.rs
@@ -6,7 +6,7 @@ use tokio::time::{timeout, Duration};
 use crate::config::{McpServerConfig, McpTransport, RuntimeConfig};
 
 use super::client::McpClientBootstrap;
-use super::naming::mcp_tool_name;
+use super::naming::{mcp_tool_name, mcp_tool_prefix};
 use super::process::{default_initialize_params, spawn_mcp_stdio_process, McpStdioProcess};
 use super::types::{
     JsonRpcId, JsonRpcResponse, ManagedMcpTool, McpListToolsParams, McpServerManagerError,
@@ -14,6 +14,28 @@ use super::types::{
 };
 
 const MCP_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Check that no two server names normalize to the same `mcp__<prefix>__`
+/// tool prefix (see `naming::normalize_name_for_mcp`). Iteration is over a
+/// `BTreeMap`'s keys, so results are deterministic: the alphabetically
+/// earlier of two colliding names is reported as `first_server`.
+fn check_for_tool_prefix_collisions<'a>(
+    server_names: impl Iterator<Item = &'a String>,
+) -> Result<(), McpServerManagerError> {
+    let mut seen_prefixes: BTreeMap<String, &'a str> = BTreeMap::new();
+    for server_name in server_names {
+        let prefix = mcp_tool_prefix(server_name);
+        if let Some(first_server) = seen_prefixes.get(&prefix) {
+            return Err(McpServerManagerError::DuplicateToolPrefix {
+                prefix,
+                first_server: (*first_server).to_string(),
+                second_server: server_name.clone(),
+            });
+        }
+        seen_prefixes.insert(prefix, server_name.as_str());
+    }
+    Ok(())
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ToolRoute {
@@ -47,13 +69,13 @@ pub struct McpServerManager {
 }
 
 impl McpServerManager {
-    #[must_use]
-    pub fn from_runtime_config(config: &RuntimeConfig) -> Self {
+    pub fn from_runtime_config(config: &RuntimeConfig) -> Result<Self, McpServerManagerError> {
         Self::from_servers(config.mcp().servers())
     }
 
-    #[must_use]
-    pub fn from_servers(servers: &BTreeMap<String, McpServerConfig>) -> Self {
+    pub fn from_servers(
+        servers: &BTreeMap<String, McpServerConfig>,
+    ) -> Result<Self, McpServerManagerError> {
         let mut managed_servers = BTreeMap::new();
         let mut unsupported_servers = Vec::new();
 
@@ -73,12 +95,21 @@ impl McpServerManager {
             }
         }
 
-        Self {
+        // `normalize_name_for_mcp` maps every non-alphanumeric/`_`/`-`
+        // character to `_`, so distinct server names (e.g. "my.server" and
+        // "my server") can collapse to the same `mcp__<prefix>__` tool
+        // prefix. Without this check, discover_tools would silently let the
+        // later-processed server's tools overwrite the earlier one's routes
+        // in `tool_index` for any matching tool name. Fail fast here instead
+        // so the user gets a clear message telling them to rename a server.
+        check_for_tool_prefix_collisions(managed_servers.keys())?;
+
+        Ok(Self {
             servers: managed_servers,
             unsupported_servers,
             tool_index: BTreeMap::new(),
             next_request_id: 1,
-        }
+        })
     }
 
     #[must_use]

--- a/crates/runtime/src/mcp/server_manager_tests.rs
+++ b/crates/runtime/src/mcp/server_manager_tests.rs
@@ -12,7 +12,7 @@ use crate::config::{
     McpWebSocketServerConfig,
 };
 
-use super::{mcp_tool_name, McpServerManager, McpServerManagerError};
+use super::{mcp_tool_name, mcp_tool_prefix, McpServerManager, McpServerManagerError};
 
 fn temp_dir() -> PathBuf {
     let nanos = SystemTime::now()
@@ -159,7 +159,8 @@ fn manager_discovers_tools_from_stdio_config() {
             "alpha".to_string(),
             manager_server_config(&script_path, "alpha", &log_path),
         )]);
-        let mut manager = McpServerManager::from_servers(&servers);
+        let mut manager =
+            McpServerManager::from_servers(&servers).expect("no server name collisions");
 
         let tools = manager.discover_tools().await.expect("discover tools");
 
@@ -196,7 +197,8 @@ fn test_server_manager_tool_routing() {
                 manager_server_config(&script_path, "beta", &beta_log),
             ),
         ]);
-        let mut manager = McpServerManager::from_servers(&servers);
+        let mut manager =
+            McpServerManager::from_servers(&servers).expect("no server name collisions");
 
         let tools = manager.discover_tools().await.expect("discover tools");
         assert_eq!(tools.len(), 2);
@@ -265,13 +267,73 @@ fn manager_records_unsupported_non_stdio_servers_without_panicking() {
         ),
     ]);
 
-    let manager = McpServerManager::from_servers(&servers);
+    let manager = McpServerManager::from_servers(&servers).expect("no server name collisions");
     let unsupported = manager.unsupported_servers();
 
     assert_eq!(unsupported.len(), 3);
     assert_eq!(unsupported[0].server_name, "http");
     assert_eq!(unsupported[1].server_name, "sdk");
     assert_eq!(unsupported[2].server_name, "ws");
+}
+
+fn trivial_stdio_config() -> McpServerConfig {
+    McpServerConfig::Stdio(McpStdioServerConfig {
+        command: "true".to_string(),
+        args: vec![],
+        env: BTreeMap::new(),
+    })
+}
+
+#[test]
+fn from_servers_rejects_server_names_that_collide_after_normalization() {
+    // "my.server" and "my server" both normalize to "my_server" (every
+    // non-alphanumeric/`_`/`-` character maps to `_`), so they would
+    // otherwise produce the same `mcp__my_server__` tool prefix and silently
+    // clobber each other's routes.
+    let servers = BTreeMap::from([
+        ("my.server".to_string(), trivial_stdio_config()),
+        ("my server".to_string(), trivial_stdio_config()),
+    ]);
+
+    let error = McpServerManager::from_servers(&servers)
+        .expect_err("colliding server names should be rejected");
+
+    match error {
+        McpServerManagerError::DuplicateToolPrefix {
+            prefix,
+            first_server,
+            second_server,
+        } => {
+            assert_eq!(prefix, mcp_tool_prefix("my server"));
+            // BTreeMap iterates in sorted key order: "my server" < "my.server"
+            // (' ' sorts before '.'), so it's reported first.
+            assert_eq!(first_server, "my server");
+            assert_eq!(second_server, "my.server");
+        }
+        other => panic!("expected DuplicateToolPrefix, got {other:?}"),
+    }
+}
+
+#[test]
+fn from_servers_allows_distinct_prefixes_and_ignores_non_stdio_collisions() {
+    // "alpha_beta" (stdio) and "alpha.beta" (sdk, unsupported) normalize to
+    // the same prefix, but the sdk server never participates in tool
+    // routing at all (see
+    // `manager_records_unsupported_non_stdio_servers_without_panicking`), so
+    // it must not trip the collision check.
+    let servers = BTreeMap::from([
+        ("alpha_beta".to_string(), trivial_stdio_config()),
+        ("gamma".to_string(), trivial_stdio_config()),
+        (
+            "alpha.beta".to_string(),
+            McpServerConfig::Sdk(McpSdkServerConfig {
+                name: "sdk-server".to_string(),
+            }),
+        ),
+    ]);
+
+    McpServerManager::from_servers(&servers)
+        .expect("distinct stdio prefixes plus an unrelated unsupported server should be fine");
 }
 
 #[test]
@@ -288,7 +350,8 @@ fn manager_shutdown_terminates_spawned_children_and_is_idempotent() {
             "alpha".to_string(),
             manager_server_config(&script_path, "alpha", &log_path),
         )]);
-        let mut manager = McpServerManager::from_servers(&servers);
+        let mut manager =
+            McpServerManager::from_servers(&servers).expect("no server name collisions");
 
         manager.discover_tools().await.expect("discover tools");
         manager.shutdown().await.expect("first shutdown");
@@ -312,7 +375,8 @@ fn manager_reuses_spawned_server_between_discovery_and_call() {
             "alpha".to_string(),
             manager_server_config(&script_path, "alpha", &log_path),
         )]);
-        let mut manager = McpServerManager::from_servers(&servers);
+        let mut manager =
+            McpServerManager::from_servers(&servers).expect("no server name collisions");
 
         manager.discover_tools().await.expect("discover tools");
         let response = manager
@@ -363,7 +427,8 @@ fn manager_reports_unknown_qualified_tool_name() {
             "alpha".to_string(),
             manager_server_config(&script_path, "alpha", &log_path),
         )]);
-        let mut manager = McpServerManager::from_servers(&servers);
+        let mut manager =
+            McpServerManager::from_servers(&servers).expect("no server name collisions");
 
         let error = manager
             .call_tool(

--- a/crates/runtime/src/mcp/types.rs
+++ b/crates/runtime/src/mcp/types.rs
@@ -264,6 +264,11 @@ pub enum McpServerManagerError {
     UnknownServer {
         server_name: String,
     },
+    DuplicateToolPrefix {
+        prefix: String,
+        first_server: String,
+        second_server: String,
+    },
 }
 
 impl std::fmt::Display for McpServerManagerError {
@@ -299,6 +304,16 @@ impl std::fmt::Display for McpServerManagerError {
                 write!(f, "unknown MCP tool `{qualified_name}`")
             }
             Self::UnknownServer { server_name } => write!(f, "unknown MCP server `{server_name}`"),
+            Self::DuplicateToolPrefix {
+                prefix,
+                first_server,
+                second_server,
+            } => write!(
+                f,
+                "MCP servers `{first_server}` and `{second_server}` both normalize to the tool \
+                 prefix `{prefix}` — rename one of them in your MCP config so their tools don't \
+                 silently overwrite each other"
+            ),
         }
     }
 }
@@ -311,7 +326,8 @@ impl std::error::Error for McpServerManagerError {
             | Self::InvalidResponse { .. }
             | Self::Timeout { .. }
             | Self::UnknownTool { .. }
-            | Self::UnknownServer { .. } => None,
+            | Self::UnknownServer { .. }
+            | Self::DuplicateToolPrefix { .. } => None,
         }
     }
 }


### PR DESCRIPTION
## Summary
- `normalize_name_for_mcp` maps every non-alphanumeric/`_`/`-` character to `_`, so two differently-named MCP servers (e.g. `"my.server"` and `"my server"`) can normalize to the same `mcp__my_server__` tool prefix. `discover_tools` inserted routes into a flat `tool_index: BTreeMap<String, ToolRoute>` keyed by that normalized name with no collision check, so the later-processed server's tools would silently overwrite the earlier one's routes for any matching tool name.
- `McpServerManager::from_servers` (and `from_runtime_config`) now return `Result<Self, McpServerManagerError>` and fail fast with a new `McpServerManagerError::DuplicateToolPrefix` variant when two configured (stdio) server names normalize to the same prefix — the error names both servers and the colliding prefix so the user knows which one to rename. Non-stdio (unsupported) servers are excluded from the check since they never register tool routes.
- Confirmed there are no other call sites for `from_servers`/`from_runtime_config` anywhere else in the workspace, so this is a contained API change.

## Test plan
- [x] `cargo fmt`
- [x] `cargo test -p runtime` (174 tests pass on Windows; the MCP stdio-process integration tests, including the two new ones — `from_servers_rejects_server_names_that_collide_after_normalization` and `from_servers_allows_distinct_prefixes_and_ignores_non_stdio_collisions` — are `#[cfg(all(test, unix))]` like the rest of that suite and will run on unix CI)
- [x] `cargo clippy -p runtime --all-targets -- -D warnings` (clean)
- [x] `cargo check --workspace` (clean)