### PR TITLE
fix: give Bedrock session token its own credential field

### DIFF
--- a/crates/api/src/credentials.rs
+++ b/crates/api/src/credentials.rs
@@ -62,6 +62,15 @@ pub struct StoredProviderConfig {
     pub region: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub aws_secret_access_key: Option<String>,
+    /// AWS `SigV4` session token (Bedrock), for temporary/STS credentials.
+    ///
+    /// Previously this was overloaded onto `base_url`, which meant a live AWS
+    /// session token could end up stored under the JSON key `"base_url"` on
+    /// disk. This field gives it a proper home; `provider::bedrock::build_client`
+    /// still falls back to `base_url` for existing on-disk configs that
+    /// already have a token stuffed there.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_token: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resource_name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -288,6 +297,55 @@ mod tests {
 
         let loaded = load_credentials_from_path(&cred_path).unwrap();
         assert_eq!(loaded, store);
+
+        let _ = fs::remove_dir_all(&temp_dir);
+    }
+
+    /// `session_token` must have its own on-disk JSON key ("`session_token`"),
+    /// distinct from `base_url`, and round-trip through save/load.
+    #[test]
+    fn test_bedrock_session_token_round_trip_and_has_own_json_key() {
+        let temp_dir = test_temp_dir("session_token_round_trip");
+        let _ = fs::remove_dir_all(&temp_dir);
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        let cred_path = temp_dir.join("credentials.json");
+
+        let mut store = CredentialStore {
+            active_provider: Some("amazon-bedrock".to_string()),
+            providers: HashMap::new(),
+        };
+
+        let bedrock_config = StoredProviderConfig {
+            auth_method: "api_key".to_string(),
+            api_key: Some("AKIATEST".to_string()),
+            aws_secret_access_key: Some("secret".to_string()),
+            region: Some("us-east-1".to_string()),
+            session_token: Some("FQoGZXIvYXdzEXAMPLE".to_string()),
+            ..Default::default()
+        };
+        store
+            .providers
+            .insert("amazon-bedrock".to_string(), bedrock_config);
+
+        save_credentials_to_path(&store, &cred_path).unwrap();
+
+        let raw = fs::read_to_string(&cred_path).unwrap();
+        assert!(
+            raw.contains("\"session_token\""),
+            "session token must be stored under its own JSON key, not base_url"
+        );
+        assert!(
+            !raw.contains("\"base_url\""),
+            "base_url must not be written when unset"
+        );
+
+        let loaded = load_credentials_from_path(&cred_path).unwrap();
+        assert_eq!(loaded, store);
+        assert_eq!(
+            loaded.providers["amazon-bedrock"].session_token.as_deref(),
+            Some("FQoGZXIvYXdzEXAMPLE")
+        );
 
         let _ = fs::remove_dir_all(&temp_dir);
     }

--- a/crates/api/src/provider/bedrock.rs
+++ b/crates/api/src/provider/bedrock.rs
@@ -38,9 +38,14 @@ pub fn build_client(
     match (access_key_id, secret_access_key) {
         (Some(key_id), Some(secret)) => {
             let session_token = config
-                .base_url
+                .session_token
                 .clone()
                 .filter(|v| !v.is_empty())
+                // Back-compat: earlier versions had no dedicated field and
+                // stuffed the session token into `base_url` instead. Fall
+                // back to it so existing on-disk configs that already have a
+                // token stored there don't lose it.
+                .or_else(|| config.base_url.clone().filter(|v| !v.is_empty()))
                 .or_else(|| {
                     std::env::var("AWS_SESSION_TOKEN")
                         .ok()
@@ -115,5 +120,76 @@ mod tests {
         let client = build_client(&config, "model");
         assert!(client.is_ok());
         assert!(matches!(client.unwrap(), ProviderClient::Bedrock(_)));
+    }
+
+    fn bedrock_debug_string(client: ProviderClient) -> String {
+        let ProviderClient::Bedrock(bedrock_client) = client else {
+            panic!("expected ProviderClient::Bedrock");
+        };
+        format!("{bedrock_client:?}")
+    }
+
+    /// The session token must be read from the dedicated `session_token`
+    /// field, not from `base_url`.
+    #[test]
+    fn builds_sigv4_client_with_dedicated_session_token_field() {
+        let config = StoredProviderConfig {
+            auth_method: "api_key".into(),
+            api_key: Some("access-key".into()),
+            aws_secret_access_key: Some("secret-key".into()),
+            region: Some("eu-west-1".into()),
+            session_token: Some("session-token-value".into()),
+            ..Default::default()
+        };
+
+        let client = build_client(&config, "model").expect("client should build");
+        let debug = bedrock_debug_string(client);
+        assert!(
+            debug.contains("session-token-value"),
+            "session token from the dedicated field should be applied: {debug}"
+        );
+    }
+
+    /// Back-compat: configs written before `session_token` existed may still
+    /// have the token stuffed into `base_url`. `build_client` must still pick
+    /// it up so existing users don't silently lose their configured token.
+    #[test]
+    fn falls_back_to_base_url_for_session_token_when_field_absent() {
+        let config = StoredProviderConfig {
+            auth_method: "api_key".into(),
+            api_key: Some("access-key".into()),
+            aws_secret_access_key: Some("secret-key".into()),
+            region: Some("eu-west-1".into()),
+            base_url: Some("legacy-session-token-in-base-url".into()),
+            session_token: None,
+            ..Default::default()
+        };
+
+        let client = build_client(&config, "model").expect("client should build");
+        let debug = bedrock_debug_string(client);
+        assert!(
+            debug.contains("legacy-session-token-in-base-url"),
+            "session token should fall back to base_url for legacy configs: {debug}"
+        );
+    }
+
+    /// When both are present, the dedicated field wins over the legacy
+    /// `base_url` fallback.
+    #[test]
+    fn session_token_field_takes_priority_over_base_url_fallback() {
+        let config = StoredProviderConfig {
+            auth_method: "api_key".into(),
+            api_key: Some("access-key".into()),
+            aws_secret_access_key: Some("secret-key".into()),
+            region: Some("eu-west-1".into()),
+            base_url: Some("stale-legacy-value".into()),
+            session_token: Some("current-session-token".into()),
+            ..Default::default()
+        };
+
+        let client = build_client(&config, "model").expect("client should build");
+        let debug = bedrock_debug_string(client);
+        assert!(debug.contains("current-session-token"));
+        assert!(!debug.contains("stale-legacy-value"));
     }
 }


### PR DESCRIPTION
## Summary
- `StoredProviderConfig` had no dedicated field for the Bedrock/SigV4 session token used with temporary STS credentials — it was overloaded onto `base_url`, so a live AWS session token could be written to disk under the JSON key `"base_url"`.
- Adds a proper `session_token: Option<String>` field. `provider::bedrock::build_client` now reads from `session_token` first, falling back to `base_url` only for pre-existing on-disk configs that already have a token stuffed there, so no one silently loses a configured token on upgrade.

## Test plan
- [x] `cargo test -p api` (194 passed), including new tests: `test_bedrock_session_token_round_trip_and_has_own_json_key`, `builds_sigv4_client_with_dedicated_session_token_field`, `falls_back_to_base_url_for_session_token_when_field_absent`, `session_token_field_takes_priority_over_base_url_fallback`
- [x] `cargo fmt --package api`
- [x] `cargo clippy -p api --all-targets -- -D warnings` (clean)