### PR TITLE
fix: preserve completed parallel branch data on error

### DIFF
--- a/crates/agent/src/script_executor/parallel.rs
+++ b/crates/agent/src/script_executor/parallel.rs
@@ -106,8 +106,20 @@ impl ScriptExecutor {
                 .err();
             self.state.step = self.step_counter.load(Ordering::Relaxed);
 
-            if let Some(error) = first_error.or(cleanup_error) {
-                return Err(error);
+            // Merge every branch that completed successfully before deciding whether to
+            // return an error. Branches that finished before a sibling errored (or before
+            // cleanup failed) already did real work — extracted data, caught errors, output
+            // byte accounting — and must not be silently discarded just because the overall
+            // parallel block is reported as failed. Merging first (rather than bailing out
+            // early) means that data still reaches the caller via `ScriptResult`, which is
+            // built from `self.extracted_data`/`self.state` regardless of success or failure.
+            let completed_branches = branch_results.iter().filter(|result| result.is_some());
+            let completed_count = completed_branches.count();
+            if first_error.is_some() && completed_count > 0 {
+                eprintln!(
+                    "Warning: parallel script block failed after {completed_count}/{} branch(es) completed successfully; merging their partial results (extracted data, caught errors) instead of discarding them",
+                    branches.len()
+                );
             }
 
             for result in branch_results.into_iter().flatten() {
@@ -116,6 +128,10 @@ impl ScriptExecutor {
                 self.output_bytes += result.output_bytes;
             }
             self.state.items_collected = self.extracted_data.len();
+
+            if let Some(error) = first_error.or(cleanup_error) {
+                return Err(error);
+            }
 
             Ok(())
         })

--- a/crates/agent/src/script_executor/tests.rs
+++ b/crates/agent/src/script_executor/tests.rs
@@ -814,6 +814,53 @@ async fn parallel_max_branches_enforced() {
 }
 
 #[tokio::test]
+async fn parallel_branch_error_preserves_completed_sibling_data() {
+    // Two branches finish successfully with real extracted data (no bridge calls at
+    // all, so nothing can race them out of completing), while a third branch performs
+    // several sequential tool calls before hitting a bridge error. Before the fix, any
+    // branch error caused `execute_parallel` to discard `branch_results` entirely via
+    // `first_error.or(cleanup_error)` before merging — so the two completed branches'
+    // data never reached `ScriptResult::extracted_data`. This asserts that data now
+    // survives even though the overall parallel block still reports failure.
+    let mock = MockBridge::new()
+        .with_evaluate_responses(vec![json!({"value": 1}), json!({"value": 2})])
+        .with_click_error("simulated click failure");
+    let bridge = make_shared_bridge(mock);
+    let executor = make_executor(bridge, default_limits());
+
+    let result = executor
+        .execute(script(vec![ScriptNode::Parallel {
+            branches: vec![
+                vec![ScriptNode::Collect {
+                    value: literal(json!("branch_a_data")),
+                }],
+                vec![ScriptNode::Collect {
+                    value: literal(json!("branch_b_data")),
+                }],
+                vec![
+                    tool_call("execute_js", json!({"script": "1"}), None),
+                    tool_call("execute_js", json!({"script": "2"}), None),
+                    tool_call("click", json!({"selector": "#missing"}), None),
+                ],
+            ],
+        }]))
+        .await;
+
+    assert_eq!(result.status, ScriptStatus::Failed);
+    assert!(result.error.is_some());
+    assert!(
+        result.extracted_data.contains(&json!("branch_a_data")),
+        "expected completed branch A data to survive a sibling branch error, got {:?}",
+        result.extracted_data
+    );
+    assert!(
+        result.extracted_data.contains(&json!("branch_b_data")),
+        "expected completed branch B data to survive a sibling branch error, got {:?}",
+        result.extracted_data
+    );
+}
+
+#[tokio::test]
 async fn step_limit_stops_execution() {
     let mock = MockBridge::new().with_evaluate_responses(vec![
         json!({"value": 1}),


### PR DESCRIPTION
## Summary
- `execute_parallel` collected each branch's `ParallelBranchResult` (extracted data, caught-error count, output-byte reservation) into `branch_results`, but whenever any branch errored (or task-join failed), the function returned `Err(...)` before ever merging `branch_results` into `self` — silently discarding all data from sibling branches that had already completed successfully, with no log or signal.
- Reordered `execute_parallel` so completed branch results are always merged into `self.extracted_data` / `self.state.errors_caught` / `self.output_bytes` before the error (if any) is returned. Since `ScriptExecutor::execute()` builds `ScriptResult` from `self.extracted_data`/`self.state` unconditionally, this partial data now reaches the caller (via `ScriptResult.extracted_data`) even when the script ultimately reports `Failed`.
- Added an `eprintln!` warning (matching this crate's existing `eprintln!("Warning: ...")` convention, e.g. in `implementation/lifecycle.rs`) logged whenever a branch error causes an early-abort after at least one sibling branch already completed, so the situation is now observable instead of silent.

## Test plan
- [x] New regression test `parallel_branch_error_preserves_completed_sibling_data` in `crates/agent/src/script_executor/tests.rs`: two branches complete with real extracted data while a third branch fails via a bridge `click` error; asserts both completed branches' data survive in `ScriptResult.extracted_data` despite the overall `Failed` status. Verified this test fails against the pre-fix code (`got []`) and passes after the fix; reran 5x to confirm no flakiness.
- [x] `cargo fmt --package agent`
- [x] `cargo test -p agent` (629 lib tests + integration suites, all passing)
- [x] `cargo clippy -p agent --all-targets -- -D warnings` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)